### PR TITLE
Revert "Log the Authorization header on /api/v1/incentives (#116)"

### DIFF
--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -124,9 +124,6 @@ export default async function (
     '/api/v1/incentives',
     { schema: API_INCENTIVES_SCHEMA },
     async (request, reply) => {
-      // TODO remove this after debugging Zuplo -> GCP auth
-      request.log.info({ authHeader: request.headers.authorization ?? null });
-
       const incentives = transformIncentives(
         IRA_INCENTIVES.map(incentive => ({
           ...incentive,


### PR DESCRIPTION
We've successfully turned on authentication on prod, so we don't need
this anymore.

This reverts commit 33bbebe7ba287f810fa48b75903fae008d37b14c.
