### PR TITLE
Don't lint on "yarn test"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,5 @@ jobs:
           cache: 'yarn'
       - run: yarn --frozen-lockfile
       - run: yarn build
+      - run: yarn lint
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "start": "fastify start -l info -a 0.0.0.0 build/app.js --options",
     "dev": "fastify start -r ts-node/register -w --ignore-watch test -l info -P src/app.ts --options",
     "build": "./scripts/build.sh",
-    "lint": "prettier --check . --ignore-path=.prettierignore && eslint .",
-    "test": "yarn lint && dotenv -- tap -- --ts \"test/**/*.test.ts\"",
+    "lint": "tsc --noEmit && prettier --check . --ignore-path=.prettierignore && eslint .",
+    "test": "dotenv -- tap -- --ts \"test/**/*.test.ts\"",
     "update-descriptions": "ts-node scripts/update-descriptions"
   },
   "tap": {


### PR DESCRIPTION
## Description

Prettier is actually kinda slow, which gets annoying if you're in a
quick edit-test-debug cycle. This makes `yarn test` literally just run
the tests. Linting now includes typechecking explicitly, and is done
in a separate CI step before testing.

## Test Plan

Run `yarn test`. Make sure CI on this PR runs lint.
