### PR TITLE
Require === comparison

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,4 +4,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   root: true,
+  rules: {
+    eqeqeq: ['error', 'always'],
+  },
 };

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -34,7 +34,7 @@ export function calculateStateIncentivesAndSavings(
   savings: APISavings;
   coverage: APICoverage;
 } {
-  if (incentives.length == 0) {
+  if (incentives.length === 0) {
     return {
       stateIncentives: [],
       savings: zeroSavings(),


### PR DESCRIPTION
## Description

I thought I'd turned on this eslint rule, but I hadn't.

## Test Plan

eslint failed without the `incentives.length` change; now it passes.
