### PR TITLE
Add authority_type and authority_name to incentive object

### DIFF
--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -10,6 +10,12 @@ export type Authority = {
   name: string;
 };
 
+export enum AuthorityType {
+  Federal = 'federal',
+  State = 'state',
+  Utility = 'utility',
+}
+
 export type StateAuthorities = {
   state: { [authId: string]: Authority };
   utility: { [authId: string]: Authority };

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -2,21 +2,24 @@ import calculateIncentives from '../lib/incentives-calculation.js';
 import fetchAMIsForAddress from '../lib/fetch-amis-for-address.js';
 import fetchAMIsForZip from '../lib/fetch-amis-for-zip.js';
 import { t } from '../lib/i18n.js';
-import { IRA_INCENTIVES, Incentive } from '../data/ira_incentives.js';
+import { IRA_INCENTIVES } from '../data/ira_incentives.js';
 import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
 import { FastifyInstance } from 'fastify';
 import { API_CALCULATOR_SCHEMA } from '../schemas/v1/calculator-endpoint.js';
 import { API_INCENTIVES_SCHEMA } from '../schemas/v1/incentives-endpoint.js';
-import { APIIncentive } from '../schemas/v1/incentive.js';
+import {
+  APIIncentive,
+  APIIncentiveMinusItemUrl,
+} from '../schemas/v1/incentive.js';
 import { APILocation } from '../schemas/v1/location.js';
 import { LOCALES } from '../data/locale.js';
 import { Database } from 'sqlite';
 import { IncomeInfo } from '../lib/income-info.js';
 import { API_UTILITIES_SCHEMA } from '../schemas/v1/utilities-endpoint.js';
-import { AUTHORITIES_BY_STATE } from '../data/authorities.js';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities.js';
 
 function transformIncentives(
-  incentives: Incentive[],
+  incentives: APIIncentiveMinusItemUrl[],
   language: keyof typeof LOCALES,
 ): APIIncentive[] {
   return incentives.map(incentive => ({
@@ -81,7 +84,11 @@ export default async function (
     { schema: API_INCENTIVES_SCHEMA },
     async (request, reply) => {
       const incentives = transformIncentives(
-        IRA_INCENTIVES,
+        IRA_INCENTIVES.map(incentive => ({
+          ...incentive,
+          authority_type: AuthorityType.Federal,
+          authority_name: null,
+        })),
         request.query.language ?? 'en',
       );
       return reply.status(200).type('application/json').send({ incentives });

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -4,6 +4,7 @@ export const API_INCENTIVE_SCHEMA = {
   type: 'object',
   required: [
     'type',
+    'authority_type',
     'program',
     'item',
     'item_url',
@@ -20,6 +21,14 @@ export const API_INCENTIVE_SCHEMA = {
         'pos_rebate',
         'tax_credit',
       ],
+    },
+    authority_type: {
+      type: 'string',
+      enum: ['federal', 'state', 'utility'],
+    },
+    authority_name: {
+      type: 'string',
+      nullable: true,
     },
     program: {
       type: 'string',
@@ -140,6 +149,7 @@ export const API_INCENTIVE_SCHEMA = {
   examples: [
     {
       type: 'pos_rebate',
+      authority_type: 'federal',
       program: 'Energy Efficient Home Improvement Credit (25C)',
       item: 'Electric Panel',
       item_url:
@@ -166,3 +176,9 @@ export const API_INCENTIVE_SCHEMA = {
 } as const;
 
 export type APIIncentive = FromSchema<typeof API_INCENTIVE_SCHEMA>;
+
+/**
+ * This is used internally, as an intermediate form between incentive
+ * calculation and external API.
+ */
+export type APIIncentiveMinusItemUrl = Omit<APIIncentive, 'item_url'>;

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -8,6 +8,8 @@
   "pos_rebate_incentives": [
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Heat Pump Air Conditioner/Heater",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
@@ -26,6 +28,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Hope for Homes (HOMES)",
       "item": "Efficiency Rebates",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/whole-home-energy-reduction-rebates",
@@ -43,6 +47,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Electric Panel",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel",
@@ -60,6 +66,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Electric Wiring",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-wiring",
@@ -77,6 +85,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Heat Pump Water Heater",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
@@ -94,6 +104,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Weatherization",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
@@ -111,6 +123,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Electric/Induction Stove",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove",
@@ -129,6 +143,8 @@
     },
     {
       "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "HEEHR",
       "item": "Heat Pump Clothes Dryer",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer",
@@ -149,6 +165,8 @@
   "tax_credit_incentives": [
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Residential Clean Energy Credit (25D)",
       "item": "Battery Storage Installation",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation",
@@ -166,6 +184,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Residential Clean Energy Credit (25D)",
       "item": "Geothermal Heating Installation",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation",
@@ -183,6 +203,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Residential Clean Energy Credit (25D)",
       "item": "Rooftop Solar Installation",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation",
@@ -200,6 +222,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Clean Vehicle Credit (30D)",
       "item": "New Electric Vehicle",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
@@ -218,6 +242,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Credit for Previously-Owned Clean Vehicles (25E)",
       "item": "Used Electric Vehicle",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
@@ -236,6 +262,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
       "item": "Heat Pump Air Conditioner/Heater",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
@@ -253,6 +281,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
       "item": "Heat Pump Water Heater",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
@@ -270,6 +300,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
       "item": "Weatherization",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
@@ -287,6 +319,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Alternative Fuel Vehicle Refueling Property Credit (30C)",
       "item": "Electric Vehicle Charger",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger",
@@ -305,6 +339,8 @@
     },
     {
       "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
       "item": "Electric Panel",
       "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel",


### PR DESCRIPTION
This is in preparation for adding state and utility incentives. For
now, this just adds the type `federal` and null name to IRA incentives.
