### PR TITLE
Add types for calculateIncentives()

### DIFF
--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -1,3 +1,4 @@
+import { FromSchema } from 'json-schema-to-ts';
 import { ERROR_SCHEMA } from '../error.js';
 import { API_INCENTIVE_SCHEMA } from './incentive.js';
 import { API_LOCATION_SCHEMA } from './location.js';
@@ -111,6 +112,7 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
       items: API_INCENTIVE_SCHEMA,
     },
   },
+  additionalProperties: false,
   examples: [
     {
       is_under_80_ami: true,
@@ -191,3 +193,10 @@ export const API_CALCULATOR_SCHEMA = {
     },
   },
 } as const;
+
+export type APICalculatorRequest = FromSchema<
+  typeof API_CALCULATOR_REQUEST_SCHEMA
+>;
+export type APICalculatorResponse = FromSchema<
+  typeof API_CALCULATOR_RESPONSE_SCHEMA
+>;

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -136,6 +136,7 @@ export const API_INCENTIVE_SCHEMA = {
       type: 'boolean',
     },
   },
+  additionalProperties: false,
   examples: [
     {
       type: 'pos_rebate',


### PR DESCRIPTION
This was the big remaining piece; now all of the `v1` stack is in
TypeScript except for `geocoder.js`, a relatively small piece.
