### PR TITLE
Add editorial notes column and better devex for writing outputs.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,8 +42,6 @@ It's recommended to also define low-income thresholds in `data/low_income_thresh
 
 1. `incentive-spreadsheet-to-json.js` reads the spreadsheet and tries to convert it to JSON. This can be a messy process – spreadsheets may not have the correct column names or values. The script tries to handle small string discrepancies itself because making edits to Google sheets has a 5-minute delay before changes are reflected, but ultimately even with the script's help, this may be a painstaking process.
 
-Make a state directory under `/data` to store the JSON if not already done, then:
-
 Usage:
 `node build/scripts/incentive-spreadsheet-to-json.js --strict CO`
 

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -3,6 +3,7 @@ import { parse } from 'csv-parse/sync';
 import fs from 'fs';
 import fetch from 'make-fetch-happen';
 import minimist from 'minimist';
+import path from 'path';
 
 import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../src/data/low_income_thresholds';
 import { STATE_SCHEMA, StateIncentive } from '../src/data/state_incentives';
@@ -53,16 +54,26 @@ async function convertToJson(
     }
   });
 
+  const dir = path.dirname(file.filepath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
   fs.writeFileSync(
     file.filepath,
     JSON.stringify(jsons, null, 2) + '\n', // include newline to satisfy prettier
     'utf-8',
   );
-  fs.writeFileSync(
-    file.filepath.replace('.json', '_invalid.json'),
-    JSON.stringify(invalids, null, 2) + '\n', // include newline to satisfy prettier
-    'utf-8',
-  );
+  const invalidsFilePath = file.filepath.replace('.json', '_invalid.json');
+  if (invalids.length === 0) {
+    if (fs.existsSync(invalidsFilePath)) {
+      // Clear any previous versions if we have no invalid records.
+      fs.unlinkSync(invalidsFilePath);
+    }
+  } else {
+    fs.writeFileSync(
+      invalidsFilePath,
+      JSON.stringify(invalids, null, 2) + '\n', // include newline to satisfy prettier
+      'utf-8',
+    );
+  }
 }
 
 (async function () {

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -30,6 +30,7 @@ export const FIELD_MAPPINGS: { [index: string]: string[] } = {
   other_restrictions: ['Other Restrictions'],
   stacking_details: ['Stacking Details'],
   financing_details: ['Financing Details'],
+  editorial_notes: ['Editorial Notes'],
 };
 
 // Note: this is from alias to canonical name, which is the reverse of

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -30,6 +30,8 @@ export const FIELD_MAPPINGS: { [index: string]: string[] } = {
   other_restrictions: ['Other Restrictions'],
   stacking_details: ['Stacking Details'],
   financing_details: ['Financing Details'],
+  // This contains notes about why we might not serve a record in the API.
+  // It may not appear in all spreadsheets.
   editorial_notes: ['Editorial Notes'],
 };
 


### PR DESCRIPTION
- make state directory if it doesn't exist
- don't write the invalid records if there aren't any, and clear out previous versions if there are
- add an editorial notes column to the mapping, which we added to Colorado to document records that we don't intend to ever show (open to suggestions for a different name). This won't affect existing spreadsheets without this column.