### PR TITLE
Switch IRA incentives to have new amount format

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -4,9 +4,7 @@
     "program": "residentialCleanEnergyCredit",
     "item": "batteryStorageInstallation",
     "item_type": "tax_credit",
-    "amount": 0.3,
-    "amount_type": "percent",
-    "representative_amount": 4800,
+    "amount": { "type": "percent", "number": 0.3, "representative": 4800 },
     "owner_status": [
       "homeowner"
     ],
@@ -21,9 +19,7 @@
     "program": "residentialCleanEnergyCredit",
     "item": "geothermalHeatingInstallation",
     "item_type": "tax_credit",
-    "amount": 0.3,
-    "amount_type": "percent",
-    "representative_amount": null,
+    "amount": { "type": "percent", "number": 0.3 },
     "owner_status": [
       "homeowner"
     ],
@@ -38,9 +34,7 @@
     "program": "energyEfficientHomeImprovementCredit",
     "item": "electricPanel",
     "item_type": "tax_credit",
-    "amount": 600,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 600 },
     "owner_status": [
       "homeowner"
     ],
@@ -55,9 +49,7 @@
     "program": "HEEHR",
     "item": "electricPanel",
     "item_type": "pos_rebate",
-    "amount": 4000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 4000 },
     "owner_status": [
       "homeowner"
     ],
@@ -72,9 +64,7 @@
     "program": "HEEHR",
     "item": "electricPanel",
     "item_type": "pos_rebate",
-    "amount": 4000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 4000 },
     "owner_status": [
       "homeowner"
     ],
@@ -89,9 +79,7 @@
     "program": "HEEHR",
     "item": "electricStove",
     "item_type": "pos_rebate",
-    "amount": 840,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 840 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -107,9 +95,7 @@
     "program": "HEEHR",
     "item": "electricStove",
     "item_type": "pos_rebate",
-    "amount": 840,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 840 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -125,9 +111,7 @@
     "program": "HEEHR",
     "item": "electricWiring",
     "item_type": "pos_rebate",
-    "amount": 2500,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 2500 },
     "owner_status": [
       "homeowner"
     ],
@@ -142,9 +126,7 @@
     "program": "HEEHR",
     "item": "electricWiring",
     "item_type": "pos_rebate",
-    "amount": 2500,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 2500 },
     "owner_status": [
       "homeowner"
     ],
@@ -159,9 +141,7 @@
     "program": "alternativeFuelVehicleRefuelingPropertyCredit",
     "item": "electricVehicleCharger",
     "item_type": "ev_charger_credit",
-    "amount": 1000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 1000 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -177,9 +157,7 @@
     "program": "cleanVehicleCredit",
     "item": "newElectricVehicle",
     "item_type": "tax_credit",
-    "amount": 7500,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 7500 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -195,9 +173,7 @@
     "program": "cleanVehicleCredit",
     "item": "newElectricVehicle",
     "item_type": "tax_credit",
-    "amount": 7500,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 7500 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -213,9 +189,7 @@
     "program": "cleanVehicleCredit",
     "item": "newElectricVehicle",
     "item_type": "tax_credit",
-    "amount": 7500,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 7500 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -231,9 +205,7 @@
     "program": "creditForPreviouslyOwnedCleanVehicles",
     "item": "usedElectricVehicle",
     "item_type": "tax_credit",
-    "amount": 4000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 4000 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -249,9 +221,7 @@
     "program": "creditForPreviouslyOwnedCleanVehicles",
     "item": "usedElectricVehicle",
     "item_type": "tax_credit",
-    "amount": 4000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 4000 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -267,9 +237,7 @@
     "program": "creditForPreviouslyOwnedCleanVehicles",
     "item": "usedElectricVehicle",
     "item_type": "tax_credit",
-    "amount": 4000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 4000 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -285,9 +253,7 @@
     "program": "energyEfficientHomeImprovementCredit",
     "item": "heatPumpAirConditionerHeater",
     "item_type": "tax_credit",
-    "amount": 2000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 2000 },
     "owner_status": [
       "homeowner"
     ],
@@ -302,9 +268,7 @@
     "program": "energyEfficientHomeImprovementCredit",
     "item": "heatPumpWaterHeater",
     "item_type": "tax_credit",
-    "amount": 2000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 2000 },
     "owner_status": [
       "homeowner"
     ],
@@ -319,9 +283,7 @@
     "program": "HEEHR",
     "item": "heatPumpWaterHeater",
     "item_type": "pos_rebate",
-    "amount": 1750,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 1750 },
     "owner_status": [
       "homeowner"
     ],
@@ -336,9 +298,7 @@
     "program": "HEEHR",
     "item": "heatPumpAirConditionerHeater",
     "item_type": "pos_rebate",
-    "amount": 8000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 8000 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -354,9 +314,7 @@
     "program": "HEEHR",
     "item": "heatPumpClothesDryer",
     "item_type": "pos_rebate",
-    "amount": 840,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 840 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -372,9 +330,7 @@
     "program": "HEEHR",
     "item": "heatPumpWaterHeater",
     "item_type": "pos_rebate",
-    "amount": 1750,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 1750 },
     "owner_status": [
       "homeowner"
     ],
@@ -389,10 +345,7 @@
     "program": "HEEHR",
     "item": "heatPumpAirConditionerHeater",
     "item_type": "pos_rebate",
-
-    "amount": 8000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 8000 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -408,9 +361,7 @@
     "program": "HEEHR",
     "item": "heatPumpClothesDryer",
     "item_type": "pos_rebate",
-    "amount": 840,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 840 },
     "owner_status": [
       "homeowner",
       "renter"
@@ -426,9 +377,7 @@
     "program": "residentialCleanEnergyCredit",
     "item": "rooftopSolarInstallation",
     "item_type": "solar_tax_credit",
-    "amount": 0.3,
-    "amount_type": "percent",
-    "representative_amount": null,
+    "amount": { "type": "percent", "number": 0.3 },
     "owner_status": [
       "homeowner"
     ],
@@ -443,9 +392,7 @@
     "program": "HEEHR",
     "item": "weatherization",
     "item_type": "pos_rebate",
-    "amount": 1600,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 1600 },
     "owner_status": [
       "homeowner"
     ],
@@ -460,9 +407,7 @@
     "program": "energyEfficientHomeImprovementCredit",
     "item": "weatherization",
     "item_type": "tax_credit",
-    "amount": 1200,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 1200 },
     "owner_status": [
       "homeowner"
     ],
@@ -477,9 +422,7 @@
     "program": "HEEHR",
     "item": "weatherization",
     "item_type": "pos_rebate",
-    "amount": 1600,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 1600 },
     "owner_status": [
       "homeowner"
     ],
@@ -494,9 +437,7 @@
     "program": "hopeForHomes",
     "item": "efficiencyRebates",
     "item_type": "performance_rebate",
-    "amount": 8000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 8000 },
     "owner_status": [
       "homeowner"
     ],
@@ -511,9 +452,7 @@
     "program": "hopeForHomes",
     "item": "efficiencyRebates",
     "item_type": "performance_rebate",
-    "amount": 4000,
-    "amount_type": "dollar_amount",
-    "representative_amount": null,
+    "amount": { "type": "dollar_amount", "number": 4000 },
     "owner_status": [
       "homeowner"
     ],

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -22,16 +22,6 @@ function transformIncentives(
   return incentives.map(incentive => ({
     ...incentive,
 
-    // Transform amount from separate fields into single object
-    amount: {
-      type: incentive.amount_type,
-      number: incentive.amount,
-      // If representative_amount is null, don't include it in output
-      representative: incentive.representative_amount ?? undefined,
-    },
-    amount_type: undefined,
-    representative_amount: undefined,
-
     // Localize localizable fields
     item: t('items', incentive.item, language),
     program: t('programs', incentive.program, language),

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -61,9 +61,9 @@ export const API_INCENTIVE_SCHEMA = {
           ],
         },
       },
+      additionalProperties: false,
       required: [
         'type',
-        'number',
       ],
     },
     item_type: {

--- a/test/lib/incentives-calculation.test.js
+++ b/test/lib/incentives-calculation.test.js
@@ -92,62 +92,62 @@ test('correctly evaluates scenerio "Single w/ $120k Household income in the Bron
 
   const posRebates = _.keyBy(data.pos_rebate_incentives, 'item');
   t.equal(posRebates['electricPanel'].eligible, true);
-  t.equal(posRebates['electricPanel'].amount, 4000);
+  t.equal(posRebates['electricPanel'].amount.number, 4000);
   t.equal(posRebates['electricPanel'].start_date, 2023);
   t.equal(posRebates['electricStove'].eligible, true);
-  t.equal(posRebates['electricStove'].amount, 840);
+  t.equal(posRebates['electricStove'].amount.number, 840);
   t.equal(posRebates['electricStove'].start_date, 2023);
   t.equal(posRebates['electricWiring'].eligible, true);
-  t.equal(posRebates['electricWiring'].amount, 2500);
+  t.equal(posRebates['electricWiring'].amount.number, 2500);
   t.equal(posRebates['electricWiring'].start_date, 2023);
   t.equal(posRebates['heatPumpWaterHeater'].eligible, true);
-  t.equal(posRebates['heatPumpWaterHeater'].amount, 1750);
+  t.equal(posRebates['heatPumpWaterHeater'].amount.number, 1750);
   t.equal(posRebates['heatPumpWaterHeater'].start_date, 2023);
   t.equal(posRebates['heatPumpAirConditionerHeater'].eligible, true);
-  t.equal(posRebates['heatPumpAirConditionerHeater'].amount, 8000);
+  t.equal(posRebates['heatPumpAirConditionerHeater'].amount.number, 8000);
   t.equal(posRebates['heatPumpAirConditionerHeater'].start_date, 2023);
   t.equal(posRebates['heatPumpClothesDryer'].eligible, true);
-  t.equal(posRebates['heatPumpClothesDryer'].amount, 840);
+  t.equal(posRebates['heatPumpClothesDryer'].amount.number, 840);
   t.equal(posRebates['heatPumpClothesDryer'].start_date, 2023);
   t.equal(posRebates['weatherization'].eligible, true);
-  t.equal(posRebates['weatherization'].amount, 1600);
+  t.equal(posRebates['weatherization'].amount.number, 1600);
   t.equal(posRebates['weatherization'].start_date, 2023);
   t.equal(posRebates['efficiencyRebates'].eligible, true);
-  t.equal(posRebates['efficiencyRebates'].amount, 4000);
+  t.equal(posRebates['efficiencyRebates'].amount.number, 4000);
   t.equal(posRebates['efficiencyRebates'].start_date, 2023);
 
   const taxCredits = _.keyBy(data.tax_credit_incentives, 'item');
   t.equal(taxCredits['batteryStorageInstallation'].eligible, true);
-  t.equal(taxCredits['batteryStorageInstallation'].amount, 0.3); // will be displayed as 30%
+  t.equal(taxCredits['batteryStorageInstallation'].amount.number, 0.3); // will be displayed as 30%
   t.equal(taxCredits['batteryStorageInstallation'].start_date, 2023);
   t.equal(taxCredits['geothermalHeatingInstallation'].eligible, true);
-  t.equal(taxCredits['geothermalHeatingInstallation'].amount, 0.3); // will be displayed as 30%
+  t.equal(taxCredits['geothermalHeatingInstallation'].amount.number, 0.3); // will be displayed as 30%
   t.equal(taxCredits['geothermalHeatingInstallation'].start_date, 2022);
   t.equal(taxCredits['electricPanel'].eligible, true);
-  t.equal(taxCredits['electricPanel'].amount, 600);
+  t.equal(taxCredits['electricPanel'].amount.number, 600);
   t.equal(taxCredits['electricPanel'].start_date, 2023);
   t.equal(taxCredits['electricVehicleCharger'].eligible, true);
-  t.equal(taxCredits['electricVehicleCharger'].amount, 1000);
+  t.equal(taxCredits['electricVehicleCharger'].amount.number, 1000);
   t.equal(taxCredits['electricVehicleCharger'].start_date, 2023);
   t.equal(taxCredits['newElectricVehicle'].eligible, true);
-  t.equal(taxCredits['newElectricVehicle'].amount, 7500);
+  t.equal(taxCredits['newElectricVehicle'].amount.number, 7500);
   t.equal(taxCredits['newElectricVehicle'].start_date, 2023);
   t.equal(taxCredits['heatPumpAirConditionerHeater'].eligible, true);
-  t.equal(taxCredits['heatPumpAirConditionerHeater'].amount, 2000);
+  t.equal(taxCredits['heatPumpAirConditionerHeater'].amount.number, 2000);
   t.equal(taxCredits['heatPumpAirConditionerHeater'].start_date, 2023);
   t.equal(taxCredits['heatPumpWaterHeater'].eligible, true);
-  t.equal(taxCredits['heatPumpWaterHeater'].amount, 2000);
+  t.equal(taxCredits['heatPumpWaterHeater'].amount.number, 2000);
   t.equal(taxCredits['heatPumpWaterHeater'].start_date, 2023);
   t.equal(taxCredits['rooftopSolarInstallation'].eligible, true);
-  t.equal(taxCredits['rooftopSolarInstallation'].amount, 0.3);
-  t.equal(taxCredits['rooftopSolarInstallation'].representative_amount, 4770);
+  t.equal(taxCredits['rooftopSolarInstallation'].amount.number, 0.3);
+  t.equal(taxCredits['rooftopSolarInstallation'].amount.representative, 4770);
   t.equal(taxCredits['rooftopSolarInstallation'].start_date, 2022);
   t.equal(taxCredits['weatherization'].eligible, true);
-  t.equal(taxCredits['weatherization'].amount, 1200);
+  t.equal(taxCredits['weatherization'].amount.number, 1200);
   t.equal(taxCredits['weatherization'].start_date, 2023);
   // everything except used EV should be eligible for tax credit (agi limit is 75k)
   t.equal(taxCredits['usedElectricVehicle'].eligible, false);
-  t.equal(taxCredits['usedElectricVehicle'].amount, 4000);
+  t.equal(taxCredits['usedElectricVehicle'].amount.number, 4000);
   t.equal(taxCredits['usedElectricVehicle'].start_date, 2023);
 });
 
@@ -184,62 +184,62 @@ test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k H
 
   const posRebates = _.keyBy(data.pos_rebate_incentives, 'item');
   t.equal(posRebates['electricPanel'].eligible, true);
-  t.equal(posRebates['electricPanel'].amount, 4000);
+  t.equal(posRebates['electricPanel'].amount.number, 4000);
   t.equal(posRebates['electricPanel'].start_date, 2023);
   t.equal(posRebates['electricStove'].eligible, true);
-  t.equal(posRebates['electricStove'].amount, 840);
+  t.equal(posRebates['electricStove'].amount.number, 840);
   t.equal(posRebates['electricStove'].start_date, 2023);
   t.equal(posRebates['electricWiring'].eligible, true);
-  t.equal(posRebates['electricWiring'].amount, 2500);
+  t.equal(posRebates['electricWiring'].amount.number, 2500);
   t.equal(posRebates['electricWiring'].start_date, 2023);
   t.equal(posRebates['heatPumpWaterHeater'].eligible, true);
-  t.equal(posRebates['heatPumpWaterHeater'].amount, 1750);
+  t.equal(posRebates['heatPumpWaterHeater'].amount.number, 1750);
   t.equal(posRebates['heatPumpWaterHeater'].start_date, 2023);
   t.equal(posRebates['heatPumpAirConditionerHeater'].eligible, true);
-  t.equal(posRebates['heatPumpAirConditionerHeater'].amount, 8000);
+  t.equal(posRebates['heatPumpAirConditionerHeater'].amount.number, 8000);
   t.equal(posRebates['heatPumpAirConditionerHeater'].start_date, 2023);
   t.equal(posRebates['heatPumpClothesDryer'].eligible, true);
-  t.equal(posRebates['heatPumpClothesDryer'].amount, 840);
+  t.equal(posRebates['heatPumpClothesDryer'].amount.number, 840);
   t.equal(posRebates['heatPumpClothesDryer'].start_date, 2023);
   t.equal(posRebates['weatherization'].eligible, true);
-  t.equal(posRebates['weatherization'].amount, 1600);
+  t.equal(posRebates['weatherization'].amount.number, 1600);
   t.equal(posRebates['weatherization'].start_date, 2023);
   t.equal(posRebates['efficiencyRebates'].eligible, true);
-  t.equal(posRebates['efficiencyRebates'].amount, 4000);
+  t.equal(posRebates['efficiencyRebates'].amount.number, 4000);
   t.equal(posRebates['efficiencyRebates'].start_date, 2023);
 
   const taxCredits = _.keyBy(data.tax_credit_incentives, 'item');
   t.equal(taxCredits['batteryStorageInstallation'].eligible, true);
-  t.equal(taxCredits['batteryStorageInstallation'].amount, 0.3); // will be displayed as 30%
+  t.equal(taxCredits['batteryStorageInstallation'].amount.number, 0.3); // will be displayed as 30%
   t.equal(taxCredits['batteryStorageInstallation'].start_date, 2023);
   t.equal(taxCredits['geothermalHeatingInstallation'].eligible, true);
-  t.equal(taxCredits['geothermalHeatingInstallation'].amount, 0.3); // will be displayed as 30%
+  t.equal(taxCredits['geothermalHeatingInstallation'].amount.number, 0.3); // will be displayed as 30%
   t.equal(taxCredits['geothermalHeatingInstallation'].start_date, 2022);
   t.equal(taxCredits['electricPanel'].eligible, true);
-  t.equal(taxCredits['electricPanel'].amount, 600);
+  t.equal(taxCredits['electricPanel'].amount.number, 600);
   t.equal(taxCredits['electricPanel'].start_date, 2023);
   t.equal(taxCredits['electricVehicleCharger'].eligible, true);
-  t.equal(taxCredits['electricVehicleCharger'].amount, 1000);
+  t.equal(taxCredits['electricVehicleCharger'].amount.number, 1000);
   t.equal(taxCredits['electricVehicleCharger'].start_date, 2023);
   t.equal(taxCredits['newElectricVehicle'].eligible, true);
-  t.equal(taxCredits['newElectricVehicle'].amount, 7500);
+  t.equal(taxCredits['newElectricVehicle'].amount.number, 7500);
   t.equal(taxCredits['newElectricVehicle'].start_date, 2023);
   t.equal(taxCredits['heatPumpAirConditionerHeater'].eligible, true);
-  t.equal(taxCredits['heatPumpAirConditionerHeater'].amount, 2000);
+  t.equal(taxCredits['heatPumpAirConditionerHeater'].amount.number, 2000);
   t.equal(taxCredits['heatPumpAirConditionerHeater'].start_date, 2023);
   t.equal(taxCredits['heatPumpWaterHeater'].eligible, true);
-  t.equal(taxCredits['heatPumpWaterHeater'].amount, 2000);
+  t.equal(taxCredits['heatPumpWaterHeater'].amount.number, 2000);
   t.equal(taxCredits['heatPumpWaterHeater'].start_date, 2023);
   t.equal(taxCredits['rooftopSolarInstallation'].eligible, true);
-  t.equal(taxCredits['rooftopSolarInstallation'].amount, 0.3);
-  t.equal(taxCredits['rooftopSolarInstallation'].representative_amount, 4572);
+  t.equal(taxCredits['rooftopSolarInstallation'].amount.number, 0.3);
+  t.equal(taxCredits['rooftopSolarInstallation'].amount.representative, 4572);
   t.equal(taxCredits['rooftopSolarInstallation'].start_date, 2022);
   t.equal(taxCredits['weatherization'].eligible, true);
-  t.equal(taxCredits['weatherization'].amount, 1200);
+  t.equal(taxCredits['weatherization'].amount.number, 1200);
   t.equal(taxCredits['weatherization'].start_date, 2023);
   // everything except used EV should be eligible for tax credit (agi limit is 75k)
   t.equal(taxCredits['usedElectricVehicle'].eligible, false);
-  t.equal(taxCredits['usedElectricVehicle'].amount, 4000);
+  t.equal(taxCredits['usedElectricVehicle'].amount.number, 4000);
   t.equal(taxCredits['usedElectricVehicle'].start_date, 2023);
 });
 
@@ -276,63 +276,63 @@ test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in 
 
   const posRebates = _.keyBy(data.pos_rebate_incentives, 'item');
   t.equal(posRebates['electricPanel'].eligible, false);
-  t.equal(posRebates['electricPanel'].amount, 4000);
+  t.equal(posRebates['electricPanel'].amount.number, 4000);
   t.equal(posRebates['electricPanel'].start_date, 2023);
   t.equal(posRebates['electricStove'].eligible, false);
-  t.equal(posRebates['electricStove'].amount, 840);
+  t.equal(posRebates['electricStove'].amount.number, 840);
   t.equal(posRebates['electricStove'].start_date, 2023);
   t.equal(posRebates['electricWiring'].eligible, false);
-  t.equal(posRebates['electricWiring'].amount, 2500);
+  t.equal(posRebates['electricWiring'].amount.number, 2500);
   t.equal(posRebates['electricWiring'].start_date, 2023);
   t.equal(posRebates['heatPumpWaterHeater'].eligible, false);
-  t.equal(posRebates['heatPumpWaterHeater'].amount, 1750);
+  t.equal(posRebates['heatPumpWaterHeater'].amount.number, 1750);
   t.equal(posRebates['heatPumpWaterHeater'].start_date, 2023);
   t.equal(posRebates['heatPumpAirConditionerHeater'].eligible, false);
-  t.equal(posRebates['heatPumpAirConditionerHeater'].amount, 8000);
+  t.equal(posRebates['heatPumpAirConditionerHeater'].amount.number, 8000);
   t.equal(posRebates['heatPumpAirConditionerHeater'].start_date, 2023);
   t.equal(posRebates['heatPumpClothesDryer'].eligible, false);
-  t.equal(posRebates['heatPumpClothesDryer'].amount, 840);
+  t.equal(posRebates['heatPumpClothesDryer'].amount.number, 840);
   t.equal(posRebates['heatPumpClothesDryer'].start_date, 2023);
   t.equal(posRebates['weatherization'].eligible, false);
-  t.equal(posRebates['weatherization'].amount, 1600);
+  t.equal(posRebates['weatherization'].amount.number, 1600);
   t.equal(posRebates['weatherization'].start_date, 2023);
   // only items.efficiencyrebates are eligible here:
   t.equal(posRebates['efficiencyRebates'].eligible, true);
-  t.equal(posRebates['efficiencyRebates'].amount, 4000);
+  t.equal(posRebates['efficiencyRebates'].amount.number, 4000);
   t.equal(posRebates['efficiencyRebates'].start_date, 2023);
 
   const taxCredits = _.keyBy(data.tax_credit_incentives, 'item');
   t.equal(taxCredits['batteryStorageInstallation'].eligible, true);
-  t.equal(taxCredits['batteryStorageInstallation'].amount, 0.3); // will be displayed as 30%
+  t.equal(taxCredits['batteryStorageInstallation'].amount.number, 0.3); // will be displayed as 30%
   t.equal(taxCredits['batteryStorageInstallation'].start_date, 2023);
   t.equal(taxCredits['geothermalHeatingInstallation'].eligible, true);
-  t.equal(taxCredits['geothermalHeatingInstallation'].amount, 0.3); // will be displayed as 30%
+  t.equal(taxCredits['geothermalHeatingInstallation'].amount.number, 0.3); // will be displayed as 30%
   t.equal(taxCredits['geothermalHeatingInstallation'].start_date, 2022);
   t.equal(taxCredits['electricPanel'].eligible, true);
-  t.equal(taxCredits['electricPanel'].amount, 600);
+  t.equal(taxCredits['electricPanel'].amount.number, 600);
   t.equal(taxCredits['electricPanel'].start_date, 2023);
   t.equal(taxCredits['electricVehicleCharger'].eligible, true);
-  t.equal(taxCredits['electricVehicleCharger'].amount, 1000);
+  t.equal(taxCredits['electricVehicleCharger'].amount.number, 1000);
   t.equal(taxCredits['electricVehicleCharger'].start_date, 2023);
   t.equal(taxCredits['heatPumpAirConditionerHeater'].eligible, true);
-  t.equal(taxCredits['heatPumpAirConditionerHeater'].amount, 2000);
+  t.equal(taxCredits['heatPumpAirConditionerHeater'].amount.number, 2000);
   t.equal(taxCredits['heatPumpAirConditionerHeater'].start_date, 2023);
   t.equal(taxCredits['heatPumpWaterHeater'].eligible, true);
-  t.equal(taxCredits['heatPumpWaterHeater'].amount, 2000);
+  t.equal(taxCredits['heatPumpWaterHeater'].amount.number, 2000);
   t.equal(taxCredits['heatPumpWaterHeater'].start_date, 2023);
   t.equal(taxCredits['rooftopSolarInstallation'].eligible, true);
-  t.equal(taxCredits['rooftopSolarInstallation'].amount, 0.3);
-  t.equal(taxCredits['rooftopSolarInstallation'].representative_amount, 4428.9);
+  t.equal(taxCredits['rooftopSolarInstallation'].amount.number, 0.3);
+  t.equal(taxCredits['rooftopSolarInstallation'].amount.representative, 4428.9);
   t.equal(taxCredits['rooftopSolarInstallation'].start_date, 2022);
   t.equal(taxCredits['weatherization'].eligible, true);
-  t.equal(taxCredits['weatherization'].amount, 1200);
+  t.equal(taxCredits['weatherization'].amount.number, 1200);
   t.equal(taxCredits['weatherization'].start_date, 2023);
   // new and used EVs should not be eligible:
   t.equal(taxCredits['newElectricVehicle'].eligible, false);
-  t.equal(taxCredits['newElectricVehicle'].amount, 7500);
+  t.equal(taxCredits['newElectricVehicle'].amount.number, 7500);
   t.equal(taxCredits['newElectricVehicle'].start_date, 2023);
   t.equal(taxCredits['usedElectricVehicle'].eligible, false);
-  t.equal(taxCredits['usedElectricVehicle'].amount, 4000);
+  t.equal(taxCredits['usedElectricVehicle'].amount.number, 4000);
   t.equal(taxCredits['usedElectricVehicle'].start_date, 2023);
 });
 


### PR DESCRIPTION
This brings them in line with the `v1` format. The `v0` API is
unchanged; the new-format amounts are transformed on the way out to
match the old format.
