### PR TITLE
Add concept of permanently ineligible incentives

### DIFF
--- a/src/lib/incentive-relationship-calculation.ts
+++ b/src/lib/incentive-relationship-calculation.ts
@@ -4,6 +4,7 @@ import { StateIncentive } from '../data/state_incentives';
 export interface RelationshipMaps {
   eligibleIncentives: Map<string, StateIncentive>;
   ineligibleIncentives: Map<string, StateIncentive>;
+  permanentlyIneligibleIncentives: Set<string>;
   requiresMap: Map<string, Set<string>>;
   requiredByMap: Map<string, Set<string>>;
   supersedesMap: Map<string, Set<string>>;
@@ -149,6 +150,7 @@ export function makeIneligible(incentiveId: string, maps: RelationshipMaps) {
     for (const dependentId of maps.supersedesMap.get(incentiveId)!) {
       if (
         maps.ineligibleIncentives.has(dependentId) &&
+        !maps.permanentlyIneligibleIncentives.has(dependentId) &&
         !isExcluded(dependentId, maps) &&
         meetsPrerequisites(dependentId, maps)
       ) {
@@ -172,6 +174,7 @@ export function makeEligible(incentiveId: string, maps: RelationshipMaps) {
     for (const dependentId of maps.requiredByMap.get(incentiveId)!) {
       if (
         maps.ineligibleIncentives.has(dependentId) &&
+        !maps.permanentlyIneligibleIncentives.has(dependentId) &&
         !isExcluded(dependentId, maps) &&
         meetsPrerequisites(dependentId, maps)
       ) {

--- a/src/lib/incentive-relationship-calculation.ts
+++ b/src/lib/incentive-relationship-calculation.ts
@@ -150,7 +150,6 @@ export function makeIneligible(incentiveId: string, maps: RelationshipMaps) {
     for (const dependentId of maps.supersedesMap.get(incentiveId)!) {
       if (
         maps.ineligibleIncentives.has(dependentId) &&
-        !maps.permanentlyIneligibleIncentives.has(dependentId) &&
         !isExcluded(dependentId, maps) &&
         meetsPrerequisites(dependentId, maps)
       ) {
@@ -162,6 +161,9 @@ export function makeIneligible(incentiveId: string, maps: RelationshipMaps) {
 
 // Switches an incentive from ineligible to eligible and checks dependents.
 export function makeEligible(incentiveId: string, maps: RelationshipMaps) {
+  if (maps.permanentlyIneligibleIncentives.has(incentiveId)) {
+    return;
+  }
   const incentive = maps.ineligibleIncentives.get(incentiveId);
   if (incentive === undefined) {
     return;
@@ -174,7 +176,6 @@ export function makeEligible(incentiveId: string, maps: RelationshipMaps) {
     for (const dependentId of maps.requiredByMap.get(incentiveId)!) {
       if (
         maps.ineligibleIncentives.has(dependentId) &&
-        !maps.permanentlyIneligibleIncentives.has(dependentId) &&
         !isExcluded(dependentId, maps) &&
         meetsPrerequisites(dependentId, maps)
       ) {

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -158,6 +158,9 @@ export function calculateStateIncentivesAndSavings(
     const maps: RelationshipMaps = {
       eligibleIncentives: eligibleIncentives,
       ineligibleIncentives: ineligibleIncentives,
+      // Any incentives which were ineligible before checking relationships
+      // must remain ineligible.
+      permanentlyIneligibleIncentives: new Set(ineligibleIncentives.keys()),
       requiresMap: prerequisiteMaps.requiresMap,
       requiredByMap: prerequisiteMaps.requiredByMap,
       supersedesMap: exclusionMaps.supersedesMap,

--- a/test/fixtures/test-incentives.json
+++ b/test/fixtures/test-incentives.json
@@ -35,6 +35,7 @@
       "homeowner",
       "renter"
     ],
+    "agi_max_limit": 130000,
     "short_description": {
       "en": "This is a model incentive only to be used for testing."
     }

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -147,7 +147,7 @@ test('test incentive relationship and combined max value logic', async t => {
     'RI',
     {
       owner_status: OwnerStatus.Renter,
-      household_income: 120000,
+      household_income: 90000,
       tax_filing: FilingStatus.Single,
       household_size: 1,
       authority_types: [AuthorityType.Utility],
@@ -157,6 +157,7 @@ test('test incentive relationship and combined max value logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
   );
+
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
   // There is a combined max value of $200 for A, B, C, D, E, and F.
@@ -165,7 +166,49 @@ test('test incentive relationship and combined max value logic', async t => {
     if (['B', 'E', 'F'].includes(incentive.id)) {
       t.equal(incentive.eligible, true);
     }
-    if (['A', 'C'].includes(incentive.id)) {
+    if (['A', 'C', 'D'].includes(incentive.id)) {
+      t.equal(incentive.eligible, false);
+    }
+  }
+});
+
+// Same as above except for income.
+// This user is a renter with an income of 140k. Based on this, they are
+// eligible for incentives A, C, E, and F (their income is too high for B).
+// However, eligibility for several incentives is affected by relationships:
+// 1) Since E and C are mutually exclusive and E supersedes C, they are not
+//    eligible for C after checking relationships.
+// 2) Since C is a prerequisite for A and they are not eligible for C, they are
+//    not eligible for A either.
+// 3) A and B and mutually exclusive and A supersedes B, but the user is not
+//    eligible for A. However, despire this, they cannot become eligible for B
+//    because their income is still too high.
+// 4) F is not affected by the relationships, so they are eligible for F.
+test('test incentive relationship and permanent ineligibility criteria', async t => {
+  const data = calculateStateIncentivesAndSavings(
+    'RI',
+    {
+      owner_status: OwnerStatus.Renter,
+      household_income: 140000,
+      tax_filing: FilingStatus.Single,
+      household_size: 1,
+      authority_types: [AuthorityType.Utility],
+      utility: 'ri-pascoag-utility-district',
+      include_beta_states: true,
+    },
+    TEST_INCENTIVES,
+    TEST_INCENTIVE_RELATIONSHIPS_3,
+  );
+
+  t.ok(data);
+  t.equal(data.stateIncentives.length, 6);
+  // There is a combined max value of $200 for A, B, C, D, E, and F.
+  t.equal(data.savings.account_credit, 200);
+  for (const incentive of data.stateIncentives) {
+    if (['E', 'F'].includes(incentive.id)) {
+      t.equal(incentive.eligible, true);
+    }
+    if (['A', 'B', 'C', 'D'].includes(incentive.id)) {
       t.equal(incentive.eligible, false);
     }
   }

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -147,7 +147,7 @@ test('test incentive relationship and combined max value logic', async t => {
     'RI',
     {
       owner_status: OwnerStatus.Renter,
-      household_income: 90000,
+      household_income: 120000,
       tax_filing: FilingStatus.Single,
       household_size: 1,
       authority_types: [AuthorityType.Utility],
@@ -157,7 +157,6 @@ test('test incentive relationship and combined max value logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
   );
-
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
   // There is a combined max value of $200 for A, B, C, D, E, and F.
@@ -181,8 +180,8 @@ test('test incentive relationship and combined max value logic', async t => {
 // 2) Since C is a prerequisite for A and they are not eligible for C, they are
 //    not eligible for A either.
 // 3) A and B and mutually exclusive and A supersedes B, but the user is not
-//    eligible for A. However, despire this, they cannot become eligible for B
-//    because their income is still too high.
+//    eligible for A. However, despite this, they cannot become eligible for B
+//    because their income was too high.
 // 4) F is not affected by the relationships, so they are eligible for F.
 test('test incentive relationship and permanent ineligibility criteria', async t => {
   const data = calculateStateIncentivesAndSavings(


### PR DESCRIPTION
 If an incentive was marked as ineligible before relationships were checked (e.g. due to income, owner status, etc), the relationships logic should not be allowed to mark it as eligible.

**Test plan**
Added a unit test for a case where an income-ineligible incentive would have been accidentally marked as eligible by the relationships logic previously.