### PR TITLE
Fixture test for the v1 calculator API

### DIFF
--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -1,0 +1,360 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "pos_savings": 14000,
+  "tax_savings": 5836,
+  "performance_rebate_savings": 8000,
+  "pos_rebate_incentives": [
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": 8000,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "Hope for Homes (HOMES)",
+      "item": "Efficiency Rebates",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/whole-home-energy-reduction-rebates",
+      "amount": 8000,
+      "amount_type": "dollar_amount",
+      "item_type": "performance_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Electric Panel",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel",
+      "amount": 4000,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Electric Wiring",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-wiring",
+      "amount": 2500,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Heat Pump Water Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
+      "amount": 1750,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Weatherization",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
+      "amount": 1600,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Electric/Induction Stove",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove",
+      "amount": 840,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "program": "HEEHR",
+      "item": "Heat Pump Clothes Dryer",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer",
+      "amount": 840,
+      "amount_type": "dollar_amount",
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    }
+  ],
+  "tax_credit_incentives": [
+    {
+      "type": "tax_credit",
+      "program": "Residential Clean Energy Credit (25D)",
+      "item": "Battery Storage Installation",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation",
+      "amount": 0.3,
+      "amount_type": "percent",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": 4800,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Residential Clean Energy Credit (25D)",
+      "item": "Geothermal Heating Installation",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation",
+      "amount": 0.3,
+      "amount_type": "percent",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2022,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Residential Clean Energy Credit (25D)",
+      "item": "Rooftop Solar Installation",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation",
+      "amount": 0.3,
+      "amount_type": "percent",
+      "item_type": "solar_tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2022,
+      "end_date": 2032,
+      "representative_amount": 5130,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Clean Vehicle Credit (30D)",
+      "item": "New Electric Vehicle",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "amount": 7500,
+      "amount_type": "dollar_amount",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": 300000,
+      "filing_status": "joint",
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Credit for Previously-Owned Clean Vehicles (25E)",
+      "item": "Used Electric Vehicle",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "amount": 4000,
+      "amount_type": "dollar_amount",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": 150000,
+      "filing_status": "joint",
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Energy Efficient Home Improvement Credit (25C)",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": 2000,
+      "amount_type": "dollar_amount",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Energy Efficient Home Improvement Credit (25C)",
+      "item": "Heat Pump Water Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
+      "amount": 2000,
+      "amount_type": "dollar_amount",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Energy Efficient Home Improvement Credit (25C)",
+      "item": "Weatherization",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
+      "amount": 1200,
+      "amount_type": "dollar_amount",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Alternative Fuel Vehicle Refueling Property Credit (30C)",
+      "item": "Electric Vehicle Charger",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger",
+      "amount": 1000,
+      "amount_type": "dollar_amount",
+      "item_type": "ev_charger_credit",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "program": "Energy Efficient Home Improvement Credit (25C)",
+      "item": "Electric Panel",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel",
+      "amount": 600,
+      "amount_type": "dollar_amount",
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "representative_amount": null,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    }
+  ]
+}

--- a/test/routes/v1.test.js
+++ b/test/routes/v1.test.js
@@ -3,6 +3,7 @@ import { build } from '../helper.js';
 import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive.js';
 import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint.js';
 import Ajv from 'ajv';
+import fs from 'fs';
 import qs from 'qs';
 
 beforeEach(() => {
@@ -45,21 +46,14 @@ test('response is valid and correct', async t => {
   await responseValidator(calculatorResponse);
   t.equal(responseValidator.errors, null);
 
-  t.equal(calculatorResponse.is_under_80_ami, true);
-  t.equal(calculatorResponse.is_under_150_ami, true);
-  t.equal(calculatorResponse.is_over_150_ami, false);
-
-  t.equal(calculatorResponse.pos_savings, 14000);
-  t.equal(calculatorResponse.tax_savings, 5836);
-  t.equal(calculatorResponse.performance_rebate_savings, 8000);
-
-  t.equal(calculatorResponse.pos_rebate_incentives.length, 8);
-  t.equal(calculatorResponse.tax_credit_incentives.length, 10);
-
-  // TODO: once the response format is stable, put a strict fixture here to catch breakage:
-  // const expectedResponse = JSON.parse(fs.readFileSync('./test/fixtures/v0-80212-homeowner-80000-joint-4.json', 'utf-8'));
-  // t.same(calculatorResponse.pos_rebate_incentives, expectedResponse.pos_rebate_incentives);
-  // t.same(calculatorResponse.tax_credit_incentives, expectedResponse.tax_credit_incentives);
+  // Verify the specific content of the response
+  const expectedResponse = JSON.parse(
+    fs.readFileSync(
+      './test/fixtures/v1-80212-homeowner-80000-joint-4.json',
+      'utf-8',
+    ),
+  );
+  t.same(calculatorResponse, expectedResponse);
 });
 
 const BAD_QUERIES = [


### PR DESCRIPTION
This was commented out with a TODO because the API format is going to
change. That's still the case, but I'd rather have this test running,
because I'm making a bunch of code changes that I don't intend to
cause API changes, and it's a good guardrail.

I generated the fixture from the state of this repo just before I
started working on it, and compared it with the `v0` fixture. There
were only the known changes:

- `estimated_annual_savings` removed from the top level
- `_es` localized keys aren't included
- The relative `more_info_url` became the absolute `item_url`
- The solar tax credit is sorted in a different position

Then I ran the test to compare it with the current `v1`, and found a
change that I made unintentionally in #90, but that I think is
correct: when `agi_max_limit` and `representative_amount` are null in
the underlying data, they now come out as `null` in the API, rather
than `0` as before. This was because the corresponding entries in the
JSON schema for incentives in the API erroneously didn't include
`null` as a possible type for those fields.
