### PR TITLE
Add include_beta_states flag to utilities endpoint

### DIFF
--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -61,3 +61,10 @@ export const BETA_STATES: string[] = [
 export const LAUNCHED_STATES: string[] = [
   'RI',
 ];
+
+export const isStateIncluded = (
+  stateId: string,
+  includeBeta: boolean,
+): boolean =>
+  LAUNCHED_STATES.includes(stateId) ||
+  (includeBeta && BETA_STATES.includes(stateId));

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -7,7 +7,7 @@ import {
 import { AmountType } from '../data/types/amount';
 import { APICoverage } from '../data/types/coverage';
 import { OwnerStatus } from '../data/types/owner-status';
-import { BETA_STATES, LAUNCHED_STATES } from '../data/types/states';
+import { isStateIncluded } from '../data/types/states';
 import { APISavings, zeroSavings } from '../schemas/v1/savings';
 import { CalculateParams, CalculatedIncentive } from './incentives-calculation';
 
@@ -16,10 +16,7 @@ export function getAllStateIncentives(
   request: CalculateParams,
 ) {
   // Only process incentives for launched states, or beta states if beta was requested.
-  if (
-    !LAUNCHED_STATES.includes(stateId) &&
-    (!request.include_beta_states || !BETA_STATES.includes(stateId))
-  ) {
+  if (!isStateIncluded(stateId, request.include_beta_states ?? false)) {
     return [];
   }
   return STATE_INCENTIVES_BY_STATE[stateId];

--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -1,4 +1,5 @@
 import { AUTHORITIES_BY_STATE, Authority } from '../data/authorities';
+import { isStateIncluded } from '../data/types/states';
 import { ZipInfo } from './income-info';
 
 /**
@@ -12,12 +13,15 @@ import { ZipInfo } from './income-info';
  *
  * TODO this is very not scalable to nationwide coverage!
  */
-export function getUtilitiesForLocation(location: ZipInfo): {
+export function getUtilitiesForLocation(
+  location: ZipInfo,
+  includeBeta: boolean,
+): {
   [id: string]: Authority;
 } {
   const stateUtilities = AUTHORITIES_BY_STATE[location.state_id]?.utility;
 
-  if (!stateUtilities) {
+  if (!stateUtilities || !isStateIncluded(location.state_id, includeBeta)) {
     return {};
   }
 

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -149,7 +149,10 @@ export default async function (
           .type('application/json')
           .send({
             location: { state: location.state_id },
-            utilities: getUtilitiesForLocation(location),
+            utilities: getUtilitiesForLocation(
+              location,
+              request.query.include_beta_states ?? false,
+            ),
           });
       } catch (error) {
         if (error instanceof InvalidInputError) {

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -37,6 +37,12 @@ export const API_UTILITIES_SCHEMA = {
         ],
         default: 'en',
       },
+      include_beta_states: {
+        type: 'boolean',
+        description:
+          'Option to include states which are in development and not fully launched.',
+        default: 'false',
+      },
     },
     required: ['location'],
   },

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -384,6 +384,7 @@ test('non-existent zips', async t => {
 const UTILITIES = [
   [
     '02807',
+    false,
     {
       location: { state: 'RI' },
       utilities: {
@@ -393,6 +394,7 @@ const UTILITIES = [
   ],
   [
     '02814',
+    false,
     {
       location: { state: 'RI' },
       utilities: {
@@ -403,13 +405,37 @@ const UTILITIES = [
   ],
   [
     '02905',
+    false,
     {
       location: { state: 'RI' },
       utilities: { 'ri-rhode-island-energy': { name: 'Rhode Island Energy' } },
     },
   ],
   [
+    '06033',
+    true,
+    {
+      location: { state: 'CT' },
+      utilities: {
+        'ct-eversource': {
+          name: 'Eversource',
+        },
+        'ct-united-illuminating-company': {
+          name: 'The United Illuminating Company',
+        },
+        'ct-groton-utilities': {
+          name: 'Groton Utilities',
+        },
+        'ct-norwich-public-utilities': {
+          name: 'Norwich Public Utilities',
+        },
+      },
+    },
+  ],
+  ['06033', false, { location: { state: 'CT' }, utilities: {} }],
+  [
     '80212',
+    false,
     {
       location: { state: 'CO' },
       utilities: {},
@@ -428,9 +454,9 @@ test('/utilities', async t => {
   });
   const validator = ajv.getSchema('APIUtilitiesResponse')!;
 
-  for (const [zip, expectedResponse] of UTILITIES) {
+  for (const [zip, beta, expectedResponse] of UTILITIES) {
     const searchParams = qs.stringify(
-      { location: { zip } },
+      { location: { zip }, include_beta_states: beta },
       { encodeValuesOnly: true },
     );
     const res = await app.inject({ url: `/api/v1/utilities?${searchParams}` });


### PR DESCRIPTION
## Description

Now that we have a fallback to returning all of a state's utilities
from `authorities.json` in the absence of state-specific logic in
`utilities-for-location.ts`, we need a way to gate states. Makes sense
to use the same logic as `/calculator`.

## Test Plan

`yarn test`. Locally request utilities for CT zip code 06033 with and
without the flag. Make sure results are the same for RI (02861) with
and without the flag.
