### PR TITLE
Make authority_types work as a filter

### DIFF
--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -255,22 +255,22 @@ const BAD_QUERIES = [
     authority_types: ['utility'],
   },
   {
-    location: { zip: '80212' },
+    location: { zip: '02861' },
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
-    authority_types: ['utility'],
+    // If you pass a utility, it must exist in the state "location" is in
     utility: 'nonexistent-utility',
   },
   {
-    // No state-level coverage in this state yet (CO)
     location: { zip: '80212' },
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
-    authority_types: ['state'],
+    // We don't have coverage in 80212 (Colorado)
+    utility: 'ri-rhode-island-energy',
   },
 ];
 


### PR DESCRIPTION
## Description

This is preparation for implementing a reasonable experience for the
RI calculator when you don't enter a RI zip code.

In the first-party context, we'll want to just fall back to IRA
incentives only, with no state map outline and utility selector. That
means the frontend wants to always receive incentives from all levels,
with graceful behavior if there's no state or utility coverage.

New behavior:

- If you don't pass `authority_types` at all, you always get federal
  incentives, plus state incentives if we have them.

  - If you pass a value in `utility`, you also get incentives for that
    utility **if** it's a valid utility ID in the state of
    `location`. If we don't have coverage in that state, or if we do
    but we don't have the utility ID, that's an error. (If we don't have
    coverage in a state, you shouldn't be passing a utility ID, because
    you should get utility IDs from `/v1/utilities`, which will return
    an error for non-covered states.)

- If you pass `authority_types`, we filter incentives to only those
  authority types.

  - If you have `utility` in `authority_types`, and you don't pass a
    value for `utility`, that's an error. The idea is that you're
    explicitly asking for utility incentives; you have to tell us
    which one.

  - However, if you have `state` in `authority_types`, it **is not**
    an error if we don't have coverage in that state. I could be
    convinced to go the other way on this.

## Test Plan

`yarn test` with updated tests.
