### PR TITLE
Log the Authorization header on /api/v1/incentives

### DIFF
--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -124,6 +124,9 @@ export default async function (
     '/api/v1/incentives',
     { schema: API_INCENTIVES_SCHEMA },
     async (request, reply) => {
+      // TODO remove this after debugging Zuplo -> GCP auth
+      request.log.info({ authHeader: request.headers.authorization ?? null });
+
       const incentives = transformIncentives(
         IRA_INCENTIVES.map(incentive => ({
           ...incentive,


### PR DESCRIPTION
I'm trying to debug why the Zuplo service account isn't successfully
authenticating to the GCR backend, on prod only. (It's working in
dev!)

This authentication is supposed to happen by means of the
Authorization header, which contains a JWT. This should let us see
how/whether something's going wrong in that step of auth.

## Test Plan

- `yarn dev`, run curl locally without an Authorization header, and
  with a populated one; make sure logs are visible in both cases.
