### PR TITLE
Switch low_income = false incentives back to having no low_income key.

### DIFF
--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -384,7 +384,6 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000.",
       "es": "Hasta $10,000 para la instalación de una aerotermia, según el tamaño. Valor típica de $2,500 a $3,000."
@@ -407,7 +406,6 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "Up to $10,000 to install a ground source (geothermal) heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000.",
       "es": "Hasta $10,000 para instalar una bomba de calor geotérmica, según el tamaño. Valor típica de $2,500 a $3,000."
@@ -428,7 +426,6 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "Additional $500 for an electrical service upgrade at the same time as installation of a heat pump or heat pump water heater.",
       "es": "Reembolso adicional de $500 para una mejora del servicio eléctrico al mismo tiempo que instalas una bomba de calor o calentador de agua con bomba de calor."
@@ -449,7 +446,6 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters.",
       "es": "$750 de reembolso después de instalar un calentador de agua con bomba de calor. $1,500 por calentadores de agua con bomba de calor de sistema dividido."


### PR DESCRIPTION
We had discussed that at some point maybe these incentives should not be available to low income households, but at the time we decided the existing behavior was ok (meaning that low_income : false incentives would not be available to low income households but would be available to others). These were missed when we switched to the low income threshold map implementation, so this change just resets that.

Tested with `yarn test`