### PR TITLE
Fix Tap-related type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/make-fetch-happen": "^10.0.3",
     "@types/node": "16.18.38",
     "@types/qs": "^6.9.8",
-    "@types/tap": "^15.0.8",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "ajv": "^8.11.0",

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -3,6 +3,7 @@
 
 import helper from 'fastify-cli/helper.js';
 import path from 'path';
+import { Test } from 'tap';
 
 const AppPath = path.join(__dirname, '..', 'src', 'app.ts');
 
@@ -13,7 +14,7 @@ function config() {
 }
 
 // automatically build and tear down our instance
-async function build(t: Tap.Test) {
+async function build(t: Test) {
   // you can set all the options supported by the fastify CLI command
   const argv = [AppPath, '--options'];
 

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 import fs from 'fs';
 import qs from 'qs';
-import { beforeEach, test } from 'tap';
+import { beforeEach, test, Test } from 'tap';
 import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v0/calculator-response';
 import { WEBSITE_INCENTIVE_SCHEMA } from '../../src/schemas/v0/incentive';
 import { build } from '../helper';
@@ -10,10 +10,7 @@ beforeEach(() => {
   process.setMaxListeners(100);
 });
 
-async function getCalculatorResponse(
-  t: Tap.Test,
-  query: Record<string, unknown>,
-) {
+async function getCalculatorResponse(t: Test, query: Record<string, unknown>) {
   const app = await build(t);
 
   const searchParams = qs.stringify(query, { encodeValuesOnly: true });

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 import fs from 'fs';
 import qs from 'qs';
-import { beforeEach, test } from 'tap';
+import { beforeEach, test, Test } from 'tap';
 import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint';
 import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive';
 import { API_UTILITIES_RESPONSE_SCHEMA } from '../../src/schemas/v1/utilities-endpoint';
@@ -11,10 +11,7 @@ beforeEach(() => {
   process.setMaxListeners(100);
 });
 
-async function getCalculatorResponse(
-  t: Tap.Test,
-  query: Record<string, unknown>,
-) {
+async function getCalculatorResponse(t: Test, query: Record<string, unknown>) {
   const app = await build(t);
 
   const searchParams = qs.stringify(query, { encodeValuesOnly: true });
@@ -25,7 +22,7 @@ async function getCalculatorResponse(
 }
 
 async function validateResponse(
-  t: Tap.Test,
+  t: Test,
   query: Record<string, unknown>,
   fixtureFile: string,
 ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,13 +770,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tap@^15.0.8":
-  version "15.0.8"
-  resolved "https://registry.yarnpkg.com/@types/tap/-/tap-15.0.8.tgz#03774f963d971e612de3bbbbf18614d0cf57c3e7"
-  integrity sha512-ZfeoiZlLIaFi4t6wccwbTEicrHREkP0bOq8dZVi/nWvG5F8O7LlS2cSUZBiOW/D4cgWS/p2uhM3lJoyzFAl80w==
-  dependencies:
-    "@types/node" "*"
-
 "@typescript-eslint/eslint-plugin@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz#96f3ca6615717659d06c9f7161a1d14ab0c49c66"


### PR DESCRIPTION
I don't know when this started happening (I haven't worked in this
codebase for a few weeks), but I was getting type errors running `tsc`
locally.

It turns out we had conflicting versions of `tap` and `@types/tap`
installed. The newest version of `tap` ships types, so the `@types`
version is no longer needed.
