### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - run: yarn --frozen-lockfile
       - run: yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION="16.19.0"
+ARG VERSION="18.16.1"
 
 # Separate build stage to compile TypeScript and build database
 FROM node:$VERSION-alpine as builder

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "author": "Tom Carden <tomc@rewiringamerica.org>",
   "license": "None",
   "private": true,
+  "engines": {
+    "node": ">=18.16.1"
+  },
   "dependencies": {
     "@fastify/autoload": "^5.7.1",
     "@fastify/sensible": "^5.2.0",


### PR DESCRIPTION
In another PR I want to use Quicktype, which requires Node 18. Rather
than downgrade that, I figure it's time to upgrade Node, since v16
is reaching end-of-life in a couple months.
