### PR TITLE
Add "coverage" response field

### DIFF
--- a/src/data/types/coverage.ts
+++ b/src/data/types/coverage.ts
@@ -1,0 +1,24 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const API_COVERAGE_SCHEMA = {
+  description:
+    'Which sub-national sets of incentives were considered for eligibility.',
+  type: 'object',
+  properties: {
+    state: {
+      type: 'string',
+      nullable: true,
+      description:
+        'Two-letter state code. Determined from the "location" request parameter.',
+    },
+    utility: {
+      type: 'string',
+      nullable: true,
+      description: 'Utility ID, as passed in the "utility" request parameter.',
+    },
+  },
+  required: ['state', 'utility'],
+  additionalProperties: false,
+} as const;
+
+export type APICoverage = FromSchema<typeof API_COVERAGE_SCHEMA>;

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -9,6 +9,7 @@ import { SOLAR_PRICES } from '../data/solar_prices';
 import { RIIncentive } from '../data/state_incentives';
 import { STATE_MFIS, StateMFI } from '../data/state_mfi';
 import { FilingStatus } from '../data/tax_brackets';
+import { APICoverage } from '../data/types/coverage';
 import { OwnerStatus } from '../data/types/owner-status';
 import {
   APICalculatorRequest,
@@ -305,6 +306,10 @@ export default function calculateIncentives(
 
   const incentives: CalculatedIncentive[] = [];
   let savings: APISavings = zeroSavings();
+  let coverage: APICoverage = {
+    state: null,
+    utility: null,
+  };
 
   if (!authority_types || authority_types.includes(AuthorityType.Federal)) {
     const federal = calculateFederalIncentivesAndSavings(
@@ -326,6 +331,7 @@ export default function calculateIncentives(
     const state = calculateStateIncentivesAndSavings(state_id, request);
     incentives.push(...state.stateIncentives);
     savings = addSavings(savings, state.savings);
+    coverage = state.coverage;
   }
 
   // Get tax owed to determine max potential tax savings
@@ -363,6 +369,7 @@ export default function calculateIncentives(
     is_under_150_ami: isUnder150Ami,
     is_over_150_ami: isOver150Ami,
     authorities,
+    coverage,
     savings,
     incentives: sortedIncentives,
   };

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -2,6 +2,7 @@ import { RI_LOW_INCOME_THRESHOLDS } from '../data/RI/low_income_thresholds';
 import { AuthorityType } from '../data/authorities';
 import { RI_INCENTIVES } from '../data/state_incentives';
 import { AmountType } from '../data/types/amount';
+import { APICoverage } from '../data/types/coverage';
 import { OwnerStatus } from '../data/types/owner-status';
 import { APISavings, zeroSavings } from '../schemas/v1/savings';
 import { CalculateParams, CalculatedIncentive } from './incentives-calculation';
@@ -12,10 +13,15 @@ export function calculateStateIncentivesAndSavings(
 ): {
   stateIncentives: CalculatedIncentive[];
   savings: APISavings;
+  coverage: APICoverage;
 } {
   // TODO condition based on existence of incentives data, not hardcoding RI.
   if (stateId !== 'RI') {
-    return { stateIncentives: [], savings: zeroSavings() };
+    return {
+      stateIncentives: [],
+      savings: zeroSavings(),
+      coverage: { state: null, utility: null },
+    };
   }
 
   const incentives = RI_INCENTIVES;
@@ -104,5 +110,9 @@ export function calculateStateIncentivesAndSavings(
   return {
     stateIncentives,
     savings,
+    coverage: {
+      state: stateId,
+      utility: request.utility ?? null,
+    },
   };
 }

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -1,6 +1,7 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { API_AUTHORITY_SCHEMA, AuthorityType } from '../../data/authorities';
 import { FilingStatus } from '../../data/tax_brackets';
+import { API_COVERAGE_SCHEMA } from '../../data/types/coverage';
 import { ALL_ITEMS } from '../../data/types/items';
 import { OwnerStatus } from '../../data/types/owner-status';
 import { API_INCENTIVE_SCHEMA } from './incentive';
@@ -101,6 +102,7 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
     'is_under_150_ami',
     'is_over_150_ami',
     'authorities',
+    'coverage',
     'savings',
     'incentives',
   ],
@@ -118,6 +120,7 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
       type: 'object',
       additionalProperties: API_AUTHORITY_SCHEMA,
     },
+    coverage: API_COVERAGE_SCHEMA,
     savings: API_SAVINGS_SCHEMA,
     incentives: {
       type: 'array',

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -12,6 +12,10 @@
       }
     }
   },
+  "coverage": {
+    "state": "RI",
+    "utility": null
+  },
   "savings": {
     "pos_rebate": 14000,
     "tax_credit": 4036,

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -26,6 +26,10 @@
       "name": "Rhode Island Department of Human Services"
     }
   },
+  "coverage": {
+    "state": "RI",
+    "utility": "ri-rhode-island-energy"
+  },
   "savings": {
     "pos_rebate": 0,
     "tax_credit": 0,

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -3,6 +3,10 @@
   "is_under_150_ami": true,
   "is_over_150_ami": false,
   "authorities": {},
+  "coverage": {
+    "state": null,
+    "utility": null
+  },
   "savings": {
     "pos_rebate": 14000,
     "tax_credit": 5836,


### PR DESCRIPTION
## Description

The new frontend will use this to determine which state-specific
experience to show, if any. When we eventually have local/municipal
incentives, the locality we determine for you will also be included in
this struct.

Although I've preferred absent/present fields over
always-present-but-nullable fields for optional info elsewhere in v1,
I think nullable fields make sense here. Semantically, we're saying
"we considered no state incentives for eligibility" rather than not
commenting on whether we considered any state incentives.

## Test Plan

`yarn test` with updated fixtures.
