### PR TITLE
Small tweaks to spreadsheet_to_json from CO review.

### DIFF
--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -69,6 +69,7 @@ export function createProgramName(
     state.toLowerCase() +
     '_' +
     lowerCamelCase(authorityName.replaceAll('.', '')) +
+    '_' +
     lowerCamelCase(programName.replaceAll('.', ''))
   );
 }

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -65,7 +65,7 @@ export const VALUE_MAPPINGS = {
     'Heat Pump Dryers / clothes dryer': 'heat_pump_clothes_dryer',
     'Electric Stove': 'electric_stove',
     'Weatherization (insulation and air sealing)': 'weatherization',
-    'Electric wiring': 'weatherization',
+    'Electric wiring': 'electric_panel',
     'Electric panel': 'electric_panel',
     'Electric lawn equipment (mower, edger, leaf blower, weedwhacker)':
       'electric_outdoor_equipment',

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -79,7 +79,7 @@ export class SpreadsheetStandardizer {
       amount: createAmount(record),
       owner_status: findOwnerStatus(record.owner_status),
       short_description: {
-        en: record.program_description,
+        en: standardizeDescription(record.program_description),
       },
     };
     if (record.program_start !== undefined && record.program_start !== '') {
@@ -92,7 +92,7 @@ export class SpreadsheetStandardizer {
       record.bonus_description !== undefined &&
       record.bonus_description !== ''
     ) {
-      output.bonus_description = true;
+      output.bonus_available = true;
     }
 
     return output;
@@ -112,6 +112,14 @@ function cleanFieldName(field: string): string {
     .replace(wordSeparators, '')
     .trim()
     .toLowerCase();
+}
+
+function standardizeDescription(desc: string): string {
+  desc = desc.replace('\n', '').trim();
+  if (!desc.endsWith('.')) {
+    desc = desc + '.';
+  }
+  return desc;
 }
 
 // Take an input map from string -> string[] and reverse it,

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -5,7 +5,7 @@ import { SpreadsheetStandardizer } from '../../scripts/lib/spreadsheet-standardi
 test('correct row to record transformation', async tap => {
   const testCases: {
     input: Record<string, string>;
-    want: Record<string, string | number | object>;
+    want: Record<string, string | number | object | boolean>;
   }[] = [
     {
       input: {
@@ -19,7 +19,7 @@ test('correct row to record transformation', async tap => {
         'Technology*': 'Heat Pump Dryers / Clothes Dryer',
         "Technology (If selected 'Other')": '',
         'Program Description (guideline)':
-          'Receive a $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
+          'Receive a $50 rebate for an Energy Star certified electric ventless\n or vented clothes dryer from an approved retailer',
         'Program Status': 'Active',
         'Program Start (MM/DD/YYYY)': '1/1/2022',
         'Program End (MM/DD/YYYY)': '12/31/2026',
@@ -31,7 +31,7 @@ test('correct row to record transformation', async tap => {
         'Amount Minimum': '',
         'Amount Maximum': '',
         'Amount Representative (only for average values)': '',
-        'Bonus Description': '',
+        'Bonus Description': 'Here is some bonus information',
         'Equipment Standards Restrictions': 'Must be ENERGY STAR certified.',
         'Equipment Capacity Restrictions': '',
         'Contractor Restrictions': '',
@@ -51,7 +51,7 @@ test('correct row to record transformation', async tap => {
         item: 'heat_pump_clothes_dryer',
         payment_methods: ['rebate'],
         program:
-          'va_appalachianPowertakeChargeVirginiaEfficientProductsProgram',
+          'va_appalachianPower_takeChargeVirginiaEfficientProductsProgram',
         amount: {
           type: 'dollar_amount',
           number: 50,
@@ -64,6 +64,7 @@ test('correct row to record transformation', async tap => {
         },
         start_date: 2022,
         end_date: 2026,
+        bonus_available: true,
       },
     },
   ];


### PR DESCRIPTION
- put an underscore between authority and program in program names for better readability and because otherwise, the camelcasing is wrong
- correct some easy user errors in program descriptions
- fix incorrect electrical wiring mapping
- fix incorrect name of bonus_available column