### PR TITLE
Remove $3k cap on Clean Heat RI low-income HP incentive

### DIFF
--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -459,8 +459,7 @@
     "program": "ri_cleanHeat",
     "amount": {
       "type": "percent",
-      "number": 1,
-      "maximum": 3000
+      "number": 1
     },
     "owner_status": [
       "homeowner"

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -66,8 +66,7 @@
       },
       "amount": {
         "type": "percent",
-        "number": 1,
-        "maximum": 3000
+        "number": 1
       },
       "item_type": "rebate",
       "owner_status": [

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -109,8 +109,7 @@
       },
       "amount": {
         "type": "percent",
-        "number": 1,
-        "maximum": 3000
+        "number": 1
       },
       "item_type": "rebate",
       "owner_status": [


### PR DESCRIPTION
## Description

The incentive is uncapped. The $3k is additional money available for an electrical service upgrade. Ideally we'd show this as a bonus incentive, but we don't have support for that yet, so we have to settle for saying it in the description.

## Test Plan

`yarn test`

Point frontend at my local API server, look up 02861 / $10,000, make sure the "100% of cost of a heat pump" incentive appears.
