### PR TITLE
[not for merge] State/utility API proposal

### DIFF
--- a/schemas/v1/calculator-request.json
+++ b/schemas/v1/calculator-request.json
@@ -4,39 +4,7 @@
   "type": "object",
   "properties": {
     "location": {
-      "type": "object",
-      "properties": {
-        "zip": {
-          "type": "string",
-          "description": "Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.",
-          "maxLength": 5,
-          "minLength": 5,
-          "examples": [
-            "80212"
-          ]
-        },
-        "address": {
-          "type": "string",
-          "description": "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
-          "examples": [
-            "1109 N Highland St, Arlington VA"
-          ]
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "zip"
-          ]
-        },
-        {
-          "required": [
-            "address"
-          ]
-        }
-      ],
-      "maxProperties": 1,
-      "minProperties": 1
+      "$ref": "APILocation"
     },
     "owner_status": {
       "type": "string",
@@ -81,6 +49,25 @@
         "es"
       ],
       "default": "en"
+    },
+    "authority_types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "federal",
+          "state",
+          "utility"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true,
+      "default": [
+        "federal"
+      ]
+    },
+    "utility_id": {
+      "type": "string"
     }
   },
   "required": [

--- a/schemas/v1/incentive.json
+++ b/schemas/v1/incentive.json
@@ -4,6 +4,7 @@
   "type": "object",
   "required": [
     "type",
+    "authority_type",
     "program",
     "item",
     "item_url",
@@ -20,6 +21,20 @@
       "enum": [
         "pos_rebate",
         "tax_credit"
+      ]
+    },
+    "authority_type": {
+      "type": "string",
+      "enum": [
+        "federal",
+        "state",
+        "utility"
+      ]
+    },
+    "authority": {
+      "type": "string",
+      "examples": [
+        "Rhode Island Office of Energy Resources"
       ]
     },
     "program": {

--- a/schemas/v1/location.json
+++ b/schemas/v1/location.json
@@ -1,0 +1,37 @@
+{
+  "$id": "APILocation",
+  "title": "APILocation",
+  "type": "object",
+  "properties": {
+    "zip": {
+      "type": "string",
+      "description": "Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.",
+      "maxLength": 5,
+      "minLength": 5,
+      "examples": [
+        "80212"
+      ]
+    },
+    "address": {
+      "type": "string",
+      "description": "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
+      "examples": [
+        "1109 N Highland St, Arlington VA"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "required": [
+        "zip"
+      ]
+    },
+    {
+      "required": [
+        "address"
+      ]
+    }
+  ],
+  "maxProperties": 1,
+  "minProperties": 1
+}

--- a/schemas/v1/utilities-request.json
+++ b/schemas/v1/utilities-request.json
@@ -1,0 +1,13 @@
+{
+  "$id": "APIUtilitiesRequest",
+  "title": "APIUtilitiesRequest",
+  "type": "object",
+  "properties": {
+    "location": {
+      "$ref": "APILocation"
+    }
+  },
+  "required": [
+    "location"
+  ]
+}

--- a/schemas/v1/utilities-response.json
+++ b/schemas/v1/utilities-response.json
@@ -1,0 +1,27 @@
+{
+  "$id": "APIUtilitiesResponse",
+  "title": "APIUtilitiesResponse",
+  "type": "object",
+  "properties": {
+    "utilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "examples": [
+              "rhode-island-energy"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "examples": [
+              "Rhode Island Energy"
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is my proposal for the changes to the incentives API that will
support the RI calculator. It's expressed as changes to the `v1` API,
which is currently not used by anything, so there are no backward
compatibility concerns.

One of the main things I'm thinking about here is that we will need to
commit to the shape of this API for the long term, to external
partners, so I'm most concerned about design decisions that will be
hard to change later.

Some design decisions:

- The basic idea is to adapt the existing federal incentives API by
  expanding both the fields comprising an incentive, and the set of
  available incentives.

- You don't explicitly filter for state in the API. `location` is
  already required, and will contain enough information for us to
  infer a state: either a zip code or a more precise address.
  (_Technically_ zip code is not enough -- there are a very small
  number of zip codes that span states. But the zip code data in this
  codebase doesn't capture that.)

- You can filter for what I'm calling "authority"; that is, the
  government/organization providing the incentive. (I'm not at all
  wedded to this name.) The three levels are federal, state, and
  utility. _Note_: I believe there'd be nothing stopping us from
  adding a `municipal` level later, if need be.

  The default is `federal` only, which means that the existing federal
  calculator could use this API without adding anything to the
  request. (It would need additional changes to switch from `v0` to
  `v1` though.)

- Incentives get a new field showing what level of authority they come
  from, as well as what the authority actually is. In practice this
  will be the name of a utility or a state government office. The
  field will be absent for federal incentives. **Discussion point**:
  I'm not sure whether this field should be localizable.

- If you request `state` incentives in `authority_types` and give a
  location in a state we don't support yet, we'll return an error
  saying that. (That's not expressed in code here, but that's my
  plan.)

- I've added an endpoint to fetch a list of utilities that may be
  relevant for a given location. The UX I'm imagining is:

  1. The form starts out blank. There's a dropdown for "utility" which
  has no items.

  2. You enter your address or zip. In the background, the frontend
  makes a request to `/api/v1/utilities` (request and response formats
  defined in this PR) to get a list of utilities for that location.

  3. The "utility" dropdown populates with the response. You can
  choose one, or not choose anything. If you choose one, the frontend
  will send that utility's `id` when you submit the form; this becomes
  the `utility_id` parameter to `/api/v1/calculator`. If you don't
  choose a utility, you won't get any utility incentives in the
  results.

  **Discussion point**: we'll need to assign stable IDs to utilities,
  to be able to identify them in the API and in incentive data. I
  believe there's no standard for this in the wider world, so we have
  to make something up. I'm currently imagining them as human-readable
  machine-friendly things like `rhode-island-energy`. Utilities do
  sometimes change names (RI Energy just did!) so these may get
  outdated; however, API clients should treat the IDs as opaque, so it
  probably doesn't matter. Any concerns?

- If you request `utility` incentives without providing a utility,
  we'll return an error.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205057814651003