### PR TITLE
Remove ev_charger_credit from item_type

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -255,7 +255,7 @@
     "program": "alternativeFuelVehicleRefuelingPropertyCredit",
     "authority_type": "federal",
     "item": "electric_vehicle_charger",
-    "item_type": "ev_charger_credit",
+    "item_type": "tax_credit",
     "amount": {
       "type": "dollar_amount",
       "number": 1000

--- a/src/data/types/incentive-types.ts
+++ b/src/data/types/incentive-types.ts
@@ -17,9 +17,6 @@ export type PaymentMethodV0 = Extract<
  * eligibility, totaling up savings, or estimating the amount of an incentive.
  */
 export enum ItemType {
-  // TODO this should go away
-  EvChargerCredit = 'ev_charger_credit',
-
   Rebate = 'rebate',
   PerformanceRebate = 'performance_rebate',
   PosRebate = 'pos_rebate',

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -129,7 +129,8 @@ function calculateFederalIncentivesAndSavings(
       amount.representative = roundCents(solarSystemCost * amount.number!);
     }
 
-    if (item.item_type === 'ev_charger_credit') {
+    // EV charger credit has some special eligibility rules
+    if (item.item === 'electric_vehicle_charger') {
       // console.log(
       //   'EV Charger Qualifications:',
       //   '\nIs Rural?',

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -176,6 +176,15 @@ export default async function (
           solarTaxCredit.item_type = 'solar_tax_credit' as ItemType;
         }
 
+        // 1.4)
+        // set the item_type of the EV charger credit
+        const evChargerCredit = tax_credit_incentives.find(
+          incentive => incentive.item === 'electric_vehicle_charger',
+        );
+        if (evChargerCredit) {
+          evChargerCredit.item_type = 'ev_charger_credit' as ItemType;
+        }
+
         const translated: WebsiteCalculatorResponse = {
           ...result,
 

--- a/src/schemas/v0/incentive.ts
+++ b/src/schemas/v0/incentive.ts
@@ -80,7 +80,11 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     },
     item_type: {
       type: 'string',
-      enum: [...Object.values(ItemType), 'solar_tax_credit'],
+      enum: [
+        ...Object.values(ItemType),
+        'solar_tax_credit',
+        'ev_charger_credit',
+      ],
     },
     owner_status: {
       type: 'array',

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -490,7 +490,7 @@
         "type": "dollar_amount",
         "number": 1000
       },
-      "item_type": "ev_charger_credit",
+      "item_type": "tax_credit",
       "owner_status": [
         "homeowner",
         "renter"


### PR DESCRIPTION
## Description

There was only one incentive, in all the data, with this item_type:
the federal EV charger credit. It's also the only incentive in the IRA
data with `item == electric_vehicle_charger`, so it's easily
distinguished that way.

The v0 output is unchanged. The v1 output is changed, but the state
calculator never reads this field, so this is fine.

The final step of removing `item_type` will be dealing with
`performance_rebate`, which will require a slightly different treatment.

## Test Plan

`yarn test`
