### PR TITLE
Use enums everywhere possible

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -16,8 +16,8 @@ import { calculateStateIncentivesAndSavings } from './state-incentives-calculati
 import estimateTaxAmount from './tax-brackets';
 
 const MAX_POS_SAVINGS = 14000;
-const OWNER_STATUSES = new Set(['homeowner', 'renter']);
-const TAX_FILINGS = new Set(['single', 'joint', 'hoh']);
+const OWNER_STATUSES = new Set(Object.values(OwnerStatus));
+const TAX_FILINGS = new Set(Object.values(FilingStatus));
 
 IRA_INCENTIVES.forEach(incentive => Object.freeze(incentive));
 

--- a/src/schemas/v0/calculator-request.ts
+++ b/src/schemas/v0/calculator-request.ts
@@ -1,3 +1,6 @@
+import { FilingStatus } from '../../data/tax_brackets';
+import { OwnerStatus } from '../../data/types/owner-status';
+
 export const WEBSITE_CALCULATOR_REQUEST_SCHEMA = {
   $id: 'WebsiteCalculatorRequest',
   title: 'WebsiteCalculatorRequest',
@@ -16,10 +19,7 @@ export const WEBSITE_CALCULATOR_REQUEST_SCHEMA = {
     owner_status: {
       type: 'string',
       description: 'Homeowners and renters qualify for different incentives.',
-      enum: [
-        'homeowner',
-        'renter',
-      ],
+      enum: Object.values(OwnerStatus),
     },
     household_income: {
       type: 'integer',
@@ -35,11 +35,7 @@ export const WEBSITE_CALCULATOR_REQUEST_SCHEMA = {
       type: 'string',
       description:
         'Select "Head of Household" if you have a child or relative living with you, and you pay more than half the costs of your home. Select "Joint" if you file your taxes as a married couple.',
-      enum: [
-        'single',
-        'joint',
-        'hoh',
-      ],
+      enum: Object.values(FilingStatus),
     },
     household_size: {
       type: 'integer',

--- a/src/schemas/v0/incentive.ts
+++ b/src/schemas/v0/incentive.ts
@@ -1,4 +1,8 @@
 import { FromSchema } from 'json-schema-to-ts';
+import { AmiQualification } from '../../data/ira_incentives';
+import { FilingStatus } from '../../data/tax_brackets';
+import { ItemType, Type } from '../../data/types/incentive-types';
+import { OwnerStatus } from '../../data/types/owner-status';
 
 export const WEBSITE_INCENTIVE_SCHEMA = {
   $id: 'WebsiteIncentive',
@@ -22,10 +26,7 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
   properties: {
     type: {
       type: 'string',
-      enum: [
-        'pos_rebate',
-        'tax_credit',
-      ],
+      enum: Object.values(Type),
     },
     program: {
       type: 'string',
@@ -79,22 +80,13 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     },
     item_type: {
       type: 'string',
-      enum: [
-        'performance_rebate',
-        'pos_rebate',
-        'tax_credit',
-        'solar_tax_credit',
-        'ev_charger_credit',
-      ],
+      enum: Object.values(ItemType),
     },
     owner_status: {
       type: 'array',
       items: {
         type: 'string',
-        enum: [
-          'homeowner',
-          'renter',
-        ],
+        enum: Object.values(OwnerStatus),
       },
     },
     start_date: {
@@ -124,12 +116,7 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     ami_qualification: {
       type: 'string',
       nullable: true,
-      enum: [
-        'less_than_80_ami',
-        'less_than_150_ami',
-        'more_than_80_ami',
-        null,
-      ],
+      enum: [...Object.values(AmiQualification), null],
     },
     agi_max_limit: {
       type: 'number',
@@ -141,12 +128,7 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     filing_status: {
       type: 'string',
       nullable: true,
-      enum: [
-        'single',
-        'joint',
-        'hoh',
-        null,
-      ],
+      enum: [...Object.values(FilingStatus), null],
     },
     eligible: {
       type: 'boolean',

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -1,6 +1,8 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { AuthorityType } from '../../data/authorities';
+import { FilingStatus } from '../../data/tax_brackets';
 import { ALL_ITEMS } from '../../data/types/items';
+import { OwnerStatus } from '../../data/types/owner-status';
 import { API_INCENTIVE_SCHEMA } from './incentive';
 import { API_LOCATION_SCHEMA } from './location';
 
@@ -41,10 +43,7 @@ export const API_CALCULATOR_REQUEST_SCHEMA = {
     owner_status: {
       type: 'string',
       description: 'Homeowners and renters qualify for different incentives.',
-      enum: [
-        'homeowner',
-        'renter',
-      ],
+      enum: Object.values(OwnerStatus),
     },
     household_income: {
       type: 'integer',
@@ -60,11 +59,7 @@ export const API_CALCULATOR_REQUEST_SCHEMA = {
       type: 'string',
       description:
         'Select "Head of Household" if you have a child or relative living with you, and you pay more than half the costs of your home. Select "Joint" if you file your taxes as a married couple.',
-      enum: [
-        'single',
-        'joint',
-        'hoh',
-      ],
+      enum: Object.values(FilingStatus),
     },
     household_size: {
       type: 'integer',

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -1,4 +1,10 @@
 import { FromSchema } from 'json-schema-to-ts';
+import { AuthorityType } from '../../data/authorities';
+import { AmiQualification } from '../../data/ira_incentives';
+import { FilingStatus } from '../../data/tax_brackets';
+import { AmountType, AmountUnit } from '../../data/types/amount';
+import { ItemType, Type } from '../../data/types/incentive-types';
+import { OwnerStatus } from '../../data/types/owner-status';
 
 export const API_INCENTIVE_SCHEMA = {
   $id: 'APIIncentive',
@@ -18,14 +24,11 @@ export const API_INCENTIVE_SCHEMA = {
   properties: {
     type: {
       type: 'string',
-      enum: [
-        'pos_rebate',
-        'tax_credit',
-      ],
+      enum: Object.values(Type),
     },
     authority_type: {
       type: 'string',
-      enum: ['federal', 'state', 'utility'],
+      enum: Object.values(AuthorityType),
     },
     authority_name: {
       type: 'string',
@@ -54,21 +57,14 @@ export const API_INCENTIVE_SCHEMA = {
       properties: {
         type: {
           type: 'string',
-          enum: [
-            'dollar_amount',
-            'percent',
-            'dollars_per_unit',
-          ],
+          enum: Object.values(AmountType),
         },
         number: { type: 'number' },
         maximum: { type: 'number' },
         representative: { type: 'number' },
         unit: {
           type: 'string',
-          enum: [
-            'ton',
-            'watt',
-          ],
+          enum: Object.values(AmountUnit),
         },
       },
       additionalProperties: false,
@@ -79,22 +75,13 @@ export const API_INCENTIVE_SCHEMA = {
     },
     item_type: {
       type: 'string',
-      enum: [
-        'performance_rebate',
-        'pos_rebate',
-        'tax_credit',
-        'solar_tax_credit',
-        'ev_charger_credit',
-      ],
+      enum: Object.values(ItemType),
     },
     owner_status: {
       type: 'array',
       items: {
         type: 'string',
-        enum: [
-          'homeowner',
-          'renter',
-        ],
+        enum: Object.values(OwnerStatus),
       },
     },
     start_date: {
@@ -118,12 +105,7 @@ export const API_INCENTIVE_SCHEMA = {
     ami_qualification: {
       type: 'string',
       nullable: true,
-      enum: [
-        'less_than_80_ami',
-        'less_than_150_ami',
-        'more_than_80_ami',
-        null,
-      ],
+      enum: [...Object.values(AmiQualification), null],
     },
     agi_max_limit: {
       type: 'number',
@@ -136,12 +118,7 @@ export const API_INCENTIVE_SCHEMA = {
     filing_status: {
       type: 'string',
       nullable: true,
-      enum: [
-        'single',
-        'joint',
-        'hoh',
-        null,
-      ],
+      enum: [...Object.values(FilingStatus), null],
     },
     eligible: {
       type: 'boolean',

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import { afterEach, beforeEach, test } from 'tap';
+import { FilingStatus } from '../../src/data/tax_brackets';
+import { OwnerStatus } from '../../src/data/types/owner-status';
 import calculateIncentives from '../../src/lib/incentives-calculation';
 
 const AMIS_FOR_11211 = JSON.parse(
@@ -28,9 +30,9 @@ afterEach(async t => {
 
 test('correctly evaluates scenerio "Single w/ $120k Household income"', async t => {
   const data = calculateIncentives(AMIS_FOR_11211, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
-    tax_filing: 'single',
+    tax_filing: FilingStatus.Single,
     household_size: 1,
   });
   t.ok(data);
@@ -38,9 +40,9 @@ test('correctly evaluates scenerio "Single w/ $120k Household income"', async t 
 
 test('correctly evaluates scenerio "Joint w/ 5 persons and $60k Household income"', async t => {
   const data = calculateIncentives(AMIS_FOR_11211, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 60000,
-    tax_filing: 'joint',
+    tax_filing: FilingStatus.Joint,
     household_size: 5,
   });
   t.ok(data);
@@ -48,9 +50,9 @@ test('correctly evaluates scenerio "Joint w/ 5 persons and $60k Household income
 
 test('correctly evaluates scenerio "Joint w/ $300k Household income"', async t => {
   const data = calculateIncentives(AMIS_FOR_11211, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 300000,
-    tax_filing: 'joint',
+    tax_filing: FilingStatus.Joint,
     household_size: 4,
   });
   t.ok(data);
@@ -58,9 +60,9 @@ test('correctly evaluates scenerio "Joint w/ $300k Household income"', async t =
 
 test('correctly evaluates scenerio "Single w/ $120k Household income in the Bronx"', async t => {
   const data = calculateIncentives(AMIS_FOR_11211, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
-    tax_filing: 'single',
+    tax_filing: FilingStatus.Single,
     household_size: 1,
   });
 
@@ -156,9 +158,9 @@ test('correctly evaluates scenerio "Single w/ $120k Household income in the Bron
 
 test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k Household income in San Francisco"', async t => {
   const data = calculateIncentives(AMIS_FOR_94117, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 250000,
-    tax_filing: 'joint',
+    tax_filing: FilingStatus.Joint,
     household_size: 4,
   });
 
@@ -254,9 +256,9 @@ test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k H
 
 test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in Missisippi"', async t => {
   const data = calculateIncentives(AMIS_FOR_39503, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 500000,
-    tax_filing: 'hoh',
+    tax_filing: FilingStatus.HoH,
     household_size: 8,
   });
 
@@ -356,9 +358,9 @@ test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in 
 
 test('correctly sorts incentives"', async t => {
   const data = calculateIncentives(AMIS_FOR_11211, {
-    owner_status: 'homeowner',
+    owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
-    tax_filing: 'single',
+    tax_filing: FilingStatus.Single,
     household_size: 1,
   });
   for (const incentives of [


### PR DESCRIPTION
## Description

In starting to add the "married filing separately" status, I realized
that these lists of strings for the various enums were duplicated all
over the place. This turns all of them into enums.

There's a little wrinkle here that comes from two separate
schema-consuming libraries. It has to do with nullable enums:

```typescript
{
  type: 'string',
  nullable: true,
  enum: [...Object.values(FilingStatus), null]
}
```

It might seem redundant to have `nullable: true` and `null` in the
array, but:

- `ajv`, which does schema validation in unit tests, considers the
  `enum` array to be authoritative. If it doesn't include `null`
  explicitly, then `null` isn't a valid value there, regardless of the
  `nullable` flag.

- `json-schema-to-ts`, which generates TS types from schema, will
  _not_ allow `null` as a possible value without the `nullable:
  true`. It generates a field of type `FilingStatus | null` for the
  above.

So we gotta have both.

## Test Plan

- `yarn test`

- `yarn dev`, send some test requests.
