### PR TITLE
Strengthen cleaning column names

### DIFF
--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -13,7 +13,7 @@ const PROGRAMS_JSON_FILE = 'data/programs.json';
 const AUTHORITIES_JSON_FILE = 'data/authorities.json';
 
 const wordSeparators =
-  /[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]+/;
+  /[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]+/g;
 const capital_plus_lower = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD][a-zà-ÿ]/g;
 const capitals = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD]+/g;
 

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -131,14 +131,16 @@ export class SpreadsheetStandardizer {
 ///////////
 //  Helpers
 ///////////
-const wordSeparators =
-  /[\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]+/;
+const punctuationSeparators =
+  /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]+/g;
+const spaceSeparators = /\s+/g;
 
 function cleanFieldName(field: string): string {
   return field
-    .replace('\n', '')
-    .replace('*', '')
-    .replace(wordSeparators, '')
+    .replace('\n', ' ')
+    .replace('*', ' ')
+    .replace(punctuationSeparators, ' ')
+    .replace(spaceSeparators, ' ')
     .trim()
     .toLowerCase();
 }


### PR DESCRIPTION
Make cleaning of program names more robust by replacing all punctuation with spaces, then trimming all but one single space. This matches many more column names and prevents us from doing more special casing based on unique ways of formatting.

Tested by running the compiled script on Rhode Island which currently has some formats that were previously unsupported.