### PR TITLE
Add Prettier plugin to organize imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,10 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "printWidth": 80,
-  "plugins": ["prettier-plugin-multiline-arrays"],
+  "plugins": [
+    "prettier-plugin-organize-imports",
+    "prettier-plugin-multiline-arrays"
+  ],
   "overrides": [
     {
       "files": ["data/*.json", "schemas/**/*.json", "test/fixtures/*.json"],

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "json-schema-to-ts": "^2.0.0",
     "prettier": "^2.8.8",
     "prettier-plugin-multiline-arrays": "^2.0.0",
+    "prettier-plugin-organize-imports": "^3.2.3",
     "tap": "^16.3.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,20 +1,20 @@
-import path from 'path';
 import AutoLoad from '@fastify/autoload';
-import qs from 'qs';
 import {
   FastifyInstance,
   FastifyRegisterOptions,
   RegisterOptions,
 } from 'fastify';
+import path from 'path';
+import qs from 'qs';
+import { ERROR_SCHEMA } from './schemas/error';
+import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from './schemas/v0/calculator-request';
+import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from './schemas/v0/calculator-response';
+import { WEBSITE_INCENTIVE_SCHEMA } from './schemas/v0/incentive';
 import {
   API_CALCULATOR_REQUEST_SCHEMA,
   API_CALCULATOR_RESPONSE_SCHEMA,
 } from './schemas/v1/calculator-endpoint';
 import { API_INCENTIVE_SCHEMA } from './schemas/v1/incentive';
-import { ERROR_SCHEMA } from './schemas/error';
-import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from './schemas/v0/calculator-request';
-import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from './schemas/v0/calculator-response';
-import { WEBSITE_INCENTIVE_SCHEMA } from './schemas/v0/incentive';
 
 // Pass --options via CLI arguments in command to enable these options.
 export const options = {

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
 import { STATES_PLUS_DC } from './states';
 
 /**

--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
-import { FilingStatus } from './tax_brackets';
+import fs from 'fs';
 import { ALL_ITEMS, Item } from './items';
+import { FilingStatus } from './tax_brackets';
 
 export enum AmiQualification {
   LessThan150_Ami = 'less_than_150_ami',

--- a/src/data/ira_state_savings.ts
+++ b/src/data/ira_state_savings.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
 import { STATES_PLUS_DC } from './states';
 
 const propertySchema = {

--- a/src/data/locale.ts
+++ b/src/data/locale.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
 import { ALL_ITEMS, ITEMS_SCHEMA } from './items';
 
 export type Items = {

--- a/src/data/solar_prices.ts
+++ b/src/data/solar_prices.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
 import { STATES_PLUS_DC } from './states';
 
 const propertySchema = {

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -1,5 +1,6 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
+import { AuthorityType } from './authorities';
 import {
   Amount,
   AmountType,
@@ -9,7 +10,6 @@ import {
   Type,
 } from './ira_incentives';
 import { ALL_ITEMS, Item } from './items';
-import { AuthorityType } from './authorities';
 
 export type StateIncentive = {
   authority_type: AuthorityType;

--- a/src/data/state_mfi.ts
+++ b/src/data/state_mfi.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
 import { STATES_PLUS_DC } from './states';
 
 const propertySchema = {

--- a/src/data/tax_brackets.ts
+++ b/src/data/tax_brackets.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import { JSONSchemaType } from 'ajv';
+import fs from 'fs';
 
 export type TaxBracket = {
   filing_status: FilingStatus;

--- a/src/lib/fetch-amis-for-zip.ts
+++ b/src/lib/fetch-amis-for-zip.ts
@@ -1,5 +1,5 @@
 import { Database } from 'sqlite';
-import { AMI, ZipInfo, IncomeInfo, MFI } from './income-info';
+import { AMI, IncomeInfo, MFI, ZipInfo } from './income-info';
 
 export default async function fetchAMIsForZip(
   db: Database,

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -1,18 +1,18 @@
 import _ from 'lodash';
-import estimateTaxAmount from './tax-brackets';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
 import { IRA_INCENTIVES, OwnerStatus } from '../data/ira_incentives';
 import { SOLAR_PRICES } from '../data/solar_prices';
 import { STATE_MFIS, StateMFI } from '../data/state_mfi';
+import { FilingStatus } from '../data/tax_brackets';
 import {
   APICalculatorRequest,
   APICalculatorResponse,
 } from '../schemas/v1/calculator-endpoint';
-import { AMI, CompleteIncomeInfo, MFI } from './income-info';
-import { FilingStatus } from '../data/tax_brackets';
 import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
-import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
-import { calculateStateIncentivesAndSavings } from './state-incentives-calculation';
 import { InvalidInputError, UnexpectedInputError } from './error';
+import { AMI, CompleteIncomeInfo, MFI } from './income-info';
+import { calculateStateIncentivesAndSavings } from './state-incentives-calculation';
+import estimateTaxAmount from './tax-brackets';
 
 const MAX_POS_SAVINGS = 14000;
 const OWNER_STATUSES = new Set(['homeowner', 'renter']);

--- a/src/lib/tax-brackets.ts
+++ b/src/lib/tax-brackets.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { TAX_BRACKETS, FilingStatus } from '../data/tax_brackets';
+import { FilingStatus, TAX_BRACKETS } from '../data/tax_brackets';
 
 export default function estimateTaxAmount(
   filing_status: FilingStatus,

--- a/src/plugins/sqlite.ts
+++ b/src/plugins/sqlite.ts
@@ -1,5 +1,5 @@
-import FastifySqlite from 'fastify-sqlite';
 import fp from 'fastify-plugin'; // the use of fastify-plugin is required to be able to export the decorators to the outer scope
+import FastifySqlite from 'fastify-sqlite';
 
 export default fp(async function (fastify) {
   await fastify.register(FastifySqlite, {

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -1,25 +1,25 @@
-import calculateIncentives from '../lib/incentives-calculation';
-import fetchAMIsForZip from '../lib/fetch-amis-for-zip';
-import { t } from '../lib/i18n';
+import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
+import { FastifyInstance } from 'fastify';
 import _ from 'lodash';
+import { Database } from 'sqlite';
+import { AuthorityType } from '../data/authorities';
 import { IRA_INCENTIVES } from '../data/ira_incentives';
 import { IRA_STATE_SAVINGS } from '../data/ira_state_savings';
 import { InvalidInputError } from '../lib/error';
-import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
-import { FastifyInstance } from 'fastify';
-import { Database } from 'sqlite';
-import {
-  WEBSITE_INCENTIVE_SCHEMA,
-  WebsiteIncentive,
-} from '../schemas/v0/incentive';
+import fetchAMIsForZip from '../lib/fetch-amis-for-zip';
+import { t } from '../lib/i18n';
+import calculateIncentives from '../lib/incentives-calculation';
+import { isCompleteIncomeInfo } from '../lib/income-info';
 import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from '../schemas/v0/calculator-request';
 import {
   WEBSITE_CALCULATOR_RESPONSE_SCHEMA,
   WebsiteCalculatorResponse,
 } from '../schemas/v0/calculator-response';
+import {
+  WEBSITE_INCENTIVE_SCHEMA,
+  WebsiteIncentive,
+} from '../schemas/v0/incentive';
 import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
-import { AuthorityType } from '../data/authorities';
-import { isCompleteIncomeInfo } from '../lib/income-info';
 
 IRA_INCENTIVES.forEach(incentive => Object.freeze(incentive));
 

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -1,29 +1,29 @@
-import calculateIncentives from '../lib/incentives-calculation';
+import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
+import { FastifyInstance } from 'fastify';
+import { Database } from 'sqlite';
+import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
+import { IRA_INCENTIVES } from '../data/ira_incentives';
+import { LOCALES } from '../data/locale';
+import { InvalidInputError, UnexpectedInputError } from '../lib/error';
 import fetchAMIsForAddress from '../lib/fetch-amis-for-address';
 import fetchAMIsForZip from '../lib/fetch-amis-for-zip';
 import { t } from '../lib/i18n';
-import { IRA_INCENTIVES } from '../data/ira_incentives';
-import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
-import { FastifyInstance } from 'fastify';
+import calculateIncentives from '../lib/incentives-calculation';
+import { IncomeInfo, isCompleteIncomeInfo } from '../lib/income-info';
+import { ERROR_SCHEMA } from '../schemas/error';
 import {
   API_CALCULATOR_REQUEST_SCHEMA,
   API_CALCULATOR_RESPONSE_SCHEMA,
   API_CALCULATOR_SCHEMA,
 } from '../schemas/v1/calculator-endpoint';
-import { API_INCENTIVES_SCHEMA } from '../schemas/v1/incentives-endpoint';
 import {
   APIIncentive,
   APIIncentiveMinusItemUrl,
   API_INCENTIVE_SCHEMA,
 } from '../schemas/v1/incentive';
+import { API_INCENTIVES_SCHEMA } from '../schemas/v1/incentives-endpoint';
 import { APILocation } from '../schemas/v1/location';
-import { LOCALES } from '../data/locale';
-import { Database } from 'sqlite';
-import { IncomeInfo, isCompleteIncomeInfo } from '../lib/income-info';
 import { API_UTILITIES_SCHEMA } from '../schemas/v1/utilities-endpoint';
-import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
-import { InvalidInputError, UnexpectedInputError } from '../lib/error';
-import { ERROR_SCHEMA } from '../schemas/error';
 
 function transformIncentives(
   incentives: APIIncentiveMinusItemUrl[],

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -1,8 +1,8 @@
 import { FromSchema } from 'json-schema-to-ts';
-import { API_INCENTIVE_SCHEMA } from './incentive';
-import { API_LOCATION_SCHEMA } from './location';
 import { AuthorityType } from '../../data/authorities';
 import { ALL_ITEMS } from '../../data/items';
+import { API_INCENTIVE_SCHEMA } from './incentive';
+import { API_LOCATION_SCHEMA } from './location';
 
 export const API_CALCULATOR_REQUEST_SCHEMA = {
   $id: 'APICalculatorRequest',

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -1,29 +1,29 @@
 import { test } from 'tap';
 import {
-  SCHEMA as I_SCHEMA,
-  IRA_INCENTIVES,
-} from '../../src/data/ira_incentives';
+  RI_LOW_INCOME_THRESHOLDS,
+  SCHEMA as RI_LOW_INCOME_THRESHOLDS_SCHEMA,
+} from '../../src/data/RI/low_income_thresholds';
 import {
-  SCHEMA as ISS_SCHEMA,
-  IRA_STATE_SAVINGS,
-} from '../../src/data/ira_state_savings';
-import { SCHEMA as L_SCHEMA, LOCALES } from '../../src/data/locale';
-import { SCHEMA as SP_SCHEMA, SOLAR_PRICES } from '../../src/data/solar_prices';
-import { SCHEMA as SMFI_SCHEMA, STATE_MFIS } from '../../src/data/state_mfi';
-import { SCHEMA as TB_SCHEMA, TAX_BRACKETS } from '../../src/data/tax_brackets';
-import {
-  SCHEMA as AUTHORITIES_SCHEMA,
   AUTHORITIES_BY_STATE,
+  SCHEMA as AUTHORITIES_SCHEMA,
 } from '../../src/data/authorities';
 import {
-  SCHEMA as RI_LOW_INCOME_THRESHOLDS_SCHEMA,
-  RI_LOW_INCOME_THRESHOLDS,
-} from '../../src/data/RI/low_income_thresholds';
+  IRA_INCENTIVES,
+  SCHEMA as I_SCHEMA,
+} from '../../src/data/ira_incentives';
+import {
+  IRA_STATE_SAVINGS,
+  SCHEMA as ISS_SCHEMA,
+} from '../../src/data/ira_state_savings';
+import { LOCALES, SCHEMA as L_SCHEMA } from '../../src/data/locale';
+import { SOLAR_PRICES, SCHEMA as SP_SCHEMA } from '../../src/data/solar_prices';
 import {
   RI_INCENTIVES,
   RI_INCENTIVES_SCHEMA,
   StateIncentive,
 } from '../../src/data/state_incentives';
+import { SCHEMA as SMFI_SCHEMA, STATE_MFIS } from '../../src/data/state_mfi';
+import { TAX_BRACKETS, SCHEMA as TB_SCHEMA } from '../../src/data/tax_brackets';
 
 import Ajv from 'ajv';
 import { SomeJSONSchema } from 'ajv/dist/types/json-schema';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -28,4 +28,4 @@ async function build(t: Tap.Test) {
   return app;
 }
 
-export { config, build };
+export { build, config };

--- a/test/lib/fetch-amis-for-address.test.ts
+++ b/test/lib/fetch-amis-for-address.test.ts
@@ -1,6 +1,6 @@
-import { test, beforeEach, afterEach } from 'tap';
-import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
+import sqlite3 from 'sqlite3';
+import { afterEach, beforeEach, test } from 'tap';
 import fetchAMIsForAddress from '../../src/lib/fetch-amis-for-address';
 import { geocoder } from '../../src/lib/geocoder';
 import { geocoder as mockGeocoder } from '../mocks/geocoder';

--- a/test/lib/i18n.test.ts
+++ b/test/lib/i18n.test.ts
@@ -1,5 +1,5 @@
-import { t } from '../../src/lib/i18n';
 import { test } from 'tap';
+import { t } from '../../src/lib/i18n';
 
 test('t finds the right string', async tap => {
   tap.equal(

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -1,9 +1,9 @@
-import { test, beforeEach, afterEach } from 'tap';
-import calculateIncentives from '../../src/lib/incentives-calculation';
-import sqlite3 from 'sqlite3';
-import { open } from 'sqlite';
-import _ from 'lodash';
 import fs from 'fs';
+import _ from 'lodash';
+import { open } from 'sqlite';
+import sqlite3 from 'sqlite3';
+import { afterEach, beforeEach, test } from 'tap';
+import calculateIncentives from '../../src/lib/incentives-calculation';
 
 const AMIS_FOR_11211 = JSON.parse(
   fs.readFileSync('./test/fixtures/amis-for-zip-11211.json', 'utf-8'),

--- a/test/lib/tax-brackets.test.ts
+++ b/test/lib/tax-brackets.test.ts
@@ -1,6 +1,6 @@
-import estimateTaxAmount from '../../src/lib/tax-brackets';
-import { FilingStatus } from '../../src/data/tax_brackets';
 import { test } from 'tap';
+import { FilingStatus } from '../../src/data/tax_brackets';
+import estimateTaxAmount from '../../src/lib/tax-brackets';
 
 /**
  * Uses 2023 IRS tax brackets and std deductions

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -1,10 +1,10 @@
-import { test, beforeEach } from 'tap';
-import { build } from '../helper';
 import Ajv from 'ajv';
 import fs from 'fs';
 import qs from 'qs';
-import { WEBSITE_INCENTIVE_SCHEMA } from '../../src/schemas/v0/incentive';
+import { beforeEach, test } from 'tap';
 import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v0/calculator-response';
+import { WEBSITE_INCENTIVE_SCHEMA } from '../../src/schemas/v0/incentive';
+import { build } from '../helper';
 
 beforeEach(() => {
   process.setMaxListeners(100);

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -1,12 +1,12 @@
-import { test, beforeEach } from 'tap';
-import { build } from '../helper';
-import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive';
-import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint';
-import { API_UTILITIES_RESPONSE_SCHEMA } from '../../src/schemas/v1/utilities-endpoint';
-import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
 import Ajv from 'ajv';
 import fs from 'fs';
 import qs from 'qs';
+import { beforeEach, test } from 'tap';
+import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
+import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint';
+import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive';
+import { API_UTILITIES_RESPONSE_SCHEMA } from '../../src/schemas/v1/utilities-endpoint';
+import { build } from '../helper';
 
 beforeEach(() => {
   process.setMaxListeners(100);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,6 +3005,11 @@ prettier-plugin-multiline-arrays@^2.0.0:
     "@augment-vir/common" "^15.3.0"
     proxy-vir "^0.0.1"
 
+prettier-plugin-organize-imports@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.3.tgz#6b0141ac71f7ee9a673ce83e95456319e3a7cf0d"
+  integrity sha512-KFvk8C/zGyvUaE3RvxN2MhCLwzV6OBbFSkwZ2OamCrs9ZY4i5L77jQ/w4UmUr+lqX8qbaqVq6bZZkApn+IgJSg==
+
 prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"


### PR DESCRIPTION
## Description

I'm annoyed at how inconsistently imports are ordered, and this fixes
it easily. This seems to be the most popular Prettier plugin for this
purpose. It's opinionated (seems no config is possible other than
skipping entire files?) which I like.

## Test Plan

Unit tests pass.
