### PR TITLE
Add bonus as an incentive type.

### DIFF
--- a/src/data/types/incentive-types.ts
+++ b/src/data/types/incentive-types.ts
@@ -5,6 +5,7 @@ export enum Type {
   TaxCredit = 'tax_credit',
   AccountCredit = 'account_credit',
   AssistanceProgram = 'assistance_program',
+  Bonus = 'bonus',
 }
 
 export type TypeV0 = Extract<Type, Type.PosRebate | Type.TaxCredit>;
@@ -23,4 +24,5 @@ export enum ItemType {
   TaxCredit = 'tax_credit',
   AccountCredit = 'account_credit',
   AssistanceProgram = 'assistance_program',
+  Bonus = 'bonus',
 }

--- a/src/schemas/v1/savings.ts
+++ b/src/schemas/v1/savings.ts
@@ -21,6 +21,11 @@ export const API_SAVINGS_SCHEMA = {
       description:
         'This may represent no-cost products or services rather than a monetary value.',
     },
+    bonus: {
+      type: 'integer',
+      description:
+        'This represents a bonus incentive amount that can only be claimed if some other prerequisite incentive is claimed as well.',
+    },
   },
   required: [
     'pos_rebate',
@@ -28,6 +33,7 @@ export const API_SAVINGS_SCHEMA = {
     'performance_rebate',
     'account_credit',
     'rebate',
+    'bonus',
   ],
   additionalProperties: false,
 } as const;
@@ -40,6 +46,7 @@ export const zeroSavings = (): APISavings => ({
   performance_rebate: 0,
   rebate: 0,
   account_credit: 0,
+  bonus: 0,
 });
 
 export const addSavings = (a: APISavings, b: APISavings): APISavings => ({
@@ -48,4 +55,5 @@ export const addSavings = (a: APISavings, b: APISavings): APISavings => ({
   performance_rebate: a.performance_rebate + b.performance_rebate,
   rebate: a.rebate + b.rebate,
   account_credit: a.account_credit + b.account_credit,
+  bonus: a.bonus + b.bonus,
 });

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -24,7 +24,8 @@
     "tax_credit": 4036,
     "performance_rebate": 0,
     "account_credit": 0,
-    "rebate": 6000
+    "rebate": 6000,
+    "bonus": 0
   },
   "incentives": [
     {

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -38,7 +38,8 @@
     "tax_credit": 0,
     "performance_rebate": 0,
     "account_credit": 0,
-    "rebate": 16600
+    "rebate": 16600,
+    "bonus": 0
   },
   "incentives": [
     {

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -15,7 +15,8 @@
     "tax_credit": 5836,
     "performance_rebate": 8000,
     "account_credit": 0,
-    "rebate": 0
+    "rebate": 0,
+    "bonus": 0
   },
   "incentives": [
     {

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -19,7 +19,8 @@
     "tax_credit": 0,
     "performance_rebate": 0,
     "account_credit": 0,
-    "rebate": 750
+    "rebate": 750,
+    "bonus": 0
   },
   "incentives": [
     {

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -25,7 +25,8 @@
     "tax_credit": 0,
     "performance_rebate": 0,
     "account_credit": 0,
-    "rebate": 1000
+    "rebate": 1000,
+    "bonus": 0
   },
   "incentives": [
     {


### PR DESCRIPTION
We will use this to represent incentives that are only available as add-ons to other incentives. It's possible that we could represent this just with the incentive relationships and we don't need it to be an actual type in the JSON, but I think this makes it easier to make the distinction in the frontend if/when we decide to do that (and it matches the way these things are represented in the spreadsheet data model now).

I updated the unit tests to reflect the new type, although I haven't added any bonus type incentives yet.