### PR TITLE
Get rid of APIIncentiveNonLocalized

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -2,6 +2,7 @@
   {
     "type": "tax_credit",
     "program": "residentialCleanEnergyCredit",
+    "authority_type": "federal",
     "item": "battery_storage_installation",
     "item_type": "tax_credit",
     "amount": {
@@ -22,6 +23,7 @@
   {
     "type": "tax_credit",
     "program": "residentialCleanEnergyCredit",
+    "authority_type": "federal",
     "item": "geothermal_heating_installation",
     "item_type": "tax_credit",
     "amount": {
@@ -42,6 +44,7 @@
   {
     "type": "tax_credit",
     "program": "energyEfficientHomeImprovementCredit",
+    "authority_type": "federal",
     "item": "electric_panel",
     "item_type": "tax_credit",
     "amount": {
@@ -61,6 +64,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "electric_panel",
     "item_type": "pos_rebate",
     "amount": {
@@ -80,6 +84,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "electric_panel",
     "item_type": "pos_rebate",
     "amount": {
@@ -99,6 +104,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "electric_stove",
     "item_type": "pos_rebate",
     "amount": {
@@ -119,6 +125,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "electric_stove",
     "item_type": "pos_rebate",
     "amount": {
@@ -139,6 +146,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "electric_wiring",
     "item_type": "pos_rebate",
     "amount": {
@@ -158,6 +166,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "electric_wiring",
     "item_type": "pos_rebate",
     "amount": {
@@ -177,6 +186,7 @@
   {
     "type": "tax_credit",
     "program": "alternativeFuelVehicleRefuelingPropertyCredit",
+    "authority_type": "federal",
     "item": "electric_vehicle_charger",
     "item_type": "ev_charger_credit",
     "amount": {
@@ -197,6 +207,7 @@
   {
     "type": "tax_credit",
     "program": "cleanVehicleCredit",
+    "authority_type": "federal",
     "item": "new_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -217,6 +228,7 @@
   {
     "type": "tax_credit",
     "program": "cleanVehicleCredit",
+    "authority_type": "federal",
     "item": "new_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -237,6 +249,7 @@
   {
     "type": "tax_credit",
     "program": "cleanVehicleCredit",
+    "authority_type": "federal",
     "item": "new_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -257,6 +270,7 @@
   {
     "type": "tax_credit",
     "program": "cleanVehicleCredit",
+    "authority_type": "federal",
     "item": "new_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -277,6 +291,7 @@
   {
     "type": "tax_credit",
     "program": "creditForPreviouslyOwnedCleanVehicles",
+    "authority_type": "federal",
     "item": "used_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -297,6 +312,7 @@
   {
     "type": "tax_credit",
     "program": "creditForPreviouslyOwnedCleanVehicles",
+    "authority_type": "federal",
     "item": "used_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -317,6 +333,7 @@
   {
     "type": "tax_credit",
     "program": "creditForPreviouslyOwnedCleanVehicles",
+    "authority_type": "federal",
     "item": "used_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -337,6 +354,7 @@
   {
     "type": "tax_credit",
     "program": "creditForPreviouslyOwnedCleanVehicles",
+    "authority_type": "federal",
     "item": "used_electric_vehicle",
     "item_type": "tax_credit",
     "amount": {
@@ -357,6 +375,7 @@
   {
     "type": "tax_credit",
     "program": "energyEfficientHomeImprovementCredit",
+    "authority_type": "federal",
     "item": "heat_pump_air_conditioner_heater",
     "item_type": "tax_credit",
     "amount": {
@@ -376,6 +395,7 @@
   {
     "type": "tax_credit",
     "program": "energyEfficientHomeImprovementCredit",
+    "authority_type": "federal",
     "item": "heat_pump_water_heater",
     "item_type": "tax_credit",
     "amount": {
@@ -395,6 +415,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "heat_pump_water_heater",
     "item_type": "pos_rebate",
     "amount": {
@@ -414,6 +435,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "heat_pump_air_conditioner_heater",
     "item_type": "pos_rebate",
     "amount": {
@@ -434,6 +456,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "heat_pump_clothes_dryer",
     "item_type": "pos_rebate",
     "amount": {
@@ -454,6 +477,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "heat_pump_water_heater",
     "item_type": "pos_rebate",
     "amount": {
@@ -473,6 +497,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "heat_pump_air_conditioner_heater",
     "item_type": "pos_rebate",
     "amount": {
@@ -493,6 +518,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "heat_pump_clothes_dryer",
     "item_type": "pos_rebate",
     "amount": {
@@ -513,6 +539,7 @@
   {
     "type": "tax_credit",
     "program": "residentialCleanEnergyCredit",
+    "authority_type": "federal",
     "item": "rooftop_solar_installation",
     "item_type": "tax_credit",
     "amount": {
@@ -532,6 +559,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "weatherization",
     "item_type": "pos_rebate",
     "amount": {
@@ -551,6 +579,7 @@
   {
     "type": "tax_credit",
     "program": "energyEfficientHomeImprovementCredit",
+    "authority_type": "federal",
     "item": "weatherization",
     "item_type": "tax_credit",
     "amount": {
@@ -570,6 +599,7 @@
   {
     "type": "pos_rebate",
     "program": "HEEHR",
+    "authority_type": "federal",
     "item": "weatherization",
     "item_type": "pos_rebate",
     "amount": {
@@ -589,6 +619,7 @@
   {
     "type": "pos_rebate",
     "program": "hopeForHomes",
+    "authority_type": "federal",
     "item": "efficiency_rebates",
     "item_type": "performance_rebate",
     "amount": {
@@ -608,6 +639,7 @@
   {
     "type": "pos_rebate",
     "program": "hopeForHomes",
+    "authority_type": "federal",
     "item": "efficiency_rebates",
     "item_type": "performance_rebate",
     "amount": {

--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -1,5 +1,6 @@
 import { JSONSchemaType } from 'ajv';
 import fs from 'fs';
+import { AuthorityType } from './authorities';
 import { FilingStatus } from './tax_brackets';
 import { Amount, AmountType, AmountUnit } from './types/amount';
 import { ItemType, Type, TypeV0 } from './types/incentive-types';
@@ -13,10 +14,11 @@ export enum AmiQualification {
   MoreThan80_Ami = 'more_than_80_ami',
 }
 
-export interface Incentive {
+export interface IRAIncentive {
   agi_max_limit: number | null;
   ami_qualification: AmiQualification | null;
   amount: Amount;
+  authority_type: AuthorityType.Federal;
   end_date: number;
   filing_status: FilingStatus | null;
   item: Item;
@@ -47,13 +49,14 @@ const amountSchema: JSONSchemaType<Amount> = {
   required: ['type', 'number'],
 } as const;
 
-export const SCHEMA: JSONSchemaType<Incentive[]> = {
+export const SCHEMA: JSONSchemaType<IRAIncentive[]> = {
   type: 'array',
   items: {
     type: 'object',
     properties: {
       type: { type: 'string', enum: [Type.PosRebate, Type.TaxCredit] },
       program: { type: 'string', enum: ALL_PROGRAMS },
+      authority_type: { type: 'string', const: AuthorityType.Federal },
       item: { type: 'string', enum: ALL_ITEMS },
       item_type: { type: 'string', enum: Object.values(ItemType) },
       amount: amountSchema,
@@ -80,6 +83,7 @@ export const SCHEMA: JSONSchemaType<Incentive[]> = {
       'agi_max_limit',
       'ami_qualification',
       'amount',
+      'authority_type',
       'end_date',
       'filing_status',
       'item',
@@ -92,6 +96,6 @@ export const SCHEMA: JSONSchemaType<Incentive[]> = {
   },
 };
 
-export const IRA_INCENTIVES: Incentive[] = JSON.parse(
+export const IRA_INCENTIVES: IRAIncentive[] = JSON.parse(
   fs.readFileSync('./data/ira_incentives.json', 'utf-8'),
 );

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -17,6 +17,8 @@ export type StateIncentive = {
   amount: Amount;
   bonus_available?: boolean;
   owner_status: OwnerStatus[];
+  start_date: number;
+  end_date: number;
 };
 
 const amountSchema: JSONSchemaType<Amount> = {
@@ -43,6 +45,12 @@ const incentivePropertySchema = {
   owner_status: {
     type: 'array',
     items: { type: 'string', enum: Object.values(OwnerStatus) },
+  },
+  start_date: {
+    type: 'number',
+  },
+  end_date: {
+    type: 'number',
   },
   short_description: { type: 'string', maxLength: 150 },
 } as const;

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -3,16 +3,15 @@ import { AUTHORITIES_BY_STATE, AuthorityType } from '../data/authorities';
 import { RI_INCENTIVES } from '../data/state_incentives';
 import { AmountType } from '../data/types/amount';
 import { OwnerStatus } from '../data/types/owner-status';
-import { APIIncentiveNonLocalized } from '../schemas/v1/incentive';
 import { APISavings, zeroSavings } from '../schemas/v1/savings';
 import { UnexpectedInputError } from './error';
-import { CalculateParams } from './incentives-calculation';
+import { CalculateParams, CalculatedIncentive } from './incentives-calculation';
 
 export function calculateStateIncentivesAndSavings(
   stateId: string,
   request: CalculateParams,
 ): {
-  stateIncentives: APIIncentiveNonLocalized[];
+  stateIncentives: CalculatedIncentive[];
   savings: APISavings;
 } {
   // TODO condition based on existence of incentives data, not hardcoding RI.

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -3,7 +3,7 @@ import { FastifyInstance } from 'fastify';
 import _ from 'lodash';
 import { Database } from 'sqlite';
 import { AuthorityType } from '../data/authorities';
-import { IRA_INCENTIVES } from '../data/ira_incentives';
+import { IRA_INCENTIVES, IRAIncentive } from '../data/ira_incentives';
 import { IRA_STATE_SAVINGS } from '../data/ira_state_savings';
 import { AmountType } from '../data/types/amount';
 import { ItemType, Type, TypeV0 } from '../data/types/incentive-types';
@@ -21,13 +21,10 @@ import {
   WEBSITE_INCENTIVE_SCHEMA,
   WebsiteIncentive,
 } from '../schemas/v0/incentive';
-import { APIIncentiveNonLocalized } from '../schemas/v1/incentive';
 
 IRA_INCENTIVES.forEach(incentive => Object.freeze(incentive));
 
-function translateIncentives(
-  incentives: APIIncentiveNonLocalized[],
-): WebsiteIncentive[] {
+function translateIncentives(incentives: IRAIncentive[]): WebsiteIncentive[] {
   return incentives.map(incentive => ({
     ...incentive,
     item_es: t('items', incentive.item, 'es'),
@@ -139,10 +136,10 @@ export default async function (
 
         const pos_rebate_incentives = result.incentives.filter(
           i => i.type === Type.PosRebate,
-        );
+        ) as IRAIncentive[];
         let tax_credit_incentives = result.incentives.filter(
           i => i.type === Type.TaxCredit,
-        );
+        ) as IRAIncentive[];
 
         // Website Calculator backwards compatiblity from v1 data:
 

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -4,7 +4,7 @@ import { AmiQualification } from '../../data/ira_incentives';
 import { FilingStatus } from '../../data/tax_brackets';
 import { AmountType, AmountUnit } from '../../data/types/amount';
 import { ItemType, Type } from '../../data/types/incentive-types';
-import { ALL_ITEMS, Item } from '../../data/types/items';
+import { ALL_ITEMS } from '../../data/types/items';
 import { OwnerStatus } from '../../data/types/owner-status';
 
 export const API_INCENTIVE_SCHEMA = {
@@ -175,11 +175,3 @@ export const API_INCENTIVE_SCHEMA = {
 } as const;
 
 export type APIIncentive = FromSchema<typeof API_INCENTIVE_SCHEMA>;
-
-/**
- * This is used internally, as an intermediate form between incentive
- * calculation and external API.
- */
-export type APIIncentiveNonLocalized = Omit<APIIncentive, 'item'> & {
-  item: Item;
-};


### PR DESCRIPTION
## Description

I'd mentioned before that this concept was getting awkward, and we're
starting to hit that point. This is the fix.

The core change here is to have `calculateIncentives` return a type
that is a union of the IRA static-data type and the RI static-dat
type, plus the `eligible` flag.

- Renamed `Incentive` to `IRAIncentive` for clarity.

- Adding the `authority_type: federal` flag to the IRA data directly
  just makes things smoother. That means the union type `(Incentive |
  RIIncentive)` has the `authority_type` field required, which matches
  with the fact that it's required in `APIIncentive`, which just makes
  things smoother.

- `start_date` and `end_date` in the state incentives definition:
  they've been there in the JSON the whole time, just not expressed in
  the types.

## Test Plan

`yarn test`
