### PR TITLE
Upgrade tap to fix sporadic test failure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ package-lock.json
 
 # tap
 .nyc_output
+.tap
 
 # production
 **/build

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^3.0.3",
     "prettier-plugin-multiline-arrays": "^3.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",
-    "tap": "^18.5.2",
+    "tap": "^18.6.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,10 +184,10 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@isaacs/ts-node-temp-fork-for-pr-2009@^10.9.1":
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/ts-node-temp-fork-for-pr-2009/-/ts-node-temp-fork-for-pr-2009-10.9.1.tgz#d8e3f75ee8a32f758ccce4ed58c2c1ea8a1353b2"
-  integrity sha512-MY4rUonz835NsTbd4dcgKZvZFYX9IkLnYFZV9M7GQV8t39fawafLin/Qw6VXD4yfMs4HcBq8P3ddeU0QHMH1YQ==
+"@isaacs/ts-node-temp-fork-for-pr-2009@^10.9.5":
+  version "10.9.5"
+  resolved "https://registry.yarnpkg.com/@isaacs/ts-node-temp-fork-for-pr-2009/-/ts-node-temp-fork-for-pr-2009-10.9.5.tgz#6e34df6e9ca5f6c9a2c9f864764bc50bb90c0c5f"
+  integrity sha512-hEDlwpHhIabtB+Urku8muNMEkGui0LVGlYLS3KoB9QBDf0Pw3r7q0RrfoQmFuk8CvRpGzErO3/vLQd9Ys+/g4g==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node14" "*"
@@ -386,139 +386,139 @@
     "@sigstore/protobuf-specs" "^0.2.1"
     tuf-js "^2.1.0"
 
-"@tapjs/after-each@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/after-each/-/after-each-1.1.13.tgz#80097187efc6f197ac14c938ee6ce2f03517f8f1"
-  integrity sha512-KnX5QCz+f0Qvm8ZkN+/QugSqbNznVTisNu+xbYWY+m2sOhUtyNYSsqvxcKEhpBTS+fRjTPl1wU5ocZv5dDUMEA==
+"@tapjs/after-each@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/after-each/-/after-each-1.1.17.tgz#b0cc87b451d6dd4512c579c0b4881fbfcc8e63c5"
+  integrity sha512-ia8sr00Wilni+2+wO4MKYCYikeRwUC41HamV8EPN63R2UmiBEOe/cMSf+KYADIh56JvxAiH7Xa0+GSFU+N2FQQ==
   dependencies:
     function-loop "^4.0.0"
 
-"@tapjs/after@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/after/-/after-1.1.13.tgz#750be9d58766101572864dc6a565b2c86547718a"
-  integrity sha512-E2yGUayyCmgtyGDGIcejcVZjdcTmqxEfQexS/TTdELE2cCVYDlkTog5sRJVW02fQUyKrqta0X6bfUjT5+VtO9g==
+"@tapjs/after@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/after/-/after-1.1.17.tgz#3ba9bbdf2fb952db7d8c243143fe42fa924b3b5b"
+  integrity sha512-14qeP+mHZ8nIMDGtdCwTgvKclLlHxfARMTasb9fw//tmF/8ZDZhTemtCDxAP75wihxy5P7nzVZo/6TpVeOZrwg==
   dependencies:
     is-actual-promise "^1.0.0"
 
-"@tapjs/asserts@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/asserts/-/asserts-1.1.13.tgz#f1d837465ab2c5d4eb7aa7e6e441066b17c7657f"
-  integrity sha512-nX9Dzkz4BToVw6Foi/naQO2oId4kvu1nOd9Brql75TrLOhSIf0BNhmUtedPouzefqHTnOQcOK+wxPqm2mUCvHQ==
+"@tapjs/asserts@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/asserts/-/asserts-1.1.17.tgz#a65545bc4c27f85fda7ffaa5a8fa44eea2d8a67d"
+  integrity sha512-eKmbWBORDXu9bUHtPTu7qFrXNj5UeeH2nABJeP9BGHIn2ydmTgMEWCO3E+ljf7tisHchY5/x672lr99+O/mbTQ==
   dependencies:
-    "@tapjs/stack" "1.2.6"
+    "@tapjs/stack" "1.2.7"
     is-actual-promise "^1.0.0"
-    tcompare "6.4.3"
+    tcompare "6.4.5"
     trivial-deferred "^2.0.0"
 
-"@tapjs/before-each@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/before-each/-/before-each-1.1.13.tgz#35405261117d15d246f0e91a510acb556c37eba0"
-  integrity sha512-wprmLLmX9QowI9Z5eNtQ8/PRpLHzip99PxukOR59V2839Ypmwu9e1vVfrSIU1F6u6CcUrb80SaJDf2Izm8hmBg==
+"@tapjs/before-each@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/before-each/-/before-each-1.1.17.tgz#63be0eaef14a9ce4f1c01a7a0f55521f58faedf3"
+  integrity sha512-d2Um3Y2j0m563QNsSxczh+QeSg5sBngnBFGOelUtQVqmq91oNWU/7mY1pwN6ip8mMIQYD75CIhq5/Z57DGomWQ==
   dependencies:
     function-loop "^4.0.0"
 
-"@tapjs/before@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/before/-/before-1.1.13.tgz#65675f96c4d941985b1fc40ca51484a476a63209"
-  integrity sha512-IBgbKmc5Mqw+4JX0A52ZSn3ycwIQSNkqfOEjzELrEqhLuzeyQnb99P6QZKYfcVDaMhPqeYHRO+ziJOgtbAgPkQ==
+"@tapjs/before@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/before/-/before-1.1.17.tgz#9afb4385b95f2278d81eed29503a61daf1281af1"
+  integrity sha512-pAmEAIMIqF9MPNUgEsnuWCM00iD/FJOX0P5eXSsWexWHjuZAkv5tIT/4qpXO9KYj+9c51Lh+7YSY2Xvk1Jjolw==
   dependencies:
     is-actual-promise "^1.0.0"
 
-"@tapjs/config@2.4.9":
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/@tapjs/config/-/config-2.4.9.tgz#dc44e994552b5adf3862dd5a8280a9a8454a181e"
-  integrity sha512-3coHlkF0XJn59ixl0ln2vRn2SyYPUXyoLDixu4jP/C38ZA7yYTlpsDYuovNiMhXUgJi1AMbWCqASmYL49rn8Sw==
+"@tapjs/config@2.4.14":
+  version "2.4.14"
+  resolved "https://registry.yarnpkg.com/@tapjs/config/-/config-2.4.14.tgz#5033e214ffb41d269ea3a0e7538e9a4966e3ac02"
+  integrity sha512-dkjPVJGbLJC9BxCAxudAGiijnKc6XcQbpBSMAGJ/+VoRSqXlPkMWz0d8Ad3rNt7s+g2GBEWBx1kV7wcKtLlxmw==
   dependencies:
-    "@tapjs/core" "1.4.2"
-    "@tapjs/test" "1.3.13"
+    "@tapjs/core" "1.4.6"
+    "@tapjs/test" "1.3.17"
     chalk "^5.2.0"
     jackspeak "^2.3.6"
     polite-json "^4.0.1"
-    tap-yaml "2.2.0"
+    tap-yaml "2.2.1"
     walk-up-path "^3.0.1"
 
-"@tapjs/core@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@tapjs/core/-/core-1.4.2.tgz#3f559fbbdf657f0c53420d4f736f5dc6d67ca4dc"
-  integrity sha512-+mI2R8l/LjRrf7VLcme7jumi9MZb8vx3ARrheuS/djaXdcUd7lWHMjJSvCvnWhV5twTTUsfnc7GytWeFL3N4vA==
+"@tapjs/core@1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@tapjs/core/-/core-1.4.6.tgz#3c6a9ebecf895f1a829ae080a86039b901949d61"
+  integrity sha512-cAKtdGJslrziwi/RJBU7jF930P/eSsemv295t6yLekNVP0XUCNtLFYirxuS1Xwob0nt0g/k+94xXB7o1wdTQvA==
   dependencies:
-    "@tapjs/processinfo" "^3.1.5"
-    "@tapjs/stack" "1.2.6"
-    "@tapjs/test" "1.3.13"
+    "@tapjs/processinfo" "^3.1.6"
+    "@tapjs/stack" "1.2.7"
+    "@tapjs/test" "1.3.17"
     async-hook-domain "^4.0.1"
     diff "^5.1.0"
     is-actual-promise "^1.0.0"
     minipass "^7.0.3"
     signal-exit "4.1"
-    tap-parser "15.3.0"
-    tap-yaml "2.2.0"
-    tcompare "6.4.3"
+    tap-parser "15.3.1"
+    tap-yaml "2.2.1"
+    tcompare "6.4.5"
     trivial-deferred "^2.0.0"
 
-"@tapjs/error-serdes@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tapjs/error-serdes/-/error-serdes-1.2.0.tgz#a0cc5f6b5f2b03e26b1954066a6e600e6af9c4da"
-  integrity sha512-Lt7kHWxILVCkfiRbsIZW5sfZ79+CmS1a+mp41dgp5oiiO2TJGBSpEWptD+bIfk9tegtU4wcMUwnStymfTKl4Xw==
+"@tapjs/error-serdes@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@tapjs/error-serdes/-/error-serdes-1.2.1.tgz#672370b8436f128e9a24955043fa37c3c101dc1b"
+  integrity sha512-/7eLEcrGo+Qz3eWrjkhDC+VSEOjabkkzr9eRADeU+OLFeZaik8L/GRk0SGhnp4YsQkv0jcNV00A42bEx2HIZcw==
   dependencies:
     minipass "^7.0.3"
 
-"@tapjs/filter@1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/filter/-/filter-1.2.13.tgz#86ad3130efe57f2a59abbb686410654d248771b9"
-  integrity sha512-HahbPSl5gkJ12pIRqMq595A0zNMaTSUvQyLYtDX8GhQM7YanCMLPPPfxg5SFk2p7XinxN5HUiZ5i+Jh1W9tpeQ==
+"@tapjs/filter@1.2.17":
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/filter/-/filter-1.2.17.tgz#b0f8f96528ace7044647be2ba1c37500e256be1d"
+  integrity sha512-ytsqoPThV92ML1+M+cHlhAS7nOQpDNRBJiPqw20/GmNeoQXsDzVUlWR89DP3WNNUPrr/c1pCVr9XHVhCIeYk0w==
 
-"@tapjs/fixture@1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/fixture/-/fixture-1.2.13.tgz#c707aeb53faa5c70aeac2a77446bf32c5eb6c3a2"
-  integrity sha512-PPw4EqgIwOzoPjaPSv4O6l7e5RKLEhJH1CbrTqdaM2YxuLgC9Gv9AN0LxJsXsfTnJgoWodzC29dE7JB5RJINuQ==
+"@tapjs/fixture@1.2.17":
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/fixture/-/fixture-1.2.17.tgz#d2b3ce3fd4e5d857b6b2bd2a8c4b6f9b8a281d5c"
+  integrity sha512-eOOQxtsEcQ/sBxaZhpqdF9DCNxXAvLuiE5HgyL6d1eB4eceu57uIUKK7NDtFVv+vlbQH/NoiSTxmN/IBRbKT8w==
   dependencies:
     mkdirp "^3.0.0"
     rimraf "^5.0.5"
 
-"@tapjs/intercept@1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/intercept/-/intercept-1.2.13.tgz#4988490895b91ba0a7c620459a84914327f9728a"
-  integrity sha512-/miqU/GK+AFW1y7Wc3N/1OpcFYK++voQ/Ai4u2cORbcxnUt0cWBxHPOZOyepZqwX88sPwr1NdrCV1/B3BbgPWw==
+"@tapjs/intercept@1.2.17":
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/intercept/-/intercept-1.2.17.tgz#ada7e48cad2bca9b4cc4a77d38dfd95014cbf2f7"
+  integrity sha512-CNuYBxiFBMNALS1PxH3yGI10H8ObxOoD67C2xGWyzXeYrPJ/R4x31Sda9bqaoK3uf/vj28bC9kSECCFjRsNAEg==
   dependencies:
-    "@tapjs/after" "1.1.13"
-    "@tapjs/stack" "1.2.6"
+    "@tapjs/after" "1.1.17"
+    "@tapjs/stack" "1.2.7"
 
-"@tapjs/mock@1.2.11":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@tapjs/mock/-/mock-1.2.11.tgz#7cbff78d3c0b10e09acf9b69b6cdd387f8144c60"
-  integrity sha512-fXMvbQa04qfnNjgGN/cKWj52flYpN8J18/gkWQDbiOLieC1QJVtF1tkTohL602mqVbxn+9rOpTPjDvyJhi65zg==
+"@tapjs/mock@1.2.15":
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/@tapjs/mock/-/mock-1.2.15.tgz#3886ecff3677124485b1b7cf3a18d2007de5dd04"
+  integrity sha512-uXfVNDAMAbCGOu46B9jbryTau2pLSQjCdWnkAm/OUgZh/OtO0i7OORz9HdEPfEF2tuy1tLo9+vsCZm3lPU5F7w==
   dependencies:
-    "@tapjs/after" "1.1.13"
-    "@tapjs/stack" "1.2.6"
-    resolve-import "^1.4.4"
+    "@tapjs/after" "1.1.17"
+    "@tapjs/stack" "1.2.7"
+    resolve-import "^1.4.5"
     walk-up-path "^3.0.1"
 
-"@tapjs/node-serialize@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tapjs/node-serialize/-/node-serialize-1.2.2.tgz#e8562d5239fe64d8d9dd4d6b237159d0587826e6"
-  integrity sha512-ycPPYNxRsj/AFoqaGY5P38nehMVcwMAz7U0uRO7/2dh4vxUQcKyIBh5KNhB3z/EEas5wiQip+YJ1CW1fAx/PHg==
+"@tapjs/node-serialize@1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@tapjs/node-serialize/-/node-serialize-1.2.6.tgz#52faa78ea04a36db764daa490c818b37782cebfe"
+  integrity sha512-xj1OJEsdTr0pQFlirfe/apN0dHUCMCx2Nm5H3SoiSOW4D1/FUKS65VZpWgo3mXMPxRyb/2T1DH3xON1eSGq4ww==
   dependencies:
-    "@tapjs/error-serdes" "1.2.0"
-    "@tapjs/stack" "1.2.6"
-    tap-parser "15.3.0"
+    "@tapjs/error-serdes" "1.2.1"
+    "@tapjs/stack" "1.2.7"
+    tap-parser "15.3.1"
 
-"@tapjs/processinfo@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@tapjs/processinfo/-/processinfo-3.1.5.tgz#c5e84f7c3244dd04058ae6269971eaf8c642f602"
-  integrity sha512-KCx0Dbatmuja9soLFFK1asDwodz+16gwHL9QWiziz83b7LK4x5h9kiUbbhTi3I3wtKREeaN8caNA0Z2m6Yxsag==
+"@tapjs/processinfo@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@tapjs/processinfo/-/processinfo-3.1.6.tgz#9e9defce887affc60d0642b06f9f934e41ba0132"
+  integrity sha512-ktDsaf79wJsLaoG1Pp+stHSRf6a1k/JydoRAaYVG5iJnd3DooL6yewZsciUi2yiN/WQc5tAXCIFTXL4uXGB8LA==
   dependencies:
     pirates "^4.0.5"
     process-on-spawn "^1.0.0"
     signal-exit "^4.0.2"
     uuid "^8.3.2"
 
-"@tapjs/reporter@1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@tapjs/reporter/-/reporter-1.3.9.tgz#238fbd91944fab6b1985ca41671b4593f01ae685"
-  integrity sha512-nMakS5iE8b8p5eQBiwqsPvakreBXWYe+qNmgNlSSmXpKhOXYq4gvL8i4K1/ilJIIA/SzSSBz8ZPA8SRZTs0/aA==
+"@tapjs/reporter@1.3.15":
+  version "1.3.15"
+  resolved "https://registry.yarnpkg.com/@tapjs/reporter/-/reporter-1.3.15.tgz#d00c59405a1fa46d042312992fa553eac56335b0"
+  integrity sha512-us1vXd6TW1V8wJxxnP2a8DNSP1WFTpODyYukqWg7ym5nCalREYnz2MFsn65rRNu/xJlmqsmv+9P63rupud7Zlg==
   dependencies:
-    "@tapjs/config" "2.4.9"
-    "@tapjs/stack" "1.2.6"
+    "@tapjs/config" "2.4.14"
+    "@tapjs/stack" "1.2.7"
     chalk "^5.2.0"
     ink "^4.4.1"
     minipass "^7.0.3"
@@ -527,23 +527,23 @@
     prismjs-terminal "^1.2.3"
     react "^18.2.0"
     string-length "^6.0.0"
-    tap-parser "15.3.0"
-    tap-yaml "2.2.0"
-    tcompare "6.4.3"
+    tap-parser "15.3.1"
+    tap-yaml "2.2.1"
+    tcompare "6.4.5"
 
-"@tapjs/run@1.4.9":
-  version "1.4.9"
-  resolved "https://registry.yarnpkg.com/@tapjs/run/-/run-1.4.9.tgz#43721df8794fe87db3dabb585883dd2b0ff7dc7a"
-  integrity sha512-98wXYtgsuFr6CvjI1d7yDLnG0oSCMgy8Avg/UYo3dcYUbobMeMXk3/VOx4/f6eGTBEtaVT8VCzz3HIOEdpD1rA==
+"@tapjs/run@1.4.16":
+  version "1.4.16"
+  resolved "https://registry.yarnpkg.com/@tapjs/run/-/run-1.4.16.tgz#d1b91e2706a393d205f5deaa58de26c9ffde9e71"
+  integrity sha512-ZTESjBDj5SitZgWz2hQdzfBoxgaFs89jQjWzqobcdfro0iF7TVRpSrvpz9GTMdo2Tu9aeFfMNfmaAtwNWnDabw==
   dependencies:
-    "@tapjs/after" "1.1.13"
-    "@tapjs/before" "1.1.13"
-    "@tapjs/config" "2.4.9"
-    "@tapjs/processinfo" "^3.1.5"
-    "@tapjs/reporter" "1.3.9"
-    "@tapjs/spawn" "1.1.13"
-    "@tapjs/stdin" "1.1.13"
-    "@tapjs/test" "1.3.13"
+    "@tapjs/after" "1.1.17"
+    "@tapjs/before" "1.1.17"
+    "@tapjs/config" "2.4.14"
+    "@tapjs/processinfo" "^3.1.6"
+    "@tapjs/reporter" "1.3.15"
+    "@tapjs/spawn" "1.1.17"
+    "@tapjs/stdin" "1.1.17"
+    "@tapjs/test" "1.3.17"
     c8 "^8.0.1"
     chalk "^5.3.0"
     chokidar "^3.5.3"
@@ -553,82 +553,82 @@
     mkdirp "^3.0.1"
     opener "^1.5.2"
     pacote "^17.0.3"
-    resolve-import "^1.4.4"
+    resolve-import "^1.4.5"
     rimraf "^5.0.5"
     semver "^7.5.4"
     signal-exit "^4.1.0"
-    tap-parser "15.3.0"
-    tap-yaml "2.2.0"
-    tcompare "6.4.3"
+    tap-parser "15.3.1"
+    tap-yaml "2.2.1"
+    tcompare "6.4.5"
     trivial-deferred "^2.0.0"
     which "^4.0.0"
 
-"@tapjs/snapshot@1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/snapshot/-/snapshot-1.2.13.tgz#8a92e45a81c5afa7c656ca8a0f2537b9123f31e0"
-  integrity sha512-/vW3kOxNA1vclsEU87A5vZ7edRbrL1Hlm7LauJwRAvAgdW2VrEcc1ivyCMbWvYi11csGu1MM9A2Poo/aOhzQ/Q==
+"@tapjs/snapshot@1.2.17":
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/snapshot/-/snapshot-1.2.17.tgz#417f1b3f4c1299fa0dcc845ba63bf49df127c4f5"
+  integrity sha512-xDHys854ZA8s/1uCkE5PgBz4H1vYKChD6a4xjLVkaoRxpBHVp/IJZCD+8d69DRGnyuA4x2MGh0JLClTA9bLGrA==
   dependencies:
     is-actual-promise "^1.0.0"
-    tcompare "6.4.3"
+    tcompare "6.4.5"
     trivial-deferred "^2.0.0"
 
-"@tapjs/spawn@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/spawn/-/spawn-1.1.13.tgz#57e16fa9855c456a05132c40ed2e00082929ee3f"
-  integrity sha512-s2byTuuyyPv+8uI4xSspFhiFPddi/Bwz2a/RHQVm3IKuvO0gW9KA53J8PEjWIRXLFNgf5X0xWIYGgMXeklYN/w==
+"@tapjs/spawn@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/spawn/-/spawn-1.1.17.tgz#3e373aee6474ab3f988a9cd8857e8567206d93d1"
+  integrity sha512-Bbyxd91bgXEcglvXYKrRl2MaNHk00RajTZJ1kKe3Scr1ivaYv0maE6ZInAl4UE0a4SJl4Dskec+uKoZY3qGUYQ==
 
-"@tapjs/stack@1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@tapjs/stack/-/stack-1.2.6.tgz#34cf61ad869e702563f537ba41befe9ad66d0398"
-  integrity sha512-us73FMZytpcvYT/gOSDDKHk/LLZQZ/bBLoz48VcEE5EFQmF0EELhNOlyg4Rrvj8DmuYuFjiliidiV/FB1Fchaw==
+"@tapjs/stack@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@tapjs/stack/-/stack-1.2.7.tgz#09d4cb7da780689f010fdb9a0bd87c3bf78ac0de"
+  integrity sha512-7qUDWDmd+y7ZQ0vTrDTvFlWnJ+ND32NemS5HVuT1ZggHtBwJ62PQHIyCx/B5RopETBb6NvFPfUE21yTiex9Jkw==
 
-"@tapjs/stdin@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/stdin/-/stdin-1.1.13.tgz#9282df86bc298fc360b4f006a757b16a2d8fc331"
-  integrity sha512-ilamAMcQ7TPzuB4fVLtTyCYaqU3bAh1YLssmwtcYwRE0J4szNIFLMsduVjWLNGnjViKRHI6x1iHGOZg2IwTXug==
+"@tapjs/stdin@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/stdin/-/stdin-1.1.17.tgz#ad0a38ca2905c300237f3555e0ac34ebd1d83eb5"
+  integrity sha512-mDutFFPDnlVM2oYDAfyYKA+fC+aEiyz5n08D8x6YAbwZNbTIVp+h6ucyp7ygJ04fshd4l3s1HUmCZLSmHb2xEw==
 
-"@tapjs/test@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/test/-/test-1.3.13.tgz#24ccfc2d0edc901db3fccc051676d15ca1cf5d62"
-  integrity sha512-eqlrFgdMwOuqMeMGWMButPmas7q5Z0yEqmyBZIsjKk246wN1GUKIwGxX+K0THMBHaiSKW4c/PvXpMynZyywqbw==
+"@tapjs/test@1.3.17":
+  version "1.3.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/test/-/test-1.3.17.tgz#c327bdb757ad88afa3acad5db02f8bbd2537b611"
+  integrity sha512-yQ4uHC2GaDS+Gr5qwx9uMGxqvpYgnlVY+QexBReSeYZthWIN0KD8HDvnVt4An5Sx/Qhd7UlnNpNMBd6AkvPEew==
   dependencies:
-    "@isaacs/ts-node-temp-fork-for-pr-2009" "^10.9.1"
-    "@tapjs/after" "1.1.13"
-    "@tapjs/after-each" "1.1.13"
-    "@tapjs/asserts" "1.1.13"
-    "@tapjs/before" "1.1.13"
-    "@tapjs/before-each" "1.1.13"
-    "@tapjs/filter" "1.2.13"
-    "@tapjs/fixture" "1.2.13"
-    "@tapjs/intercept" "1.2.13"
-    "@tapjs/mock" "1.2.11"
-    "@tapjs/node-serialize" "1.2.2"
-    "@tapjs/snapshot" "1.2.13"
-    "@tapjs/spawn" "1.1.13"
-    "@tapjs/stdin" "1.1.13"
-    "@tapjs/typescript" "1.3.2"
-    "@tapjs/worker" "1.1.13"
+    "@isaacs/ts-node-temp-fork-for-pr-2009" "^10.9.5"
+    "@tapjs/after" "1.1.17"
+    "@tapjs/after-each" "1.1.17"
+    "@tapjs/asserts" "1.1.17"
+    "@tapjs/before" "1.1.17"
+    "@tapjs/before-each" "1.1.17"
+    "@tapjs/filter" "1.2.17"
+    "@tapjs/fixture" "1.2.17"
+    "@tapjs/intercept" "1.2.17"
+    "@tapjs/mock" "1.2.15"
+    "@tapjs/node-serialize" "1.2.6"
+    "@tapjs/snapshot" "1.2.17"
+    "@tapjs/spawn" "1.1.17"
+    "@tapjs/stdin" "1.1.17"
+    "@tapjs/typescript" "1.3.6"
+    "@tapjs/worker" "1.1.17"
     glob "^10.3.10"
     jackspeak "^2.3.6"
     mkdirp "^3.0.0"
-    resolve-import "^1.4.4"
+    resolve-import "^1.4.5"
     rimraf "^5.0.5"
     sync-content "^1.0.1"
-    tap-parser "15.3.0"
+    tap-parser "15.3.1"
     tshy "^1.2.2"
     typescript "5.2"
 
-"@tapjs/typescript@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@tapjs/typescript/-/typescript-1.3.2.tgz#7ac44f71cc9bb8b3549b168cefc35d76fb11f2b1"
-  integrity sha512-R8E36Kd1ImufcygVzSbQt/rEgg5RIW+CvIBzJNmv1IczRoAVFo5/OElZwOThiko7CAxDMRJxI8Cla63uK3gsLA==
+"@tapjs/typescript@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@tapjs/typescript/-/typescript-1.3.6.tgz#eb4d2a6f77c62568dd07249f13479437bfe55ee2"
+  integrity sha512-bHqQb06HcD1vFvSwElH0WK4cnCNthvA5OX/KBs5w1TNFHIeRHemp/hsSnGSNDwYwDETuOxD68rDZNTpNbzysBg==
   dependencies:
-    "@isaacs/ts-node-temp-fork-for-pr-2009" "^10.9.1"
+    "@isaacs/ts-node-temp-fork-for-pr-2009" "^10.9.5"
 
-"@tapjs/worker@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@tapjs/worker/-/worker-1.1.13.tgz#e4e75d36ad79755bb51143c470a53647cd5413b3"
-  integrity sha512-B/g1rdQcuOFdU6OeBHkdYUjzM6pbHo64nV+ckQNE7Atj4yzV0u7C+Emq+f7F+zItsGXaMm/a4Z7Zoliszy7YXw==
+"@tapjs/worker@1.1.17":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@tapjs/worker/-/worker-1.1.17.tgz#8e15c4d019f96aeac82da1590404107b429a708a"
+  integrity sha512-DCRzEBT+OgP518rQqzlX6KawvGTegkeEjPVa/TB6Iifj8WOHJ+XtunkR7riIRGEoCEOMD49DCJXj70c+XP0jNw==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -3455,6 +3455,14 @@ resolve-import@^1.4.4:
     glob "^10.3.3"
     walk-up-path "^3.0.1"
 
+resolve-import@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/resolve-import/-/resolve-import-1.4.5.tgz#d6f74648ef53ca0e8f2d5cab95322573de9737a4"
+  integrity sha512-HXb4YqODuuXT7Icq1Z++0g2JmhgbUHSs3VT2xR83gqvAPUikYT2Xk+562KHQgiaNkbBOlPddYrDLsC44qQggzw==
+  dependencies:
+    glob "^10.3.3"
+    walk-up-path "^3.0.1"
+
 restore-cursor@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-4.0.0.tgz#519560a4318975096def6e609d44100edaa4ccb9"
@@ -3827,46 +3835,46 @@ sync-content@^1.0.1, sync-content@^1.0.2:
     path-scurry "^1.9.2"
     rimraf "^5.0.1"
 
-tap-parser@15.3.0:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-15.3.0.tgz#b03f954655cde009a9b2e2abd88a3a5534333e91"
-  integrity sha512-R0yLuoC288K+gHtwcOhH7Af/8EocDglAyMpaASsmzNxV1chmq3v4juSAVhvMBbPx/pRVJYrPKe9Wsj9aaqMalQ==
+tap-parser@15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-15.3.1.tgz#2d18027340eb357396df5758bcb42df946a7e4aa"
+  integrity sha512-hwAtXX5TBGt2MJeYvASc7DjP48PUzA7P8RTbLxQcgKCEH7ICD5IsRco7l5YvkzjHlZbUbeI9wzO8B4hw2sKgnQ==
   dependencies:
     events-to-array "^2.0.3"
-    tap-yaml "2.2.0"
+    tap-yaml "2.2.1"
 
-tap-yaml@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tap-yaml/-/tap-yaml-2.2.0.tgz#53f23153a6587ec78679245f0f05ade1b588254e"
-  integrity sha512-o8I7WDNiGpuF04tGAVaNYY5rX9waCtqw9A7Y0YVSQBGcFwNUJWUPLkr2lbhgLRTxc+Tpnw4xUXlIanZc+ZAGnw==
+tap-yaml@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tap-yaml/-/tap-yaml-2.2.1.tgz#dcc2e901533a9c053630d070e8a1603ef2831f40"
+  integrity sha512-ovZuUMLAIH59jnFHXKEGJ+WyDYl6Cuduwg9qpvnqkZOUA1nU84q02Sry1HT0KXcdv2uB91bEKKxnIybBgrb6oA==
   dependencies:
     yaml "^2.3.0"
     yaml-types "^0.3.0"
 
-tap@^18.5.2:
-  version "18.5.2"
-  resolved "https://registry.yarnpkg.com/tap/-/tap-18.5.2.tgz#3c57bc95d4f9c9538dc1844cf50f19ca48b80b01"
-  integrity sha512-Fd8JN1fwA5+CNwKxLf6zhBgMMJZKYWxBwi6551Y4uGU/IFrKvEsK/hYEbBsw+Ae335wkW96+gmnu2lHJh26CPw==
+tap@^18.6.1:
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/tap/-/tap-18.6.1.tgz#7c79c813967bf511dcd3e27b85dcb5a3979c62ee"
+  integrity sha512-5cBQhJ1gdbsrTR3tA5kZZTts0HyOML6bcM7pEF7GF8d6y1ajfRMjbInS1Ty7/x2Ip0ko3cY1dYjPJ9JFNPsm7w==
   dependencies:
-    "@tapjs/after" "1.1.13"
-    "@tapjs/after-each" "1.1.13"
-    "@tapjs/asserts" "1.1.13"
-    "@tapjs/before" "1.1.13"
-    "@tapjs/before-each" "1.1.13"
-    "@tapjs/core" "1.4.2"
-    "@tapjs/filter" "1.2.13"
-    "@tapjs/fixture" "1.2.13"
-    "@tapjs/intercept" "1.2.13"
-    "@tapjs/mock" "1.2.11"
-    "@tapjs/node-serialize" "1.2.2"
-    "@tapjs/run" "1.4.9"
-    "@tapjs/snapshot" "1.2.13"
-    "@tapjs/spawn" "1.1.13"
-    "@tapjs/stdin" "1.1.13"
-    "@tapjs/test" "1.3.13"
-    "@tapjs/typescript" "1.3.2"
-    "@tapjs/worker" "1.1.13"
-    resolve-import "^1.4.4"
+    "@tapjs/after" "1.1.17"
+    "@tapjs/after-each" "1.1.17"
+    "@tapjs/asserts" "1.1.17"
+    "@tapjs/before" "1.1.17"
+    "@tapjs/before-each" "1.1.17"
+    "@tapjs/core" "1.4.6"
+    "@tapjs/filter" "1.2.17"
+    "@tapjs/fixture" "1.2.17"
+    "@tapjs/intercept" "1.2.17"
+    "@tapjs/mock" "1.2.15"
+    "@tapjs/node-serialize" "1.2.6"
+    "@tapjs/run" "1.4.16"
+    "@tapjs/snapshot" "1.2.17"
+    "@tapjs/spawn" "1.1.17"
+    "@tapjs/stdin" "1.1.17"
+    "@tapjs/test" "1.3.17"
+    "@tapjs/typescript" "1.3.6"
+    "@tapjs/worker" "1.1.17"
+    resolve-import "^1.4.5"
 
 tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
   version "6.1.13"
@@ -3880,10 +3888,10 @@ tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tcompare@6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/tcompare/-/tcompare-6.4.3.tgz#8cb1a962c4976d4fea42232526d0f54a3fec500a"
-  integrity sha512-bKVNHmQ6Nd7/K3+SFuhsppUrXGwQjXts/U9NAVz52JNYeOlyCjtVydNZHgscw3RmtHp+JdWuheYjVqPvY9x9kg==
+tcompare@6.4.5:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/tcompare/-/tcompare-6.4.5.tgz#68a8786309050e645099a0eff34941ef75fb241c"
+  integrity sha512-Whuz9xlKKI2XXICKDSDRKjXdBuC6gBNOgmEUtH7UFyQeYzfUMQ19DyjZULarGKDGFhgOg3CJ+IQUEfpkOPg0Uw==
   dependencies:
     diff "^5.1.0"
     react-element-to-jsx-string "^15.0.0"


### PR DESCRIPTION
## Description

Something about upgrading to Node v18.19 broke the tests. Sometimes
Github CI uses 18.19 and sometimes it uses 18.18, so this resulted in
sporadic test failures.

Upgrading tap fixes it. (I have no idea why, but I don't think it's
worth the time to figure it out.)

## Test Plan

Run `yarn test` locally using Node 18.18 and 18.19.
