### PR TITLE
Do state/utility incentive calculation, return in API

### DIFF
--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -1,0 +1,111 @@
+import { RI_LOW_INCOME_THRESHOLDS } from '../data/RI/low_income_thresholds.js';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities.js';
+import { AmountType, OwnerStatus, Type } from '../data/ira_incentives.js';
+import { RI_INCENTIVES } from '../data/state_incentives.js';
+import { APICalculatorRequest } from '../schemas/v1/calculator-endpoint.js';
+import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive.js';
+
+export function calculateStateIncentivesAndSavings(
+  stateId: string,
+  request: APICalculatorRequest,
+): {
+  stateIncentives: APIIncentiveMinusItemUrl[];
+  tax_savings: number;
+  pos_savings: number;
+  performance_rebate_savings: number;
+} {
+  // TODO not like this
+  if (stateId !== 'RI') {
+    throw new Error("We don't have coverage in that state yet.");
+  }
+
+  const incentives = RI_INCENTIVES;
+
+  const eligibleIncentives = [];
+  const ineligibleIncentives = [];
+
+  for (const item of incentives) {
+    if (
+      item.authority_type === AuthorityType.State &&
+      !request.authority_types?.includes(AuthorityType.State)
+    ) {
+      // Don't include state incentives at all if they weren't requested, not
+      // even as "ineligible" incentives.
+      continue;
+    }
+
+    if (
+      item.authority_type === AuthorityType.Utility &&
+      (!request.authority_types?.includes(AuthorityType.Utility) ||
+        item.authority !== request.utility)
+    ) {
+      // Don't include utility incentives at all if they weren't requested, or
+      // if they're for the wrong utility.
+      continue;
+    }
+
+    let eligible = true;
+
+    if (!item.owner_status.includes(request.owner_status as OwnerStatus)) {
+      eligible = false;
+    }
+
+    if (
+      item.low_income &&
+      request.household_income >
+        RI_LOW_INCOME_THRESHOLDS[request.household_size]
+    ) {
+      eligible = false;
+    }
+
+    const authority_name =
+      item.authority_type === AuthorityType.State
+        ? AUTHORITIES_BY_STATE[stateId].state[item.authority].name
+        : item.authority_type === AuthorityType.Utility
+        ? AUTHORITIES_BY_STATE[stateId].utility[item.authority].name
+        : null;
+
+    const transformedItem = {
+      ...item,
+      authority_name,
+      eligible,
+
+      // Fill in fields expected for IRA incentive.
+      // TODO: don't require these on APIIncentive
+      agi_max_limit: null,
+      ami_qualification: null,
+      filing_status: null,
+
+      // TODO: unclear whether state/utility incentives always have defined
+      // end dates.
+      start_date: 2023,
+      end_date: 2024,
+    };
+    if (eligible) {
+      eligibleIncentives.push(transformedItem);
+    } else {
+      ineligibleIncentives.push(transformedItem);
+    }
+  }
+
+  const stateIncentives = [...eligibleIncentives, ...ineligibleIncentives];
+
+  let savings = 0;
+
+  stateIncentives.forEach(item => {
+    if (item.type === Type.PosRebate) {
+      if (item.amount.representative) {
+        savings += item.amount.representative;
+      } else if (item.amount.type === AmountType.DollarAmount) {
+        savings += item.amount.number;
+      }
+    }
+  });
+
+  return {
+    stateIncentives,
+    tax_savings: 0,
+    pos_savings: savings,
+    performance_rebate_savings: 0,
+  };
+}

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -2,6 +2,7 @@ import { FromSchema } from 'json-schema-to-ts';
 import { ERROR_SCHEMA } from '../error.js';
 import { API_INCENTIVE_SCHEMA } from './incentive.js';
 import { API_LOCATION_SCHEMA } from './location.js';
+import { AuthorityType } from '../../data/authorities.js';
 
 const API_CALCULATOR_REQUEST_SCHEMA = {
   $id: 'APICalculatorRequest',
@@ -9,6 +10,23 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
   type: 'object',
   properties: {
     location: API_LOCATION_SCHEMA,
+    authority_types: {
+      type: 'array',
+      description:
+        'Which types of authority to fetch incentives for: "federal", "state", or "utility".',
+      items: {
+        type: 'string',
+        enum: Object.values(AuthorityType),
+      },
+      minItems: 1,
+      uniqueItems: true,
+    },
+    utility: {
+      type: 'string',
+      description:
+        'The ID of your utility company, as returned from /utilities. ' +
+        'Required if authority_types includes "utility".',
+    },
     owner_status: {
       type: 'string',
       description: 'Homeowners and renters qualify for different incentives.',

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -1,0 +1,220 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "pos_savings": 11600,
+  "tax_savings": 0,
+  "performance_rebate_savings": 0,
+  "pos_rebate_incentives": [
+    {
+      "type": "pos_rebate",
+      "authority_type": "utility",
+      "authority_name": "Rhode Island Energy",
+      "program": "Income Eligible Energy Savings Program",
+      "item": "Weatherization",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
+      "amount": {
+        "type": "percent",
+        "number": 1
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Office of Energy Resources",
+      "program": "Clean Heat RI",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": {
+        "type": "dollars_per_unit",
+        "number": 1250,
+        "representative": 2500,
+        "unit": "ton"
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "utility",
+      "authority_name": "Rhode Island Energy",
+      "program": "Residential electric heating and cooling rebates",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": {
+        "type": "dollars_per_unit",
+        "number": 350,
+        "representative": 700,
+        "unit": "ton"
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Commerce Corporation",
+      "program": "Small Scale Solar Program",
+      "item": "Rooftop Solar Installation",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation",
+      "amount": {
+        "type": "dollars_per_unit",
+        "number": 0.65,
+        "maximum": 5000,
+        "representative": 3000,
+        "unit": "watt"
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Office of Energy Resources",
+      "program": "DRIVE",
+      "item": "New Electric Vehicle",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2500
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Office of Energy Resources",
+      "program": "DRIVE",
+      "item": "Used Electric Vehicle",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1500
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Office of Energy Resources",
+      "program": "Clean Heat RI",
+      "item": "Heat Pump Water Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 750
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "utility",
+      "authority_name": "Rhode Island Energy",
+      "program": "Residential heat pump water heater rebates",
+      "item": "Heat Pump Water Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 600,
+        "maximum": 600
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "utility",
+      "authority_name": "Rhode Island Energy",
+      "program": "Rhode Island ENERGY STAR®  Certified Electric Clothes Dryer Rebate",
+      "item": "Heat Pump Clothes Dryer",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 50
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    }
+  ],
+  "tax_credit_incentives": []
+}


### PR DESCRIPTION
This finally puts it all together: the logic for calculating eligible state/utility incentives, requesting them in the API, and returning them.

A couple of nontrivial decisions here:

- We calculate the savings in each category (tax, POS rebate) for IRA incentives, and separately for state/utility incentives, then add them together.

- Sorting of incentives is still done the same way; in practice we'll likely want to separate them by authority type.