### PR TITLE
Switch to CommonJS modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
   },
   "scripts": {
     "start": "fastify start -l info -a 0.0.0.0 build/app.js --options",
-    "dev": "NODE_OPTIONS=\"--no-warnings --loader=ts-node/esm\" fastify start -w -l info -P src/app.ts --options",
+    "dev": "fastify start -r ts-node/register -w -l info -P src/app.ts --options",
     "build": "./scripts/build.sh",
     "lint": "prettier --check . && eslint .",
     "deploy:dev": "gcloud run deploy incentives-api-dev --project rewiring-america-dev --source .",
     "deploy:production": "gcloud run deploy incentives-api --project rewiring-america --source .",
-    "test": "yarn lint && dotenv -- tap --node-arg=--no-warnings --node-arg=--loader=ts-node/esm \"test/**/*.test.ts\""
-  },
-  "type": "module"
+    "test": "yarn lint && dotenv -- tap --no-check-coverage --ts \"test/**/*.test.ts\""
+  }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import AutoLoad from '@fastify/autoload';
-import { fileURLToPath } from 'url';
 import qs from 'qs';
 import {
   FastifyInstance,
@@ -10,15 +9,12 @@ import {
 import {
   API_CALCULATOR_REQUEST_SCHEMA,
   API_CALCULATOR_RESPONSE_SCHEMA,
-} from './schemas/v1/calculator-endpoint.js';
-import { API_INCENTIVE_SCHEMA } from './schemas/v1/incentive.js';
-import { ERROR_SCHEMA } from './schemas/error.js';
-import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from './schemas/v0/calculator-request.js';
-import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from './schemas/v0/calculator-response.js';
-import { WEBSITE_INCENTIVE_SCHEMA } from './schemas/v0/incentive.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+} from './schemas/v1/calculator-endpoint';
+import { API_INCENTIVE_SCHEMA } from './schemas/v1/incentive';
+import { ERROR_SCHEMA } from './schemas/error';
+import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from './schemas/v0/calculator-request';
+import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from './schemas/v0/calculator-response';
+import { WEBSITE_INCENTIVE_SCHEMA } from './schemas/v0/incentive';
 
 // Pass --options via CLI arguments in command to enable these options.
 export const options = {
@@ -47,7 +43,6 @@ export default async function (
   // through your application
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'plugins'),
-    forceESM: true,
     options: Object.assign({}, opts),
   });
 
@@ -55,7 +50,6 @@ export default async function (
   // define your routes in one of these
   fastify.register(AutoLoad, {
     dir: path.join(__dirname, 'routes'),
-    forceESM: true,
     options: Object.assign({}, opts),
   });
 }

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { STATES_PLUS_DC } from './states.js';
+import { STATES_PLUS_DC } from './states';
 
 /**
  * An authority is a government agency, utility, or other organization that

--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { FilingStatus } from './tax_brackets.js';
-import { ALL_ITEMS, Item } from './items.js';
+import { FilingStatus } from './tax_brackets';
+import { ALL_ITEMS, Item } from './items';
 
 export enum AmiQualification {
   LessThan150_Ami = 'less_than_150_ami',

--- a/src/data/ira_state_savings.ts
+++ b/src/data/ira_state_savings.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { STATES_PLUS_DC } from './states.js';
+import { STATES_PLUS_DC } from './states';
 
 const propertySchema = {
   estimate_savings_space_heat: { type: 'number' },

--- a/src/data/locale.ts
+++ b/src/data/locale.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { ALL_ITEMS, ITEMS_SCHEMA } from './items.js';
+import { ALL_ITEMS, ITEMS_SCHEMA } from './items';
 
 export type Items = {
   [k in keyof typeof ITEMS_SCHEMA]: string;

--- a/src/data/solar_prices.ts
+++ b/src/data/solar_prices.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { STATES_PLUS_DC } from './states.js';
+import { STATES_PLUS_DC } from './states';
 
 const propertySchema = {
   cost_per_watt: { type: 'number' },

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -7,9 +7,9 @@ import {
   ItemType,
   OwnerStatus,
   Type,
-} from './ira_incentives.js';
-import { ALL_ITEMS, Item } from './items.js';
-import { AuthorityType } from './authorities.js';
+} from './ira_incentives';
+import { ALL_ITEMS, Item } from './items';
+import { AuthorityType } from './authorities';
 
 export type StateIncentive = {
   authority_type: AuthorityType;

--- a/src/data/state_mfi.ts
+++ b/src/data/state_mfi.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { STATES_PLUS_DC } from './states.js';
+import { STATES_PLUS_DC } from './states';
 
 const propertySchema = {
   METRO: { type: 'number' },

--- a/src/lib/fetch-amis-for-address.ts
+++ b/src/lib/fetch-amis-for-address.ts
@@ -1,6 +1,6 @@
 import { Database } from 'sqlite';
-import { geocoder } from './geocoder.js';
-import { AMI, IncomeInfo, MFI } from './income-info.js';
+import { geocoder } from './geocoder';
+import { AMI, IncomeInfo, MFI } from './income-info';
 
 export default async function fetchAMIsForAddress(
   db: Database,

--- a/src/lib/fetch-amis-for-zip.ts
+++ b/src/lib/fetch-amis-for-zip.ts
@@ -1,5 +1,5 @@
 import { Database } from 'sqlite';
-import { AMI, ZipInfo, IncomeInfo, MFI } from './income-info.js';
+import { AMI, ZipInfo, IncomeInfo, MFI } from './income-info';
 
 export default async function fetchAMIsForZip(
   db: Database,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,4 +1,4 @@
-import { Locale, LOCALES } from '../data/locale.js';
+import { Locale, LOCALES } from '../data/locale';
 
 // FIXME: if we get tempted to start optimizing this, use a real i18n library
 // looked at fastify-polyglot but it didn't have good docs on switching locale

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -1,18 +1,18 @@
 import _ from 'lodash';
-import estimateTaxAmount from './tax-brackets.js';
-import { IRA_INCENTIVES, OwnerStatus } from '../data/ira_incentives.js';
-import { SOLAR_PRICES } from '../data/solar_prices.js';
-import { STATE_MFIS, StateMFI } from '../data/state_mfi.js';
+import estimateTaxAmount from './tax-brackets';
+import { IRA_INCENTIVES, OwnerStatus } from '../data/ira_incentives';
+import { SOLAR_PRICES } from '../data/solar_prices';
+import { STATE_MFIS, StateMFI } from '../data/state_mfi';
 import {
   APICalculatorRequest,
   APICalculatorResponse,
-} from '../schemas/v1/calculator-endpoint.js';
-import { AMI, CompleteIncomeInfo, MFI } from './income-info.js';
-import { FilingStatus } from '../data/tax_brackets.js';
-import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive.js';
-import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities.js';
-import { calculateStateIncentivesAndSavings } from './state-incentives-calculation.js';
-import { InvalidInputError, UnexpectedInputError } from './error.js';
+} from '../schemas/v1/calculator-endpoint';
+import { AMI, CompleteIncomeInfo, MFI } from './income-info';
+import { FilingStatus } from '../data/tax_brackets';
+import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
+import { calculateStateIncentivesAndSavings } from './state-incentives-calculation';
+import { InvalidInputError, UnexpectedInputError } from './error';
 
 const MAX_POS_SAVINGS = 14000;
 const OWNER_STATUSES = new Set(['homeowner', 'renter']);

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -1,10 +1,10 @@
-import { RI_LOW_INCOME_THRESHOLDS } from '../data/RI/low_income_thresholds.js';
-import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities.js';
-import { AmountType, OwnerStatus, Type } from '../data/ira_incentives.js';
-import { RI_INCENTIVES } from '../data/state_incentives.js';
-import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive.js';
-import { UnexpectedInputError } from './error.js';
-import { CalculateParams } from './incentives-calculation.js';
+import { RI_LOW_INCOME_THRESHOLDS } from '../data/RI/low_income_thresholds';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
+import { AmountType, OwnerStatus, Type } from '../data/ira_incentives';
+import { RI_INCENTIVES } from '../data/state_incentives';
+import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
+import { UnexpectedInputError } from './error';
+import { CalculateParams } from './incentives-calculation';
 
 export function calculateStateIncentivesAndSavings(
   stateId: string,

--- a/src/lib/tax-brackets.ts
+++ b/src/lib/tax-brackets.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { TAX_BRACKETS, FilingStatus } from '../data/tax_brackets.js';
+import { TAX_BRACKETS, FilingStatus } from '../data/tax_brackets';
 
 export default function estimateTaxAmount(
   filing_status: FilingStatus,

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -1,25 +1,25 @@
-import calculateIncentives from '../lib/incentives-calculation.js';
-import fetchAMIsForZip from '../lib/fetch-amis-for-zip.js';
-import { t } from '../lib/i18n.js';
+import calculateIncentives from '../lib/incentives-calculation';
+import fetchAMIsForZip from '../lib/fetch-amis-for-zip';
+import { t } from '../lib/i18n';
 import _ from 'lodash';
-import { IRA_INCENTIVES } from '../data/ira_incentives.js';
-import { IRA_STATE_SAVINGS } from '../data/ira_state_savings.js';
-import { InvalidInputError } from '../lib/error.js';
+import { IRA_INCENTIVES } from '../data/ira_incentives';
+import { IRA_STATE_SAVINGS } from '../data/ira_state_savings';
+import { InvalidInputError } from '../lib/error';
 import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
 import { FastifyInstance } from 'fastify';
 import { Database } from 'sqlite';
 import {
   WEBSITE_INCENTIVE_SCHEMA,
   WebsiteIncentive,
-} from '../schemas/v0/incentive.js';
-import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from '../schemas/v0/calculator-request.js';
+} from '../schemas/v0/incentive';
+import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from '../schemas/v0/calculator-request';
 import {
   WEBSITE_CALCULATOR_RESPONSE_SCHEMA,
   WebsiteCalculatorResponse,
-} from '../schemas/v0/calculator-response.js';
-import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive.js';
-import { AuthorityType } from '../data/authorities.js';
-import { isCompleteIncomeInfo } from '../lib/income-info.js';
+} from '../schemas/v0/calculator-response';
+import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
+import { AuthorityType } from '../data/authorities';
+import { isCompleteIncomeInfo } from '../lib/income-info';
 
 IRA_INCENTIVES.forEach(incentive => Object.freeze(incentive));
 

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -1,29 +1,29 @@
-import calculateIncentives from '../lib/incentives-calculation.js';
-import fetchAMIsForAddress from '../lib/fetch-amis-for-address.js';
-import fetchAMIsForZip from '../lib/fetch-amis-for-zip.js';
-import { t } from '../lib/i18n.js';
-import { IRA_INCENTIVES } from '../data/ira_incentives.js';
+import calculateIncentives from '../lib/incentives-calculation';
+import fetchAMIsForAddress from '../lib/fetch-amis-for-address';
+import fetchAMIsForZip from '../lib/fetch-amis-for-zip';
+import { t } from '../lib/i18n';
+import { IRA_INCENTIVES } from '../data/ira_incentives';
 import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
 import { FastifyInstance } from 'fastify';
 import {
   API_CALCULATOR_REQUEST_SCHEMA,
   API_CALCULATOR_RESPONSE_SCHEMA,
   API_CALCULATOR_SCHEMA,
-} from '../schemas/v1/calculator-endpoint.js';
-import { API_INCENTIVES_SCHEMA } from '../schemas/v1/incentives-endpoint.js';
+} from '../schemas/v1/calculator-endpoint';
+import { API_INCENTIVES_SCHEMA } from '../schemas/v1/incentives-endpoint';
 import {
   APIIncentive,
   APIIncentiveMinusItemUrl,
   API_INCENTIVE_SCHEMA,
-} from '../schemas/v1/incentive.js';
-import { APILocation } from '../schemas/v1/location.js';
-import { LOCALES } from '../data/locale.js';
+} from '../schemas/v1/incentive';
+import { APILocation } from '../schemas/v1/location';
+import { LOCALES } from '../data/locale';
 import { Database } from 'sqlite';
-import { IncomeInfo, isCompleteIncomeInfo } from '../lib/income-info.js';
-import { API_UTILITIES_SCHEMA } from '../schemas/v1/utilities-endpoint.js';
-import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities.js';
-import { InvalidInputError, UnexpectedInputError } from '../lib/error.js';
-import { ERROR_SCHEMA } from '../schemas/error.js';
+import { IncomeInfo, isCompleteIncomeInfo } from '../lib/income-info';
+import { API_UTILITIES_SCHEMA } from '../schemas/v1/utilities-endpoint';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
+import { InvalidInputError, UnexpectedInputError } from '../lib/error';
+import { ERROR_SCHEMA } from '../schemas/error';
 
 function transformIncentives(
   incentives: APIIncentiveMinusItemUrl[],

--- a/src/schemas/v0/calculator-response.ts
+++ b/src/schemas/v0/calculator-response.ts
@@ -1,5 +1,5 @@
 import { FromSchema } from 'json-schema-to-ts';
-import { WEBSITE_INCENTIVE_SCHEMA } from './incentive.js';
+import { WEBSITE_INCENTIVE_SCHEMA } from './incentive';
 
 export const WEBSITE_CALCULATOR_RESPONSE_SCHEMA = {
   $id: 'WebsiteCalculatorResponse',

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -1,8 +1,8 @@
 import { FromSchema } from 'json-schema-to-ts';
-import { API_INCENTIVE_SCHEMA } from './incentive.js';
-import { API_LOCATION_SCHEMA } from './location.js';
-import { AuthorityType } from '../../data/authorities.js';
-import { ALL_ITEMS } from '../../data/items.js';
+import { API_INCENTIVE_SCHEMA } from './incentive';
+import { API_LOCATION_SCHEMA } from './location';
+import { AuthorityType } from '../../data/authorities';
+import { ALL_ITEMS } from '../../data/items';
 
 export const API_CALCULATOR_REQUEST_SCHEMA = {
   $id: 'APICalculatorRequest',

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -1,4 +1,4 @@
-import { API_LOCATION_SCHEMA } from './location.js';
+import { API_LOCATION_SCHEMA } from './location';
 
 export const API_UTILITIES_RESPONSE_SCHEMA = {
   $id: 'APIUtilitiesResponse',

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -2,37 +2,31 @@ import { test } from 'tap';
 import {
   SCHEMA as I_SCHEMA,
   IRA_INCENTIVES,
-} from '../../src/data/ira_incentives.js';
+} from '../../src/data/ira_incentives';
 import {
   SCHEMA as ISS_SCHEMA,
   IRA_STATE_SAVINGS,
-} from '../../src/data/ira_state_savings.js';
-import { SCHEMA as L_SCHEMA, LOCALES } from '../../src/data/locale.js';
-import {
-  SCHEMA as SP_SCHEMA,
-  SOLAR_PRICES,
-} from '../../src/data/solar_prices.js';
-import { SCHEMA as SMFI_SCHEMA, STATE_MFIS } from '../../src/data/state_mfi.js';
-import {
-  SCHEMA as TB_SCHEMA,
-  TAX_BRACKETS,
-} from '../../src/data/tax_brackets.js';
+} from '../../src/data/ira_state_savings';
+import { SCHEMA as L_SCHEMA, LOCALES } from '../../src/data/locale';
+import { SCHEMA as SP_SCHEMA, SOLAR_PRICES } from '../../src/data/solar_prices';
+import { SCHEMA as SMFI_SCHEMA, STATE_MFIS } from '../../src/data/state_mfi';
+import { SCHEMA as TB_SCHEMA, TAX_BRACKETS } from '../../src/data/tax_brackets';
 import {
   SCHEMA as AUTHORITIES_SCHEMA,
   AUTHORITIES_BY_STATE,
-} from '../../src/data/authorities.js';
+} from '../../src/data/authorities';
 import {
   SCHEMA as RI_LOW_INCOME_THRESHOLDS_SCHEMA,
   RI_LOW_INCOME_THRESHOLDS,
-} from '../../src/data/RI/low_income_thresholds.js';
+} from '../../src/data/RI/low_income_thresholds';
 import {
   RI_INCENTIVES,
   RI_INCENTIVES_SCHEMA,
   StateIncentive,
-} from '../../src/data/state_incentives.js';
+} from '../../src/data/state_incentives';
 
 import Ajv from 'ajv';
-import { SomeJSONSchema } from 'ajv/dist/types/json-schema.js';
+import { SomeJSONSchema } from 'ajv/dist/types/json-schema';
 
 const TESTS = [
   [I_SCHEMA, IRA_INCENTIVES, 'ira_incentives'],
@@ -48,8 +42,7 @@ const TESTS = [
 
 test('static JSON files match schema', async tap => {
   tap.plan(TESTS.length);
-  // Workaround for https://github.com/ajv-validator/ajv/issues/2047
-  const ajv = new Ajv.default();
+  const ajv = new Ajv();
 
   TESTS.forEach(([schema, data, label]) => {
     if (!tap.ok(ajv.validate(schema, data))) {
@@ -83,7 +76,7 @@ function isIncentiveAmountValid<T extends StateIncentive>(
 }
 
 test('state incentives JSON files match schemas', async tap => {
-  const ajv = new Ajv.default();
+  const ajv = new Ajv();
 
   STATE_INCENTIVE_TESTS.forEach(([stateId, schema, data]) => {
     const authorities = AUTHORITIES_BY_STATE[stateId as string];

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -3,10 +3,7 @@
 
 import helper from 'fastify-cli/helper.js';
 import path from 'path';
-import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 const AppPath = path.join(__dirname, '..', 'src', 'app.ts');
 
 // Fill in this config with all the configurations

--- a/test/lib/fetch-amis-for-address.test.ts
+++ b/test/lib/fetch-amis-for-address.test.ts
@@ -1,9 +1,9 @@
 import { test, beforeEach, afterEach } from 'tap';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
-import fetchAMIsForAddress from '../../src/lib/fetch-amis-for-address.js';
-import { geocoder } from '../../src/lib/geocoder.js';
-import { geocoder as mockGeocoder } from '../mocks/geocoder.js';
+import fetchAMIsForAddress from '../../src/lib/fetch-amis-for-address';
+import { geocoder } from '../../src/lib/geocoder';
+import { geocoder as mockGeocoder } from '../mocks/geocoder';
 
 beforeEach(async t => {
   t.context.db = await open({

--- a/test/lib/i18n.test.ts
+++ b/test/lib/i18n.test.ts
@@ -1,4 +1,4 @@
-import { t } from '../../src/lib/i18n.js';
+import { t } from '../../src/lib/i18n';
 import { test } from 'tap';
 
 test('t finds the right string', async tap => {

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -1,5 +1,5 @@
 import { test, beforeEach, afterEach } from 'tap';
-import calculateIncentives from '../../src/lib/incentives-calculation.js';
+import calculateIncentives from '../../src/lib/incentives-calculation';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 import _ from 'lodash';

--- a/test/lib/tax-brackets.test.ts
+++ b/test/lib/tax-brackets.test.ts
@@ -1,5 +1,5 @@
-import estimateTaxAmount from '../../src/lib/tax-brackets.js';
-import { FilingStatus } from '../../src/data/tax_brackets.js';
+import estimateTaxAmount from '../../src/lib/tax-brackets';
+import { FilingStatus } from '../../src/data/tax_brackets';
 import { test } from 'tap';
 
 /**

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -1,10 +1,10 @@
 import { test, beforeEach } from 'tap';
-import { build } from '../helper.js';
+import { build } from '../helper';
 import Ajv from 'ajv';
 import fs from 'fs';
 import qs from 'qs';
-import { WEBSITE_INCENTIVE_SCHEMA } from '../../src/schemas/v0/incentive.js';
-import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v0/calculator-response.js';
+import { WEBSITE_INCENTIVE_SCHEMA } from '../../src/schemas/v0/incentive';
+import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v0/calculator-response';
 
 beforeEach(() => {
   process.setMaxListeners(100);
@@ -36,7 +36,7 @@ test('response is valid and correct', async t => {
 
   const calculatorResponse = JSON.parse(res.payload);
 
-  const ajv = new Ajv.default({
+  const ajv = new Ajv({
     schemas: [WEBSITE_INCENTIVE_SCHEMA, WEBSITE_CALCULATOR_RESPONSE_SCHEMA],
     coerceTypes: true,
     useDefaults: true,
@@ -331,7 +331,7 @@ test('/incentives', async t => {
   t.equal(incentivesResponse.incentives.length, 30);
   t.equal(res.statusCode, 200, 'response status is 200');
 
-  const ajv = new Ajv.default({
+  const ajv = new Ajv({
     schemas: [WEBSITE_INCENTIVE_SCHEMA],
     coerceTypes: true,
     useDefaults: true,

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -1,9 +1,9 @@
 import { test, beforeEach } from 'tap';
-import { build } from '../helper.js';
-import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive.js';
-import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint.js';
-import { API_UTILITIES_RESPONSE_SCHEMA } from '../../src/schemas/v1/utilities-endpoint.js';
-import { AUTHORITIES_BY_STATE } from '../../src/data/authorities.js';
+import { build } from '../helper';
+import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive';
+import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint';
+import { API_UTILITIES_RESPONSE_SCHEMA } from '../../src/schemas/v1/utilities-endpoint';
+import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
 import Ajv from 'ajv';
 import fs from 'fs';
 import qs from 'qs';
@@ -35,7 +35,7 @@ async function validateResponse(
 
   const calculatorResponse = JSON.parse(res.payload);
 
-  const ajv = new Ajv.default({
+  const ajv = new Ajv({
     schemas: [API_INCENTIVE_SCHEMA, API_CALCULATOR_RESPONSE_SCHEMA],
     coerceTypes: true,
     useDefaults: true,
@@ -331,7 +331,7 @@ test('/incentives', async t => {
   t.equal(incentivesResponse.incentives.length, 30);
   t.equal(res.statusCode, 200, 'response status is 200');
 
-  const ajv = new Ajv.default({
+  const ajv = new Ajv({
     schemas: [{ ...API_INCENTIVE_SCHEMA, $id: 'APIIncentive' }],
     coerceTypes: true,
     useDefaults: true,
@@ -358,7 +358,7 @@ test('/utilities', async t => {
 
   const utilitiesResponse = JSON.parse(res.payload);
 
-  const ajv = new Ajv.default({
+  const ajv = new Ajv({
     schemas: [API_UTILITIES_RESPONSE_SCHEMA],
     coerceTypes: true,
     useDefaults: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "fastify-tsconfig",
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "NodeNext",
     "declaration": false,
     "outDir": "build/",


### PR DESCRIPTION
## Description

This is the generally-expected config for pure Node projects. Node's
ESM support is not mature yet, and I had to do some slightly janky
stuff to get it to work with TypeScript.

Now that everything is TypeScript, though, it's easy to switch module
systems. The substantive changes are:

- `package.json`: adjusting the commands to load ts-node more cleanly,
  removing `"type": "module"`.

- `tsconfig.json`: changing to `commonjs`.

- `src/app.ts`: removing the `__dirname` shim and `forceESM` flag to
  fastify loading

- `test/helper.ts`: removing the `__dirname` shim

- Various tests: removing the `Ajv.default` workaround

Everything else is just removing suffixes from imports.

One interesting side effect of this is that `tap` checks code coverage
now, without me telling it to. I don't know exactly why this happened.
Anyway, by default it expects 100% test coverage (!!) and we don't
have that, so I've turned off the 100% enforcement for now. (It will
still print the coverage report at the end of each test run.)

## Test Plan

- `yarn test`

- `yarn dev`, run some manual requests with curl

## Next Steps

See what it would take to get 100% test coverage, I guess? If it
doesn't seem worthwhile, maybe figure out a reasonably attainable
coverage threshold and configure tap to enforce it?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205262224585558