### PR TITLE
Add /calculator param to filter by item

### DIFF
--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
 import { FilingStatus } from './tax_brackets.js';
-import { ALL_ITEMS } from './items.js';
+import { ALL_ITEMS, Item } from './items.js';
 
 export enum AmiQualification {
   LessThan150_Ami = 'less_than_150_ami',
@@ -69,7 +69,7 @@ export interface Incentive {
   amount: Amount;
   end_date: number;
   filing_status: FilingStatus | null;
-  item: string;
+  item: Item;
   item_type: ItemType;
   owner_status: OwnerStatus[];
   program: string;

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -19,6 +19,6 @@ export const ITEMS_SCHEMA = {
   weatherization: { type: 'string' },
 } as const;
 
-export const ALL_ITEMS = Object.keys(
-  ITEMS_SCHEMA,
-) as unknown as (keyof typeof ITEMS_SCHEMA)[];
+export type Item = keyof typeof ITEMS_SCHEMA;
+
+export const ALL_ITEMS = Object.keys(ITEMS_SCHEMA) as unknown as Item[];

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -8,14 +8,14 @@ import {
   OwnerStatus,
   Type,
 } from './ira_incentives.js';
-import { ALL_ITEMS } from './items.js';
+import { ALL_ITEMS, Item } from './items.js';
 import { AuthorityType } from './authorities.js';
 
 export type StateIncentive = {
   authority_type: AuthorityType;
   authority: string;
   type: Type;
-  item: string;
+  item: Item;
   item_type: ItemType;
   program: string;
   amount: Amount;

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -25,6 +25,12 @@ export function calculateStateIncentivesAndSavings(
   const ineligibleIncentives = [];
 
   for (const item of incentives) {
+    if (request.items && !request.items.includes(item.item)) {
+      // Don't include an incentive at all if the query is filtering by item and
+      // this doesn't match.
+      continue;
+    }
+
     if (
       item.authority_type === AuthorityType.State &&
       !request.authority_types?.includes(AuthorityType.State)

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -3,6 +3,7 @@ import { ERROR_SCHEMA } from '../error.js';
 import { API_INCENTIVE_SCHEMA } from './incentive.js';
 import { API_LOCATION_SCHEMA } from './location.js';
 import { AuthorityType } from '../../data/authorities.js';
+import { ALL_ITEMS } from '../../data/items.js';
 
 const API_CALCULATOR_REQUEST_SCHEMA = {
   $id: 'APICalculatorRequest',
@@ -26,6 +27,17 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
       description:
         'The ID of your utility company, as returned from /utilities. ' +
         'Required if authority_types includes "utility".',
+    },
+    items: {
+      type: 'array',
+      description:
+        'Which types of product or project to fetch incentives for. If absent, include all products/projects.',
+      items: {
+        type: 'string',
+        enum: ALL_ITEMS,
+      },
+      minItems: 1,
+      uniqueItems: true,
     },
     owner_status: {
       type: 'string',

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -1,0 +1,127 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "pos_savings": 19000,
+  "tax_savings": 4036,
+  "performance_rebate_savings": 0,
+  "pos_rebate_incentives": [
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Office of Energy Resources",
+      "program": "Clean Heat RI",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": {
+        "type": "dollars_per_unit",
+        "number": 1250,
+        "representative": 2500,
+        "unit": "ton"
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "federal",
+      "authority_name": null,
+      "program": "HEEHR",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 8000
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    },
+    {
+      "type": "pos_rebate",
+      "authority_type": "state",
+      "authority_name": "Rhode Island Office of Energy Resources",
+      "program": "DRIVE",
+      "item": "New Electric Vehicle",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2500
+      },
+      "item_type": "pos_rebate",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    }
+  ],
+  "tax_credit_incentives": [
+    {
+      "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
+      "program": "Clean Vehicle Credit (30D)",
+      "item": "New Electric Vehicle",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 7500
+      },
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": 300000,
+      "filing_status": "joint",
+      "eligible": true
+    },
+    {
+      "type": "tax_credit",
+      "authority_type": "federal",
+      "authority_name": null,
+      "program": "Energy Efficient Home Improvement Credit (25C)",
+      "item": "Heat Pump Air Conditioner/Heater",
+      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
+      "item_type": "tax_credit",
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true
+    }
+  ]
+}


### PR DESCRIPTION
PEP will want this feature (as I've alluded to in Slack) and the
designs for the RI calculator assume it as well.

This assumes that the existing taxonomy of products/projects (which
comes from the IRA data) is what we want for this feature, and I'm not
sure that's the case long-term. This will be good enough for the time
being.

New unit test passes; a few spot-check manual requests return the
expected results.
