### PR TITLE
Make item into a struct

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -9,7 +9,7 @@ import {
   APICalculatorRequest,
   APICalculatorResponse,
 } from '../schemas/v1/calculator-endpoint';
-import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
+import { APIIncentiveNonLocalized } from '../schemas/v1/incentive';
 import { InvalidInputError, UnexpectedInputError } from './error';
 import { AMI, CompleteIncomeInfo, MFI } from './income-info';
 import { calculateStateIncentivesAndSavings } from './state-incentives-calculation';
@@ -34,8 +34,8 @@ type CalculatedIncentives = Omit<
   APICalculatorResponse,
   'pos_rebate_incentives' | 'tax_credit_incentives'
 > & {
-  pos_rebate_incentives: APIIncentiveMinusItemUrl[];
-  tax_credit_incentives: APIIncentiveMinusItemUrl[];
+  pos_rebate_incentives: APIIncentiveNonLocalized[];
+  tax_credit_incentives: APIIncentiveNonLocalized[];
 };
 
 export type CalculateParams = Omit<APICalculatorRequest, 'location'>;
@@ -53,13 +53,13 @@ function calculateFederalIncentivesAndSavings(
     items,
   }: CalculateParams,
 ): {
-  federalIncentives: APIIncentiveMinusItemUrl[];
+  federalIncentives: APIIncentiveNonLocalized[];
   pos_savings: number;
   performance_rebate_savings: number;
   tax_savings: number;
 } {
-  const eligibleIncentives: APIIncentiveMinusItemUrl[] = [];
-  const ineligibleIncentives: APIIncentiveMinusItemUrl[] = [];
+  const eligibleIncentives: APIIncentiveNonLocalized[] = [];
+  const ineligibleIncentives: APIIncentiveNonLocalized[] = [];
 
   // Loop through each of the incentives, running several tests to see if visitor is eligible
   for (const item of IRA_INCENTIVES) {
@@ -298,7 +298,7 @@ export default function calculateIncentives(
   const isOver150Ami =
     household_income >= Number(ami[`l150_${household_size}`]);
 
-  const incentives: APIIncentiveMinusItemUrl[] = [];
+  const incentives: APIIncentiveNonLocalized[] = [];
   let tax_savings = 0;
   let pos_savings = 0;
   let performance_rebate_savings = 0;

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -4,7 +4,7 @@ import { RI_INCENTIVES } from '../data/state_incentives';
 import { AmountType } from '../data/types/amount';
 import { Type } from '../data/types/incentive-types';
 import { OwnerStatus } from '../data/types/owner-status';
-import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
+import { APIIncentiveNonLocalized } from '../schemas/v1/incentive';
 import { UnexpectedInputError } from './error';
 import { CalculateParams } from './incentives-calculation';
 
@@ -12,7 +12,7 @@ export function calculateStateIncentivesAndSavings(
   stateId: string,
   request: CalculateParams,
 ): {
-  stateIncentives: APIIncentiveMinusItemUrl[];
+  stateIncentives: APIIncentiveNonLocalized[];
   tax_savings: number;
   pos_savings: number;
   performance_rebate_savings: number;

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -19,12 +19,12 @@ import {
   WEBSITE_INCENTIVE_SCHEMA,
   WebsiteIncentive,
 } from '../schemas/v0/incentive';
-import { APIIncentiveMinusItemUrl } from '../schemas/v1/incentive';
+import { APIIncentiveNonLocalized } from '../schemas/v1/incentive';
 
 IRA_INCENTIVES.forEach(incentive => Object.freeze(incentive));
 
 function translateIncentives(
-  incentives: APIIncentiveMinusItemUrl[],
+  incentives: APIIncentiveNonLocalized[],
 ): WebsiteIncentive[] {
   return incentives.map(incentive => ({
     ...incentive,

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -19,7 +19,7 @@ import {
 } from '../schemas/v1/calculator-endpoint';
 import {
   APIIncentive,
-  APIIncentiveMinusItemUrl,
+  APIIncentiveNonLocalized,
   API_INCENTIVE_SCHEMA,
 } from '../schemas/v1/incentive';
 import { API_INCENTIVES_SCHEMA } from '../schemas/v1/incentives-endpoint';
@@ -27,16 +27,19 @@ import { APILocation } from '../schemas/v1/location';
 import { API_UTILITIES_SCHEMA } from '../schemas/v1/utilities-endpoint';
 
 function transformIncentives(
-  incentives: APIIncentiveMinusItemUrl[],
+  incentives: APIIncentiveNonLocalized[],
   language: keyof typeof LOCALES,
 ): APIIncentive[] {
   return incentives.map(incentive => ({
     ...incentive,
 
     // Localize localizable fields
-    item: t('items', incentive.item, language),
+    item: {
+      type: incentive.item,
+      name: t('items', incentive.item, language),
+      url: t('urls', incentive.item, language),
+    },
     program: t('programs', incentive.program, language),
-    item_url: t('urls', incentive.item, language),
   }));
 }
 

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -4,6 +4,7 @@ import { AmiQualification } from '../../data/ira_incentives';
 import { FilingStatus } from '../../data/tax_brackets';
 import { AmountType, AmountUnit } from '../../data/types/amount';
 import { ItemType, Type } from '../../data/types/incentive-types';
+import { ALL_ITEMS, Item } from '../../data/types/items';
 import { OwnerStatus } from '../../data/types/owner-status';
 
 export const API_INCENTIVE_SCHEMA = {
@@ -14,7 +15,6 @@ export const API_INCENTIVE_SCHEMA = {
     'authority_type',
     'program',
     'item',
-    'item_url',
     'item_type',
     'amount',
     'owner_status',
@@ -41,16 +41,27 @@ export const API_INCENTIVE_SCHEMA = {
       ],
     },
     item: {
-      type: 'string',
-      examples: [
-        'Battery Storage Installation',
-      ],
-    },
-    item_url: {
-      type: 'string',
-      examples: [
-        'https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation',
-      ],
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: ALL_ITEMS,
+        },
+        name: {
+          type: 'string',
+          examples: [
+            'Battery Storage Installation',
+          ],
+        },
+        url: {
+          type: 'string',
+          examples: [
+            'https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation',
+          ],
+        },
+      },
+      required: ['type', 'name', 'url'],
+      additionalProperties: false,
     },
     amount: {
       type: 'object',
@@ -160,4 +171,6 @@ export type APIIncentive = FromSchema<typeof API_INCENTIVE_SCHEMA>;
  * This is used internally, as an intermediate form between incentive
  * calculation and external API.
  */
-export type APIIncentiveMinusItemUrl = Omit<APIIncentive, 'item_url'>;
+export type APIIncentiveNonLocalized = Omit<APIIncentive, 'item'> & {
+  item: Item;
+};

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -11,8 +11,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "Clean Heat RI",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
       "amount": {
         "type": "dollars_per_unit",
         "number": 1250,
@@ -35,8 +38,11 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 8000
@@ -58,8 +64,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "DRIVE",
-      "item": "New Electric Vehicle",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 2500
@@ -83,8 +92,11 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Clean Vehicle Credit (30D)",
-      "item": "New Electric Vehicle",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 7500
@@ -106,8 +118,11 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 2000

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -11,8 +11,11 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Income Eligible Energy Savings Program",
-      "item": "Weatherization",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+      },
       "amount": {
         "type": "percent",
         "number": 1
@@ -33,8 +36,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "Clean Heat RI",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
       "amount": {
         "type": "dollars_per_unit",
         "number": 1250,
@@ -57,8 +63,11 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Residential electric heating and cooling rebates",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
       "amount": {
         "type": "dollars_per_unit",
         "number": 350,
@@ -81,8 +90,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Commerce Corporation",
       "program": "Small Scale Solar Program",
-      "item": "Rooftop Solar Installation",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation",
+      "item": {
+        "type": "rooftop_solar_installation",
+        "name": "Rooftop Solar Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+      },
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.65,
@@ -106,8 +118,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "DRIVE",
-      "item": "New Electric Vehicle",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 2500
@@ -129,8 +144,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "DRIVE",
-      "item": "Used Electric Vehicle",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
+      "item": {
+        "type": "used_electric_vehicle",
+        "name": "Used Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -152,8 +170,11 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "Clean Heat RI",
-      "item": "Heat Pump Water Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 750
@@ -174,8 +195,11 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Residential heat pump water heater rebates",
-      "item": "Heat Pump Water Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 600,
@@ -197,8 +221,11 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Rhode Island ENERGY STAR®  Certified Electric Clothes Dryer Rebate",
-      "item": "Heat Pump Clothes Dryer",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer",
+      "item": {
+        "type": "heat_pump_clothes_dryer",
+        "name": "Heat Pump Clothes Dryer",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+      },
       "amount": {
         "type": "dollar_amount",
         "number": 50

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -11,9 +11,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
-      "amount": { "type": "dollar_amount", "number": 8000 },
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 8000
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner",
@@ -31,9 +37,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Hope for Homes (HOMES)",
-      "item": "Efficiency Rebates",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/whole-home-energy-reduction-rebates",
-      "amount": { "type": "dollar_amount", "number": 8000 },
+      "item": {
+        "type": "efficiency_rebates",
+        "name": "Efficiency Rebates",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/whole-home-energy-reduction-rebates"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 8000
+      },
       "item_type": "performance_rebate",
       "owner_status": [
         "homeowner"
@@ -50,9 +62,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Electric Panel",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel",
-      "amount": { "type": "dollar_amount", "number": 4000 },
+      "item": {
+        "type": "electric_panel",
+        "name": "Electric Panel",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 4000
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner"
@@ -69,9 +87,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Electric Wiring",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-wiring",
-      "amount": { "type": "dollar_amount", "number": 2500 },
+      "item": {
+        "type": "electric_wiring",
+        "name": "Electric Wiring",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-wiring"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2500
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner"
@@ -88,9 +112,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Heat Pump Water Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
-      "amount": { "type": "dollar_amount", "number": 1750 },
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1750
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner"
@@ -107,9 +137,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Weatherization",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
-      "amount": { "type": "dollar_amount", "number": 1600 },
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1600
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner"
@@ -126,9 +162,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Electric/Induction Stove",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove",
-      "amount": { "type": "dollar_amount", "number": 840 },
+      "item": {
+        "type": "electric_stove",
+        "name": "Electric/Induction Stove",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 840
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner",
@@ -146,9 +188,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "HEEHR",
-      "item": "Heat Pump Clothes Dryer",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer",
-      "amount": { "type": "dollar_amount", "number": 840 },
+      "item": {
+        "type": "heat_pump_clothes_dryer",
+        "name": "Heat Pump Clothes Dryer",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 840
+      },
       "item_type": "pos_rebate",
       "owner_status": [
         "homeowner",
@@ -168,9 +216,16 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Residential Clean Energy Credit (25D)",
-      "item": "Battery Storage Installation",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation",
-      "amount": { "type": "percent", "number": 0.3, "representative": 4800 },
+      "item": {
+        "type": "battery_storage_installation",
+        "name": "Battery Storage Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 0.3,
+        "representative": 4800
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner"
@@ -187,9 +242,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Residential Clean Energy Credit (25D)",
-      "item": "Geothermal Heating Installation",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation",
-      "amount": { "type": "percent", "number": 0.3 },
+      "item": {
+        "type": "geothermal_heating_installation",
+        "name": "Geothermal Heating Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 0.3
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner"
@@ -206,9 +267,16 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Residential Clean Energy Credit (25D)",
-      "item": "Rooftop Solar Installation",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation",
-      "amount": { "type": "percent", "number": 0.3, "representative": 5130 },
+      "item": {
+        "type": "rooftop_solar_installation",
+        "name": "Rooftop Solar Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 0.3,
+        "representative": 5130
+      },
       "item_type": "solar_tax_credit",
       "owner_status": [
         "homeowner"
@@ -225,9 +293,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Clean Vehicle Credit (30D)",
-      "item": "New Electric Vehicle",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
-      "amount": { "type": "dollar_amount", "number": 7500 },
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 7500
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner",
@@ -245,9 +319,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Credit for Previously-Owned Clean Vehicles (25E)",
-      "item": "Used Electric Vehicle",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles",
-      "amount": { "type": "dollar_amount", "number": 4000 },
+      "item": {
+        "type": "used_electric_vehicle",
+        "name": "Used Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 4000
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner",
@@ -265,9 +345,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
-      "item": "Heat Pump Air Conditioner/Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater",
-      "amount": { "type": "dollar_amount", "number": 2000 },
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner"
@@ -284,9 +370,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
-      "item": "Heat Pump Water Heater",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater",
-      "amount": { "type": "dollar_amount", "number": 2000 },
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner"
@@ -303,9 +395,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
-      "item": "Weatherization",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization",
-      "amount": { "type": "dollar_amount", "number": 1200 },
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1200
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner"
@@ -322,9 +420,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Alternative Fuel Vehicle Refueling Property Credit (30C)",
-      "item": "Electric Vehicle Charger",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger",
-      "amount": { "type": "dollar_amount", "number": 1000 },
+      "item": {
+        "type": "electric_vehicle_charger",
+        "name": "Electric Vehicle Charger",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1000
+      },
       "item_type": "ev_charger_credit",
       "owner_status": [
         "homeowner",
@@ -342,9 +446,15 @@
       "authority_type": "federal",
       "authority_name": null,
       "program": "Energy Efficient Home Improvement Credit (25C)",
-      "item": "Electric Panel",
-      "item_url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel",
-      "amount": { "type": "dollar_amount", "number": 600 },
+      "item": {
+        "type": "electric_panel",
+        "name": "Electric Panel",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 600
+      },
       "item_type": "tax_credit",
       "owner_status": [
         "homeowner"


### PR DESCRIPTION
## Description

The RI frontend design requires knowing which item an incentive is
for, so we need to start sending a machine-friendly stable identifier
for items.

I'm turning it into a struct instead of just adding a field because it
seems conceptually cleaner and more scalable. It also allows the
possibility of a `/v1/items` endpoint in future.

Side note: the `APIIncentiveNonLocalized` thing is starting to be a
little awkward. It's an intermediate stage of incentive
representation, halfway between the static-data format and the API
format. It still works OK but I think eventually it might work better
to have incentive calculation return `v1`-format data.

## Test Plan

`yarn test` with updated fixtures.
