### PR TITLE
Add logos to authorities

### DIFF
--- a/data/authorities.json
+++ b/data/authorities.json
@@ -1,19 +1,41 @@
 {
   "RI": {
     "state": {
-      "ri-oer": { "name": "Rhode Island Office of Energy Resources" },
+      "ri-oer": {
+        "name": "Rhode Island Office of Energy Resources",
+        "logo": {
+          "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-oer.png",
+          "width": 311,
+          "height": 100
+        }
+      },
       "ri-commerce-corp": { "name": "Rhode Island Commerce Corporation" },
       "ri-dhs": { "name": "Rhode Island Department of Human Services" }
     },
     "utility": {
       "ri-rhode-island-energy": {
-        "name": "Rhode Island Energy"
+        "name": "Rhode Island Energy",
+        "logo": {
+          "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-rhode-island-energy.png",
+          "width": 287,
+          "height": 100
+        }
       },
       "ri-pascoag-utility-district": {
-        "name": "Pascoag Utility District"
+        "name": "Pascoag Utility District",
+        "logo": {
+          "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-pascoag-utility-district.svg",
+          "width": 369,
+          "height": 100
+        }
       },
       "ri-block-island-power-company": {
-        "name": "Block Island Power Company"
+        "name": "Block Island Power Company",
+        "logo": {
+          "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-block-island-power-company.png",
+          "width": 119,
+          "height": 100
+        }
       }
     }
   }

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
+import { API_IMAGE_SCHEMA } from '../schemas/v1/image';
 import { STATES_PLUS_DC } from './types/states';
 
 /**
@@ -26,6 +27,7 @@ export const API_AUTHORITY_SCHEMA = {
   type: 'object',
   properties: {
     name: { type: 'string' },
+    logo: API_IMAGE_SCHEMA,
   },
   required: ['name'],
   additionalProperties: false,

--- a/src/schemas/v1/image.ts
+++ b/src/schemas/v1/image.ts
@@ -1,0 +1,20 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const API_IMAGE_SCHEMA = {
+  type: 'object',
+  properties: {
+    src: {
+      type: 'string',
+    },
+    width: {
+      type: 'number',
+    },
+    height: {
+      type: 'number',
+    },
+  },
+  required: ['src', 'width', 'height'],
+  additionalProperties: false,
+} as const;
+
+export type APIImage = FromSchema<typeof API_IMAGE_SCHEMA>;

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -4,7 +4,12 @@
   "is_over_150_ami": false,
   "authorities": {
     "ri-oer": {
-      "name": "Rhode Island Office of Energy Resources"
+      "name": "Rhode Island Office of Energy Resources",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-oer.png",
+        "width": 311,
+        "height": 100
+      }
     }
   },
   "savings": {

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -4,10 +4,20 @@
   "is_over_150_ami": false,
   "authorities": {
     "ri-oer": {
-      "name": "Rhode Island Office of Energy Resources"
+      "name": "Rhode Island Office of Energy Resources",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-oer.png",
+        "width": 311,
+        "height": 100
+      }
     },
     "ri-rhode-island-energy": {
-      "name": "Rhode Island Energy"
+      "name": "Rhode Island Energy",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-rhode-island-energy.png",
+        "width": 287,
+        "height": 100
+      }
     },
     "ri-commerce-corp": {
       "name": "Rhode Island Commerce Corporation"


### PR DESCRIPTION
## Description

Logos are structs with width and height values for the images, rather
than just image URLs, so that frontends can render sized images and
thus avoid redraws after the images load.

One thing I considered is setting the width and height as metadata in
Cloud Storage, and having the API backend read that metadata to serve
to the frontend, rather than hardcoded the dimensions next to the
URL. But that seemed like a needless number of moving pieces.

## Test Plan

`yarn test` with updated fixtures


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205405733037671