### PR TITLE
Script to update all the fixtures from real output

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "start": "fastify start -l info -a 0.0.0.0 build/app.js --options",
-    "dev": "fastify start -r ts-node/register -w -l info -P src/app.ts --options",
+    "dev": "fastify start -r ts-node/register -w --ignore-watch test -l info -P src/app.ts --options",
     "build": "./scripts/build.sh",
     "lint": "prettier --check . && eslint .",
     "deploy:dev": "gcloud run deploy incentives-api --project rewiring-america-dev --source .",

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Must have jq installed:
+#   brew install jq
+
+curl \
+  "http://localhost:3000/api/v0/calculator\
+?zip=80212\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=joint\
+&household_size=4" \
+  | jq . > test/fixtures/v0-80212-homeowner-80000-joint-4.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=80212\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=joint\
+&household_size=4" \
+  | jq . > test/fixtures/v1-80212-homeowner-80000-joint-4.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=02807\
+&owner_status=homeowner\
+&household_income=65000\
+&tax_filing=joint\
+&household_size=4\
+&authority_types=state\
+&authority_types=federal\
+&items=heat_pump_air_conditioner_heater\
+&items=new_electric_vehicle" \
+  | jq . > test/fixtures/v1-02807-state-items.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=02903\
+&owner_status=homeowner\
+&household_income=65000\
+&tax_filing=joint\
+&household_size=4\
+&authority_types=state\
+&authority_types=utility\
+&utility=ri-rhode-island-energy" \
+  | jq . > test/fixtures/v1-02903-state-utility-lowincome.json


### PR DESCRIPTION
## Description

When making a change to the API output, I run `yarn test` to see the
diff, and then if the diff is right, I want to update the fixture file
to match. Currently, this entails either updating it manually, or
putting together just the right API request to get that output.

This script contains explicit curl commands that generate each fixture
file. I'm sure there's a prettier way to do this, but this is the
simplest, and it doubles as a quick way to get curl commands to run
locally.

I had to tell Fastify to stop watching the `test` directory, otherwise
it restarts the server in response to the fixture file changing, and
the next `curl` command fails because the server isn't up yet.

## Test Plan

Run the script; make sure there are no changes to the
fixtures. Introduce a deliberate change to API output and run the
script again; make sure that change is reflected in the fixture files.
