### PR TITLE
Use parent ZCTA when available

### DIFF
--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -114,3 +114,12 @@ curl \
 &authority_types=utility\
 &utility=vt-burlington-electric-department" \
   | jq . > test/fixtures/v1-vt-05401-state-utility-lowincome.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=15289\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=joint\
+&household_size=4" \
+  | jq . > test/fixtures/v1-15289-homeowner-80000-joint-4.json

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -1,0 +1,517 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {},
+  "coverage": {
+    "state": null,
+    "utility": null
+  },
+  "location": {
+    "state": "PA"
+  },
+  "savings": {
+    "pos_rebate": 14000,
+    "tax_credit": 5836,
+    "performance_rebate": 4000,
+    "account_credit": 0,
+    "rebate": 0
+  },
+  "incentives": [
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 8000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "electric_panel",
+        "name": "Electric Panel",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 4000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%."
+    },
+    {
+      "type": "performance_rebate",
+      "payment_methods": [
+        "performance_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Efficiency Rebates (HOMES)",
+      "item": {
+        "type": "efficiency_rebates",
+        "name": "Efficiency Rebates",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/whole-home-energy-reduction-rebates"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 4000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "more_than_80_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "electric_wiring",
+        "name": "Electric Wiring",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-wiring"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2500
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1750
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1600
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "electric_stove",
+        "name": "Electric/Induction Stove",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 840
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Home Electrification and Appliance Rebates (HEEHR)",
+      "item": {
+        "type": "heat_pump_clothes_dryer",
+        "name": "Heat Pump Clothes Dryer",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 840
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": "less_than_150_ami",
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Residential Clean Energy Credit (25D)",
+      "item": {
+        "type": "battery_storage_installation",
+        "name": "Battery Storage Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 0.3,
+        "representative": 4800
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Residential Clean Energy Credit (25D)",
+      "item": {
+        "type": "geothermal_heating_installation",
+        "name": "Geothermal Heating Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 0.3,
+        "representative": 7200
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2022,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Residential Clean Energy Credit (25D)",
+      "item": {
+        "type": "rooftop_solar_installation",
+        "name": "Rooftop Solar Installation",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 0.3,
+        "representative": 4626
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2022,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Clean Vehicle Credit (30D)",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 7500
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": 300000,
+      "filing_status": "joint",
+      "eligible": true,
+      "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Credit for Previously-Owned Clean Vehicles (25E)",
+      "item": {
+        "type": "used_electric_vehicle",
+        "name": "Used Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 4000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": 150000,
+      "filing_status": "joint",
+      "eligible": true,
+      "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1200
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows, and energy audits. Yearly reset."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Alternative Fuel Vehicle Refueling Property Credit (30C)",
+      "item": {
+        "type": "electric_vehicle_charger",
+        "name": "Electric Vehicle Charger",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities."
+    },
+    {
+      "type": "tax_credit",
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "item": {
+        "type": "electric_panel",
+        "name": "Electric Panel",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 600
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2032,
+      "ami_qualification": null,
+      "agi_max_limit": null,
+      "filing_status": null,
+      "eligible": true,
+      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
+    }
+  ]
+}

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -259,8 +259,10 @@ test('non-existent zips', async t => {
   t.equal(calculatorResponse.field, 'zip');
 });
 
-test('existing zips without data', async t => {
+test('zips with parent ZCTA', async t => {
   const res = await getCalculatorResponse(t, {
+    // This ZIP doesn't correspond to physical land area, but its parent ZCTA
+    // is 85014, which does.
     zip: '85011',
     owner_status: 'homeowner',
     household_income: 0,
@@ -268,14 +270,9 @@ test('existing zips without data', async t => {
     tax_filing: 'single',
   });
   const calculatorResponse = JSON.parse(res.payload);
-  t.equal(res.statusCode, 404, 'response status is 404');
-  t.equal(calculatorResponse.statusCode, 404, 'payload statusCode is 404');
-  t.equal(calculatorResponse.error, 'Not Found', 'payload error is Not Found');
-  t.equal(
-    calculatorResponse.message,
-    "We currently don't have data for that location.",
-  );
-  t.equal(calculatorResponse.field, 'zip');
+  t.equal(res.statusCode, 200, 'response status is 200');
+  t.equal(calculatorResponse.pos_rebate_incentives.length, 8);
+  t.equal(calculatorResponse.tax_credit_incentives.length, 10);
 });
 
 const ESTIMATION_TESTS = [

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -68,6 +68,22 @@ test('response is valid and correct', async t => {
   );
 });
 
+test('parent ZCTA is used', async t => {
+  await validateResponse(
+    t,
+    {
+      // This does not correspond to physical land area, but its parent ZCTA
+      // is 15213, which does.
+      location: { zip: '15289' },
+      owner_status: 'homeowner',
+      household_income: 80000,
+      tax_filing: 'joint',
+      household_size: 4,
+    },
+    './test/fixtures/v1-15289-homeowner-80000-joint-4.json',
+  );
+});
+
 test('response with state and utility is valid and correct', async t => {
   await validateResponse(
     t,
@@ -391,8 +407,8 @@ test('bad queries', async t => {
 });
 
 const BAD_ZIPS = [
-  // Exists, but is not a ZCTA and has no AMI data
-  '02117',
+  // Exists, but is not a ZCTA and has no parent ZCTA
+  '96669',
   // Does not exist
   '80088',
 ];


### PR DESCRIPTION
## Description

The distinction between ZIPs that are ZCTAs and ZIPs that aren't keeps
confusing internal testers, and it's a decent bet that external users
have gotten bit by this too.

The `location` field in the v1 response doesn't currently contain a
ZIP, but there's an opportunity here to return the ZIP we used for
calculations in case it differs from the one the user entered. I don't
feel very strongly about this, and I think maybe it could stand to
wait until we add a more thought-out "showing our work" feature.

https://app.asana.com/0/1204738794846444/1205397060691934

## Test Plan

New and updated tests.
