### PR TITLE
Prepare CT for launch

### DIFF
--- a/data/programs.json
+++ b/data/programs.json
@@ -102,12 +102,12 @@
       "en": "Norwich Public Utilities Cooling & Heating Incentive Pilot Program"
     },
     "url": {
-      "en": "https://norwichpublicutilities.com/residential/chipp/"
+      "en": "https://norwichpublicutilities.com/residential/chipp"
     }
   },
   "ct_residentialGroundSourceHeatPumpIncentive": {
     "name": {
-      "en": "Eversource Residential Ground Source Heat Pump Incentive"
+      "en": "Energize CT Residential Ground Source Heat Pump Incentive"
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential"
@@ -115,7 +115,7 @@
   },
   "ct_residentialHeatPumpWaterHeaterIncentive": {
     "name": {
-      "en": "Eversource Residential Heat Pump Water Heater Incentive"
+      "en": "Energize CT Residential Heat Pump Water Heater Incentive"
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump"

--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -53,11 +53,11 @@ export const STATES_PLUS_DC = [
 ] as const;
 
 export const BETA_STATES: string[] = [
-  'CT',
   'NY',
   'VA',
 ];
 
 export const LAUNCHED_STATES: string[] = [
+  'CT',
   'RI',
 ];

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -54,7 +54,7 @@
       "type": "rebate",
       "authority_type": "utility",
       "authority": "ct-eversource",
-      "program": "Eversource Residential Ground Source Heat Pump Incentive",
+      "program": "Energize CT Residential Ground Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential",
       "item": {
         "type": "geothermal_heating_installation",
@@ -83,7 +83,7 @@
       "type": "rebate",
       "authority_type": "utility",
       "authority": "ct-eversource",
-      "program": "Eversource Residential Heat Pump Water Heater Incentive",
+      "program": "Energize CT Residential Heat Pump Water Heater Incentive",
       "program_url": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump",
       "item": {
         "type": "heat_pump_water_heater",

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -22,9 +22,6 @@ const AMIS_FOR_39503 = JSON.parse(
 const AMIS_FOR_02861 = JSON.parse(
   fs.readFileSync('./test/fixtures/amis-for-zip-02861.json', 'utf-8'),
 );
-const AMIS_FOR_06002 = JSON.parse(
-  fs.readFileSync('./test/fixtures/amis-for-zip-06002.json', 'utf-8'),
-);
 
 beforeEach(async t => {
   t.context.db = await open({
@@ -67,14 +64,14 @@ test('correctly evaluates state incentives for launched states', async t => {
 });
 
 test('correctly excludes state incentives for beta states', async t => {
-  // CT is not launched so will not get state incentives.
-  const data = calculateIncentives(AMIS_FOR_06002, {
+  // NY is not launched so will not get state incentives.
+  const data = calculateIncentives(AMIS_FOR_11211, {
     owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
     tax_filing: FilingStatus.Single,
-    household_size: 1,
     authority_types: [AuthorityType.State, AuthorityType.Utility],
-    utility: 'ct-norwich-public-utilities',
+    utility: 'ny-pseg-long-island',
+    household_size: 1,
     include_beta_states: false,
   });
   t.ok(data);
@@ -82,14 +79,14 @@ test('correctly excludes state incentives for beta states', async t => {
 });
 
 test('correctly evaluates state incentives for beta states', async t => {
-  // CT is in beta so we should get incentives for it when beta is requested.
-  const data = calculateIncentives(AMIS_FOR_06002, {
+  // NY is in beta so we should get incentives for it when beta is requested.
+  const data = calculateIncentives(AMIS_FOR_11211, {
     owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
     tax_filing: FilingStatus.Single,
-    household_size: 1,
     authority_types: [AuthorityType.State, AuthorityType.Utility],
-    utility: 'ct-norwich-public-utilities',
+    utility: 'ny-pseg-long-island',
+    household_size: 1,
     include_beta_states: true,
   });
   t.ok(data);

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -113,8 +113,6 @@ test('CT low income response with state and utility filtering is valid and corre
       tax_filing: 'joint',
       authority_types: ['state', 'utility'],
       utility: 'ct-eversource',
-      // TODO: Remove when CT is fully launched.
-      include_beta_states: true,
     },
     './test/fixtures/v1-ct-06002-state-utility-lowincome.json',
   );


### PR DESCRIPTION
Following steps [here](https://docs.google.com/document/d/1ZC4e2ccYACxS0emT1hq25CW_LTH26kVP9YHL8-ZVUWs/edit), except for updating utilities-for-location, since it was not easy to determine which zip codes corresponded to which utilities, and the current representation won't scale well when we have to add a lot more zip codes. I created an Asana [task for that.](https://app.asana.com/0/1205271193902672/1206080952937946/f). For now, I think the user can pick their utility and it will show up regardless of zip code as long as it was in the request.

I also renamed two of the "Eversource" programs to "Energize CT" since Energize CT is the providing authority and they are also applicable for customers of UI.