### PR TITLE
Don't error in /utilities if we don't have coverage

### DIFF
--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -1,5 +1,4 @@
 import { AUTHORITIES_BY_STATE, Authority } from '../data/authorities';
-import { InvalidInputError } from './error';
 import { ZipInfo } from './income-info';
 
 /**
@@ -16,10 +15,7 @@ export function getUtilitiesForLocation(location: ZipInfo): {
   const stateUtilities = AUTHORITIES_BY_STATE[location.state_id]?.utility;
 
   if (!stateUtilities) {
-    throw new InvalidInputError(
-      'We currently do not have coverage for that location',
-      'location',
-    );
+    return {};
   }
 
   let ids: string[];

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -354,6 +354,13 @@ const UTILITIES = [
       utilities: { 'ri-rhode-island-energy': { name: 'Rhode Island Energy' } },
     },
   ],
+  [
+    '80212',
+    {
+      location: { state: 'CO' },
+      utilities: {},
+    },
+  ],
 ];
 
 test('/utilities', async t => {


### PR DESCRIPTION
The frontend will rely on the `location` in this response to implement
locking to a specific state, so it needs to know the location
regardless of what utility coverage exists.

The semantics of this endpoint are now straightforwardly "here are the
utilities that we know may be operating in the given location". This
includes the possibility of "none", when we just don't know what
utilities are there.

NB: I think you could make a good argument for either behavior here.
This way happens to make the frontend logic a little cleaner, but I
don't know if that should be what drives the decision.
