### PR TITLE
Add program URLs

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -51,5 +51,18 @@
     "ri_residentialHeatPumpWaterHeater": "Rhode Island Energy residential heat pump water heater rebates",
     "ri_electricHeatingAndCoolingRebates": "Rhode Island Energy residential electric heating and cooling rebates",
     "ri_incomeEligibleEnergySavings": "Rhode Island Energy Income-Eligible Energy Savings Program"
+  },
+  "program_urls": {
+    "ri_hvacAndWaterHeaterIncentives": "https://pud-ri.org/conservation/download-rebate-forms",
+    "ri_residentialEnergyStarOfferings": "https://pud-ri.org/conservation/download-rebate-forms",
+    "ri_residentialEnergyAuditWeatherization": "https://pud-ri.org/conservation/download-rebate-forms",
+    "ri_blockIslandEnergyEfficiency": "https://blockislandpowercompany.com/efficiency-program/",
+    "ri_drive": "https://drive.ri.gov/ev-programs/drive-ev",
+    "ri_smallScaleSolar": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf",
+    "ri_highEfficiencyHeatPumpProgram": "https://cleanheatri.com/",
+    "ri_energyStarClothesDryer": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+    "ri_residentialHeatPumpWaterHeater": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+    "ri_electricHeatingAndCoolingRebates": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+    "ri_incomeEligibleEnergySavings": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -51,5 +51,18 @@
     "ri_residentialHeatPumpWaterHeater": "Rhode Island Energy residential heat pump water heater rebates",
     "ri_electricHeatingAndCoolingRebates": "Rhode Island Energy residential electric heating and cooling rebates",
     "ri_incomeEligibleEnergySavings": "Rhode Island Energy Income-Eligible Energy Savings Program"
+  },
+  "program_urls": {
+    "ri_hvacAndWaterHeaterIncentives": "https://pud-ri.org/conservation/download-rebate-forms",
+    "ri_residentialEnergyStarOfferings": "https://pud-ri.org/conservation/download-rebate-forms",
+    "ri_residentialEnergyAuditWeatherization": "https://pud-ri.org/conservation/download-rebate-forms",
+    "ri_blockIslandEnergyEfficiency": "https://blockislandpowercompany.com/efficiency-program/",
+    "ri_drive": "https://drive.ri.gov/ev-programs/drive-ev",
+    "ri_smallScaleSolar": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf",
+    "ri_highEfficiencyHeatPumpProgram": "https://cleanheatri.com/",
+    "ri_energyStarClothesDryer": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+    "ri_residentialHeatPumpWaterHeater": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+    "ri_electricHeatingAndCoolingRebates": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+    "ri_incomeEligibleEnergySavings": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services"
   }
 }

--- a/src/data/locale.ts
+++ b/src/data/locale.ts
@@ -1,43 +1,41 @@
-import { JSONSchemaType } from 'ajv';
 import fs from 'fs';
+import { FromSchema } from 'json-schema-to-ts';
 import { ALL_ITEMS, ITEMS_SCHEMA } from './types/items';
 import { ALL_PROGRAMS, PROGRAMS_SCHEMA } from './types/programs';
 
-export type Items = {
-  [k in keyof typeof ITEMS_SCHEMA]: string;
-};
-
-export type Programs = {
-  [k in keyof typeof PROGRAMS_SCHEMA]: string;
-};
-
-export interface Locale {
-  items: Items;
-  programs: Programs;
-  urls: Items;
-}
-
-export const SCHEMA: JSONSchemaType<Locale> = {
+export const SCHEMA = {
   type: 'object',
   properties: {
     items: {
       type: 'object',
       properties: ITEMS_SCHEMA,
       required: ALL_ITEMS,
+      additionalProperties: false,
     },
     programs: {
       type: 'object',
       properties: PROGRAMS_SCHEMA,
       required: ALL_PROGRAMS,
+      additionalProperties: false,
     },
     urls: {
       type: 'object',
       properties: ITEMS_SCHEMA,
       required: ALL_ITEMS,
+      additionalProperties: false,
+    },
+    program_urls: {
+      type: 'object',
+      properties: PROGRAMS_SCHEMA,
+      required: [],
+      additionalProperties: false,
     },
   },
-  required: ['items', 'programs', 'urls'],
-};
+  required: ['items', 'programs', 'urls', 'program_urls'],
+  additionalProperties: false,
+} as const;
+
+export type Locale = FromSchema<typeof SCHEMA>;
 
 export const LOCALES = {
   en: JSON.parse(fs.readFileSync('./locales/en.json', 'utf-8')) as Locale,

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -40,6 +40,7 @@ function transformIncentives(
       url: t('urls', incentive.item, language),
     },
     program: t('programs', incentive.program, language),
+    program_url: t('program_urls', incentive.program, language),
   }));
 }
 

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -40,6 +40,9 @@ export const API_INCENTIVE_SCHEMA = {
         'Residential Clean Energy Credit (25D)',
       ],
     },
+    program_url: {
+      type: 'string',
+    },
     item: {
       type: 'object',
       properties: {

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -99,3 +99,23 @@ test('state incentives JSON files match schemas', async tap => {
     });
   });
 });
+
+const isURLValid = (url: string): boolean => {
+  try {
+    new URL(url);
+    return true;
+  } catch (_) {
+    return false;
+  }
+};
+
+test('locale URLs are valid', async tap => {
+  for (const [lang, locale] of Object.entries(LOCALES)) {
+    for (const [key, url] of Object.entries(locale.urls)) {
+      tap.ok(isURLValid(url), `${lang}.urls.${key} invalid`);
+    }
+    for (const [key, url] of Object.entries(locale.program_urls)) {
+      tap.ok(isURLValid(url), `${lang}.program_urls.${key} invalid`);
+    }
+  }
+});

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -42,6 +42,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "RI Office of Energy Resources Clean Heat RI",
+      "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -70,6 +71,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "RI Office of Energy Resources DRIVE EV",
+      "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "item": {
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle",

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -15,6 +15,7 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Rhode Island Energy Income-Eligible Energy Savings Program",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services",
       "item": {
         "type": "weatherization",
         "name": "Weatherization",
@@ -41,6 +42,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "RI Office of Energy Resources Clean Heat RI",
+      "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -69,6 +71,7 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Rhode Island Energy residential electric heating and cooling rebates",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -97,6 +100,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Commerce Corporation",
       "program": "Rhode Island Commerce Corp. Small-Scale Solar Program",
+      "program_url": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf",
       "item": {
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation",
@@ -126,6 +130,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "RI Office of Energy Resources DRIVE EV",
+      "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "item": {
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle",
@@ -153,6 +158,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "RI Office of Energy Resources DRIVE EV",
+      "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "item": {
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle",
@@ -180,6 +186,7 @@
       "authority_type": "state",
       "authority_name": "Rhode Island Office of Energy Resources",
       "program": "RI Office of Energy Resources Clean Heat RI",
+      "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -206,6 +213,7 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Rhode Island Energy residential heat pump water heater rebates",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -233,6 +241,7 @@
       "authority_type": "utility",
       "authority_name": "Rhode Island Energy",
       "program": "Rhode Island Energy ENERGY STAR® Certified Electric Clothes Dryer Rebate",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
       "item": {
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer",


### PR DESCRIPTION
## Description

This is to support sending people directly to program pages from
incentive cards in the calculator.

I debated between associating URLs with _programs_ or with _specific
incentives_. I think the per-program approach makes sense, and it
doesn't preclude eventually adding per-incentive URLs.

The URLs are localizable, but are optional for each program.

## Test Plan

`yarn test`, which includes an added test to make sure URLs are valid.
