### PR TITLE
Return all of a state's utilities as a fallback

### DIFF
--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -2,7 +2,10 @@ import { AUTHORITIES_BY_STATE, Authority } from '../data/authorities';
 import { ZipInfo } from './income-info';
 
 /**
- * Find the utilities that may serve the given location.
+ * Find the utilities that may serve the given location. False positives are
+ * not ideal but acceptable (i.e. returning a utility as an option for a
+ * location they don't actually serve), whereas false negatives are a bug (i.e.
+ * failing to return a utility for a location they do actually serve).
  *
  * Returns a map of utility IDs to utility info, suitable for the response
  * from /api/v1/utilities.
@@ -20,21 +23,28 @@ export function getUtilitiesForLocation(location: ZipInfo): {
 
   let ids: string[];
 
-  // Source: https://catalog.data.gov/dataset/u-s-electric-utility-companies-and-rates-look-up-by-zipcode-2021
-  // According to that dataset, 02839 is not served by Pascoag, but in a meeting
-  // with them they mentioned it, so it's included here.
-  switch (location.zip) {
-    case '02807':
-      ids = ['ri-block-island-power-company'];
-      break;
-    case '02814':
-    case '02830':
-    case '02839':
-    case '02859':
-      ids = ['ri-rhode-island-energy', 'ri-pascoag-utility-district'];
-      break;
-    default:
-      ids = ['ri-rhode-island-energy'];
+  // If we know details about where the state's utilities operate, we can
+  // encode that here.
+  if (location.state_id === 'RI') {
+    // Source: https://catalog.data.gov/dataset/u-s-electric-utility-companies-and-rates-look-up-by-zipcode-2021
+    // According to that dataset, 02839 is not served by Pascoag, but in a meeting
+    // with them they mentioned it, so it's included here.
+    switch (location.zip) {
+      case '02807':
+        ids = ['ri-block-island-power-company'];
+        break;
+      case '02814':
+      case '02830':
+      case '02839':
+      case '02859':
+        ids = ['ri-rhode-island-energy', 'ri-pascoag-utility-district'];
+        break;
+      default:
+        ids = ['ri-rhode-island-energy'];
+    }
+  } else {
+    // Fall back to returning all the state's utilities, regardless of location.
+    return stateUtilities;
   }
 
   return Object.fromEntries(ids.map(id => [id, stateUtilities[id]]));


### PR DESCRIPTION
## Description

In states where we have their set of utilities but not detailed
information about which utilities serve which ZIPs, just return all
the utilities. Returning overly-broad results is OK (as explained in
the comment); what's important is that a user can choose their actual
utility.

This unblocks opening up CT for testing using `include_beta_states`.

## Test Plan

Locally call `/v1/utilities?location[zip]=06033` and make sure the CT
utilities are returned.
