### PR TITLE
Update Block Island incentives per their request

### DIFF
--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -93,18 +93,16 @@
     "item_type": "rebate",
     "program": "ri_blockIslandEnergyEfficiency",
     "amount": {
-      "type": "dollars_per_unit",
-      "unit": "ton",
-      "number": 250,
-      "maximum": 750,
-      "representative": 750
+      "type": "dollar_amount",
+      "number": 750,
+      "maximum": 750
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $750 back after purchase and installation of qualifying heat pumps and mini-splits.",
-      "es": "Reembolsos hasta $750 después de la compra e instalación de bombas de calor y mini-splits calificados."
+      "en": "Up to $750 back after purchase and installation of qualifying heat pumps and mini-splits, depending on size.",
+      "es": "Reembolsos hasta $750 después de la compra e instalación de bombas de calor y mini-splits calificados, según el tamaño."
     }
   },
   {
@@ -137,8 +135,8 @@
     "item_type": "rebate",
     "program": "ri_blockIslandEnergyEfficiency",
     "amount": {
-      "type": "dollar_amount",
-      "number": 2000,
+      "type": "percent",
+      "number": 1,
       "maximum": 2000
     },
     "bonus_available": true,
@@ -146,8 +144,8 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $800 back after air/duct sealing work, plus 40% back on additional weatherization, up to $2,000 in total weatherization costs.",
-      "es": "Reembolsos hasta $800 después del trabajo de sellado de aire/ductos. Además, un reembolso de 40% por la impermeabilización, hasta $2,000 en costos totales."
+      "en": "100% of weatherization costs, including air/duct sealing and insulation, up to $2,000.",
+      "es": "El total de los costos de la impermeabilización, hasta $2000, incluyendo el sellado de conductos de aire y el aislamiento."
     }
   },
   {

--- a/scripts/update-descriptions.ts
+++ b/scripts/update-descriptions.ts
@@ -71,6 +71,11 @@ async function edit(file: IncentiveFile, write: boolean) {
   incentives.forEach(incentive => {
     if (descriptionsById.has(incentive.id)) {
       const spreadsheetDescription = descriptionsById.get(incentive.id)!;
+      if (spreadsheetDescription.es === '') {
+        // Don't include blank Spanish strings
+        delete spreadsheetDescription.es;
+      }
+
       let edits = false;
       if (incentive.short_description.en !== spreadsheetDescription.en) {
         console.log(


### PR DESCRIPTION
## Description

- Their HVAC incentive provides different per-ton amount for different
  equipment types. We're not yet set up to handle that gracefully on
  the frontend, so I've just made the incentive into an "up to $750"
  one, removing the per-ton part entirely.

  This is lossy -- we're removing some detail from the incentive that
  we were previously capturing -- but I think on balance it's OK for
  now.

  BIPC also reminded us that the HVAC/HPWH/smart thermostat incentives
  are all a single program, which is capped at $3000 per household. We
  don't have a way to capture that right now, so we'll have to come
  back to that once incentive relationships are ready to go.

- Their weatherization incentive has been simplified (nice!)

- Drive-by fix to the update-descriptions script to prevent it from
  putting in an empty string as a Spanish description when it's blank
  in the spreadsheet.

## Test Plan

`yarn test`
