### PR TITLE
Generate valid OpenAPI

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,13 +7,9 @@ import {
 import path from 'path';
 import qs from 'qs';
 import { ERROR_SCHEMA } from './schemas/error';
-import { WEBSITE_CALCULATOR_REQUEST_SCHEMA } from './schemas/v0/calculator-request';
 import { WEBSITE_CALCULATOR_RESPONSE_SCHEMA } from './schemas/v0/calculator-response';
 import { WEBSITE_INCENTIVE_SCHEMA } from './schemas/v0/incentive';
-import {
-  API_CALCULATOR_REQUEST_SCHEMA,
-  API_CALCULATOR_RESPONSE_SCHEMA,
-} from './schemas/v1/calculator-endpoint';
+import { API_CALCULATOR_RESPONSE_SCHEMA } from './schemas/v1/calculator-endpoint';
 import { API_INCENTIVE_SCHEMA } from './schemas/v1/incentive';
 
 // These are the options described here:
@@ -32,10 +28,8 @@ export default async function (
   // Add any schemas that are referred to by $id
   fastify.addSchema(ERROR_SCHEMA);
   fastify.addSchema(WEBSITE_INCENTIVE_SCHEMA);
-  fastify.addSchema(WEBSITE_CALCULATOR_REQUEST_SCHEMA);
   fastify.addSchema(WEBSITE_CALCULATOR_RESPONSE_SCHEMA);
   fastify.addSchema(API_INCENTIVE_SCHEMA);
-  fastify.addSchema(API_CALCULATOR_REQUEST_SCHEMA);
   fastify.addSchema(API_CALCULATOR_RESPONSE_SCHEMA);
 
   // Replace Fastify's default request-start logging, to include more structured

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -60,20 +60,15 @@ function translateIncentives(incentives: IRAIncentive[]): WebsiteIncentive[] {
 
 const CalculatorSchema = {
   description: 'How much money will you get with the Inflation Reduction Act?',
-  querystring: {
-    $ref: 'WebsiteCalculatorRequest',
-  },
+  querystring: WEBSITE_CALCULATOR_REQUEST_SCHEMA,
   response: {
     200: {
-      description: 'Successful response',
       $ref: 'WebsiteCalculatorResponse',
     },
     400: {
-      description: 'Bad request',
       $ref: 'Error',
     },
     404: {
-      description: 'Resource not found',
       $ref: 'Error',
     },
   },
@@ -106,7 +101,6 @@ export default async function (
     JsonSchemaToTsProvider<{
       references: [
         typeof WEBSITE_INCENTIVE_SCHEMA,
-        typeof WEBSITE_CALCULATOR_REQUEST_SCHEMA,
         typeof WEBSITE_CALCULATOR_RESPONSE_SCHEMA,
       ];
     }>

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -14,7 +14,6 @@ import { IncomeInfo, isCompleteIncomeInfo } from '../lib/income-info';
 import { getUtilitiesForLocation } from '../lib/utilities-for-location';
 import { ERROR_SCHEMA } from '../schemas/error';
 import {
-  API_CALCULATOR_REQUEST_SCHEMA,
   API_CALCULATOR_RESPONSE_SCHEMA,
   API_CALCULATOR_SCHEMA,
 } from '../schemas/v1/calculator-endpoint';
@@ -68,7 +67,6 @@ export default async function (
       references: [
         typeof ERROR_SCHEMA,
         typeof API_INCENTIVE_SCHEMA,
-        typeof API_CALCULATOR_REQUEST_SCHEMA,
         typeof API_CALCULATOR_RESPONSE_SCHEMA,
       ];
     }>

--- a/src/schemas/error.ts
+++ b/src/schemas/error.ts
@@ -10,38 +10,17 @@ export const ERROR_SCHEMA = {
   properties: {
     statusCode: {
       type: 'integer',
-      examples: [
-        400,
-        404,
-      ],
     },
     error: {
       type: 'string',
-      examples: [
-        'Not Found',
-      ],
     },
     message: {
       type: 'string',
-      examples: [
-        'Route GET:/ not found',
-      ],
     },
     field: {
       type: 'string',
       description:
         'If the error was related to a specific field in the request, it will be specified here.',
-      examples: [
-        'zip',
-        'owner_status',
-      ],
     },
   },
-  examples: [
-    {
-      message: 'Route GET:/ not found',
-      error: 'Not Found',
-      statusCode: 404,
-    },
-  ],
 } as const;

--- a/src/schemas/v0/calculator-request.ts
+++ b/src/schemas/v0/calculator-request.ts
@@ -2,7 +2,6 @@ import { FilingStatus } from '../../data/tax_brackets';
 import { OwnerStatus } from '../../data/types/owner-status';
 
 export const WEBSITE_CALCULATOR_REQUEST_SCHEMA = {
-  $id: 'WebsiteCalculatorRequest',
   title: 'WebsiteCalculatorRequest',
   type: 'object',
   properties: {

--- a/src/schemas/v0/calculator-response.ts
+++ b/src/schemas/v0/calculator-response.ts
@@ -57,67 +57,6 @@ export const WEBSITE_CALCULATOR_RESPONSE_SCHEMA = {
     },
   },
   additionalProperties: false,
-  examples: [
-    {
-      is_under_80_ami: true,
-      is_under_150_ami: true,
-      is_over_150_ami: false,
-      pos_savings: 14000,
-      tax_savings: 6081,
-      performance_rebate_savings: 8000,
-      estimated_annual_savings: 1040,
-      pos_rebate_incentives: [
-        {
-          type: 'pos_rebate',
-          program: 'HEEHR',
-          program_es: 'HEEHR',
-          item: 'Electric Panel',
-          item_es: 'Cuadro eléctrico',
-          more_info_url: '/app/ira-calculator/information/electrical-panel',
-          more_info_url_es: '/app/ira-calculator/information/cuadro-electrico',
-          amount: 4000,
-          amount_type: 'dollar_amount',
-          representative_amount: null,
-          item_type: 'pos_rebate',
-          owner_status: [
-            'homeowner',
-          ],
-          ami_qualification: 'less_than_80_ami',
-          agi_max_limit: null,
-          filing_status: null,
-          start_date: 2023,
-          end_date: 2032,
-          eligible: true,
-        },
-      ],
-      tax_credit_incentives: [
-        {
-          type: 'tax_credit',
-          program: 'Residential Clean Energy Credit (25D)',
-          program_es: 'Crédito de energía limpia residencial (25D)',
-          item: 'Battery Storage Installation',
-          item_es: 'Instalación de baterías',
-          more_info_url:
-            '/app/ira-calculator/information/battery-storage-installation',
-          more_info_url_es:
-            '/app/ira-calculator/information/instalacion-de-baterias',
-          amount: 0.3,
-          amount_type: 'percent',
-          representative_amount: 4800,
-          item_type: 'tax_credit',
-          owner_status: [
-            'homeowner',
-          ],
-          ami_qualification: null,
-          agi_max_limit: null,
-          filing_status: null,
-          start_date: 2023,
-          end_date: 2032,
-          eligible: true,
-        },
-      ],
-    },
-  ],
 } as const;
 
 export type WebsiteCalculatorResponse = FromSchema<

--- a/src/schemas/v0/incentive.ts
+++ b/src/schemas/v0/incentive.ts
@@ -30,48 +30,40 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     },
     program: {
       type: 'string',
-      examples: [
-        'Residential Clean Energy Credit (25D)',
-      ],
+      description: 'The name of the incentive program, in English.',
     },
     program_es: {
       type: 'string',
-      examples: [
-        'Crédito de energía limpia residencial (25D)',
-      ],
+      description: 'The name of the incentive program, in Spanish.',
     },
     item: {
       type: 'string',
-      examples: [
-        'Battery Storage Installation',
-      ],
+      description:
+        'The equipment or project that this incentive is for, in English.',
     },
     item_es: {
       type: 'string',
-      examples: [
-        'Instalación de baterías',
-      ],
+      description:
+        'The equipment or project that this incentive is for, in Spanish.',
     },
     more_info_url: {
       type: 'string',
-      examples: [
-        'https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation',
-      ],
+      description:
+        'A URL to more information, in English, about the equipment or project.',
     },
     more_info_url_es: {
       type: 'string',
-      examples: [
-        'https://www.rewiringamerica.org/app/ira-calculator/information/instalacion-de-baterias',
-      ],
+      description:
+        'A URL to more information, in Spanish, about the equipment or project.',
     },
     amount: {
       type: 'number',
-      examples: [
-        4800,
-      ],
+      description:
+        'Depending on `amount_type`, either a dollar amount, or a number between 0 and 1 indicating a percentage.',
     },
     amount_type: {
       type: 'string',
+      description: 'The significance of the `amount` field.',
       enum: [
         'dollar_amount',
         'percent',
@@ -95,42 +87,37 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     },
     start_date: {
       type: 'number',
-      examples: [
-        2023,
-      ],
+      description:
+        'The four-digit year in which the incentive begins, or began, to be available.',
     },
     end_date: {
       type: 'number',
-      examples: [
-        2032,
-      ],
+      description:
+        'The four-digit year in which the incentive stops, or stopped, being available.',
     },
     special_note: {
       type: 'string',
-      examples: [
-        null,
-      ],
+      description: 'Not used.',
     },
     representative_amount: {
       type: 'number',
-      examples: [
-        4800,
-      ],
+      description: 'A dollar amount that this incentive is typically worth.',
     },
     ami_qualification: {
       type: 'string',
+      description:
+        'The income level required for this incentive, expressed as a percentage of Area Median Income (AMI).',
       nullable: true,
       enum: [...Object.values(AmiQualification), null],
     },
     agi_max_limit: {
       type: 'number',
-      examples: [
-        null,
-        150000,
-      ],
+      description:
+        'The maximum Adjusted Gross Income (AGI) to be eligible for this incentive.',
     },
     filing_status: {
       type: 'string',
+      description: 'Which tax filing statuses are eligible for this incentive.',
       nullable: true,
       enum: [...Object.values(FilingStatus), null],
     },
@@ -139,39 +126,11 @@ export const WEBSITE_INCENTIVE_SCHEMA = {
     },
     short_description: {
       type: 'string',
-      examples: [
+      description:
         'A 150 character (or shorter) display description for the incentive.',
-      ],
     },
   },
   additionalProperties: false,
-  examples: [
-    {
-      type: 'pos_rebate',
-      program: 'Energy Efficient Home Improvement Credit (25C)',
-      program_es:
-        'Crédito para la mejora de la eficiencia energética en el hogar (25C)',
-      item: 'Electric Panel',
-      item_es: 'Cuadro eléctrico',
-      more_info_url:
-        'https://rewiringamerica.org/app/ira-calculator/information/electrical-panel',
-      more_info_url_es:
-        'https://rewiringamerica.org/app/ira-calculator/information/cuadro-electrico',
-      amount: 4000,
-      amount_type: 'dollar_amount',
-      representative_amount: null,
-      item_type: 'pos_rebate',
-      owner_status: [
-        'homeowner',
-      ],
-      ami_qualification: 'less_than_80_ami',
-      agi_max_limit: null,
-      filing_status: null,
-      start_date: 2023,
-      end_date: 2032,
-      eligible: true,
-    },
-  ],
 } as const;
 
 export type WebsiteIncentive = FromSchema<typeof WEBSITE_INCENTIVE_SCHEMA>;

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -11,8 +11,7 @@ import {
 } from './location';
 import { API_SAVINGS_SCHEMA } from './savings';
 
-export const API_CALCULATOR_REQUEST_SCHEMA = {
-  $id: 'APICalculatorRequest',
+const API_CALCULATOR_REQUEST_SCHEMA = {
   title: 'APICalculatorRequest',
   type: 'object',
   properties: {
@@ -139,84 +138,17 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
     },
   },
   additionalProperties: false,
-  examples: [
-    {
-      is_under_80_ami: true,
-      is_under_150_ami: true,
-      is_over_150_ami: false,
-      savings: {
-        pos_rebate: 14000,
-        tax_credit: 6081,
-        performance_rebate: 8000,
-      },
-      incentives: [
-        {
-          type: 'pos_rebate',
-          program: 'HEEHR',
-          program_es: 'HEEHR',
-          item: 'Electric Panel',
-          item_es: 'Cuadro eléctrico',
-          more_info_url: '/app/ira-calculator/information/electrical-panel',
-          more_info_url_es: '/app/ira-calculator/information/cuadro-electrico',
-          amount: {
-            type: 'dollar_amount',
-            number: 4000,
-          },
-          item_type: 'pos_rebate',
-          owner_status: [
-            'homeowner',
-          ],
-          ami_qualification: 'less_than_80_ami',
-          agi_max_limit: null,
-          filing_status: null,
-          start_date: 2023,
-          end_date: 2032,
-          eligible: true,
-        },
-        {
-          type: 'tax_credit',
-          program: 'Residential Clean Energy Credit (25D)',
-          program_es: 'Crédito de energía limpia residencial (25D)',
-          item: 'Battery Storage Installation',
-          item_es: 'Instalación de baterías',
-          more_info_url:
-            '/app/ira-calculator/information/battery-storage-installation',
-          more_info_url_es:
-            '/app/ira-calculator/information/instalacion-de-baterias',
-          amount: {
-            type: 'percent',
-            number: 0.3,
-            representative: 4800,
-          },
-          item_type: 'tax_credit',
-          owner_status: [
-            'homeowner',
-          ],
-          ami_qualification: null,
-          agi_max_limit: null,
-          filing_status: null,
-          start_date: 2023,
-          end_date: 2032,
-          eligible: true,
-        },
-      ],
-    },
-  ],
 } as const;
 
 export const API_CALCULATOR_SCHEMA = {
   description:
     'How much money will your customer get with the Inflation Reduction Act?',
-  querystring: {
-    $ref: 'APICalculatorRequest',
-  },
+  querystring: API_CALCULATOR_REQUEST_SCHEMA,
   response: {
     200: {
-      description: 'Successful response',
       $ref: 'APICalculatorResponse',
     },
     400: {
-      description: 'Bad request',
       $ref: 'Error',
     },
   },

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -43,9 +43,6 @@ export const API_INCENTIVE_SCHEMA = {
     },
     program: {
       type: 'string',
-      examples: [
-        'Residential Clean Energy Credit (25D)',
-      ],
     },
     program_url: {
       type: 'string',
@@ -59,15 +56,9 @@ export const API_INCENTIVE_SCHEMA = {
         },
         name: {
           type: 'string',
-          examples: [
-            'Battery Storage Installation',
-          ],
         },
         url: {
           type: 'string',
-          examples: [
-            'https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation',
-          ],
         },
       },
       required: ['type', 'name', 'url'],
@@ -107,21 +98,12 @@ export const API_INCENTIVE_SCHEMA = {
     },
     start_date: {
       type: 'number',
-      examples: [
-        2023,
-      ],
     },
     end_date: {
       type: 'number',
-      examples: [
-        2032,
-      ],
     },
     special_note: {
       type: 'string',
-      examples: [
-        null,
-      ],
     },
     ami_qualification: {
       type: 'string',
@@ -131,10 +113,6 @@ export const API_INCENTIVE_SCHEMA = {
     agi_max_limit: {
       type: 'number',
       nullable: true,
-      examples: [
-        null,
-        150000,
-      ],
     },
     filing_status: {
       type: 'string',
@@ -146,42 +124,11 @@ export const API_INCENTIVE_SCHEMA = {
     },
     short_description: {
       type: 'string',
-      examples: [
+      description:
         'A 150 character (or shorter) display description for the incentive.',
-      ],
     },
   },
   additionalProperties: false,
-  examples: [
-    {
-      type: 'pos_rebate',
-      payment_methods: [
-        'pos_rebate',
-      ],
-      authority_type: 'federal',
-      program: 'Energy Efficient Home Improvement Credit (25C)',
-      item: 'Electric Panel',
-      item_url:
-        'https://rewiringamerica.org/app/ira-calculator/information/electrical-panel',
-      amount: {
-        type: 'dollars_per_unit',
-        number: 0.65,
-        unit: 'watt',
-        maximum: 5000,
-        representative: 3000,
-      },
-      item_type: 'pos_rebate',
-      owner_status: [
-        'homeowner',
-      ],
-      ami_qualification: 'less_than_80_ami',
-      agi_max_limit: null,
-      filing_status: null,
-      start_date: 2023,
-      end_date: 2032,
-      eligible: true,
-    },
-  ],
 } as const;
 
 export type APIIncentive = FromSchema<typeof API_INCENTIVE_SCHEMA>;

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -13,17 +13,11 @@ export const API_REQUEST_LOCATION_SCHEMA = {
         'Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.',
       maxLength: 5,
       minLength: 5,
-      examples: [
-        '80212',
-      ],
     },
     address: {
       type: 'string',
       description:
         "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
-      examples: [
-        '1109 N Highland St, Arlington VA',
-      ],
     },
   },
   oneOf: [

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -48,11 +48,9 @@ export const API_UTILITIES_SCHEMA = {
   },
   response: {
     200: {
-      description: 'Successful response',
       ...API_UTILITIES_RESPONSE_SCHEMA,
     },
     400: {
-      description: 'Bad request',
       $ref: 'Error',
     },
   },


### PR DESCRIPTION
## Description

The main problem was that almost nowhere we had an `"example"` field
is actually allowed to have it. OpenAPI 3 only allows them in a few
places:

- Parameters

- Headers

- "Media Type": that is, here:
  ```
  paths:
    /api/v0/calculator:
      get:
        responses:
	  200:
	    content:
	      application/json:
	        schema: ...
		examples: # here
  ```
  However, I haven't found a way to get `fastify-swagger` to put examples there.

https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json

For the most part I think getting rid of the examples is fine. Some of
them are trivial -- you don't need an example of a number between 1
and 8. None of the parameters are hard to understand.

The examples of entire incentives had gotten out of date because they
aren't checked. (JSON Schema doesn't actually require that `examples`
conform to the schema they're in; it's only "recommended".) I think
there's nonzero value in those, but we can define them in the Zuplo
config (maybe as part of some automation to keep the schemas in Zuplo
up to date?)

For the v0 incentive fields, instead of examples I wrote
`description`s. I didn't do that for v1 because I anticipate doing a
thorough pass over v1 when we start to open it up externally.

One other error was that you can't have any properties alongside a `$ref`.

## Test Plan

`curl http://localhost:3000/spec.json` and paste it into:

- https://validator.swagger.io/
- https://apitools.dev/swagger-parser/online/

and get no errors.

`yarn test`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206040063611968