### PR TITLE
Adding EV incentives for CT based on testing feedback

### DIFF
--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -256,7 +256,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebate off a qualifying heat pump system, dependent on size. Typical heat pump installations will receive approximately $900."
+      "en": "Rebate for a qualifying heat pump system, dependent on size. Typical heat pump installations will receive approximately $900."
     },
     "start_date": 2023,
     "end_date": 2023
@@ -281,7 +281,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Size dependent rebate off the installation of a heat pump replacing oil or gas, up to $20,000. Obtain pre-approval from NPU before installation."
+      "en": "Size dependent rebate for installation of an air source heat pump replacing oil or gas, up to $20,000. Obtain pre-approval from NPU beforehand."
     },
     "start_date": 2023,
     "end_date": 2023
@@ -427,7 +427,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $1,200 per ton off qualifying ground source heat pumps, up to $20,000."
+      "en": "Size dependent rebate for qualifying ground source heat pumps, up to $20,000."
     },
     "start_date": 2023,
     "end_date": 2023
@@ -523,5 +523,145 @@
     },
     "start_date": 2023,
     "end_date": 2024
+  },
+  {
+    "id": "CT-29",
+    "authority_type": "utility",
+    "authority": "ct-norwich-public-utilities",
+    "type": "rebate",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "new_electric_vehicle",
+    "program": "ct_electricVehicleAndChargingRebateProgram",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1500
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "Rebate up to $1,500 for purchasing a new EV (model year 2020 or newer). Can be combined with federal, state, or manufacturer incentives."
+    },
+    "start_date": 2024,
+    "end_date": 2024
+  },
+  {
+    "id": "CT-30",
+    "authority_type": "utility",
+    "authority": "ct-norwich-public-utilities",
+    "type": "rebate",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "used_electric_vehicle",
+    "program": "ct_electricVehicleAndChargingRebateProgram",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1000
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "Rebate up to $1,000 for purchasing a used EV (model year 2019 or newer). Can be combined with federal, state, or manufacturer incentives."
+    },
+    "start_date": 2024,
+    "end_date": 2024
+  },
+  {
+    "id": "CT-31",
+    "authority_type": "utility",
+    "authority": "ct-norwich-public-utilities",
+    "type": "rebate",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "electric_vehicle_charger",
+    "program": "ct_electricVehicleAndChargingRebateProgram",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$1,000 rebate for purchasing a residential use Level 2 EVSE. Must apply within 60 days of installation."
+    },
+    "start_date": 2024,
+    "end_date": 2024
+  },
+  {
+    "id": "CT-32",
+    "authority_type": "state",
+    "authority": "ct-deep",
+    "type": "pos_rebate",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "item": "new_electric_vehicle",
+    "program": "ct_cheapr",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2250
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$2,250 rebate for a qualifying new electric vehicle."
+    }
+  },
+  {
+    "id": "CT-33",
+    "authority_type": "state",
+    "authority": "ct-deep",
+    "type": "pos_rebate",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "item": "new_electric_vehicle",
+    "program": "ct_cheapr",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2000
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "low_income": "ct-cheapr",
+    "short_description": {
+      "en": "Bonus $2,000 off a qualifying new electric vehicle for income-eligible individuals."
+    }
+  },
+  {
+    "id": "CT-34",
+    "authority_type": "state",
+    "authority": "ct-deep",
+    "type": "pos_rebate",
+    "payment_methods": [
+      "pos_rebate",
+      "rebate"
+    ],
+    "item": "used_electric_vehicle",
+    "program": "ct_cheapr",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 3000
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "low_income": "ct-cheapr",
+    "short_description": {
+      "en": "$3,000 rebate for a qualifying used electric vehicle for income-qualifying individuals."
+    }
   }
 ]

--- a/data/authorities.json
+++ b/data/authorities.json
@@ -148,7 +148,11 @@
     }
   },
   "CT": {
-    "state": {},
+    "state": {
+      "ct-deep": {
+        "name": "CT Department of Energy & Environmental Protection"
+      }
+    },
     "local": {},
     "utility": {
       "ct-eversource": {

--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -139,6 +139,19 @@
         "7": 103227,
         "8": 105521
       }
+    },
+    "ct-cheapr": {
+      "source_url": "https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines",
+      "thresholds": {
+        "1": 45180,
+        "2": 61320,
+        "3": 77460,
+        "4": 93600,
+        "5": 109740,
+        "6": 125880,
+        "7": 142020,
+        "8": 158160
+      }
     }
   },
   "NY": {

--- a/data/programs.json
+++ b/data/programs.json
@@ -561,6 +561,14 @@
       "en": "https://www.ywelectric.coop/rebate-program-information"
     }
   },
+  "ct_cheapr": {
+    "name": {
+      "en": "Connecticut Hydrogen and Electric Automobile Purchase Rebate"
+    },
+    "url": {
+      "en": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home"
+    }
+  },
   "ct_energizeCtHomeEnergySolutions": {
     "name": {
       "en": "Energize CT Home Energy Solutions"
@@ -623,6 +631,14 @@
     },
     "url": {
       "en": "https://norwichpublicutilities.com/residential/chipp"
+    }
+  },
+  "ct_electricVehicleAndChargingRebateProgram": {
+    "name": {
+      "en": "Electric Vehicle & Charging Rebate Program"
+    },
+    "url": {
+      "en": "https://norwichpublicutilities.com/residential/electric-vehicle-charging-rebate-program"
     }
   },
   "ct_residentialGroundSourceHeatPumpIncentive": {

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -126,6 +126,8 @@ export const ALL_PROGRAMS = [
   'co_yWElectricAssociation_rebateProgram',
 
   // CT
+  // State
+  'ct_cheapr',
   // Energize CT
   'ct_energizeCtHomeEnergySolutions',
   'ct_residentialAirSourceHeatPumpIncentive',
@@ -141,6 +143,7 @@ export const ALL_PROGRAMS = [
   'ct_wallOrAtticInsulationProgram',
   'ct_coolChoiceProgram',
   'ct_coolingAndHeatingIncentivePilotProgram',
+  'ct_electricVehicleAndChargingRebateProgram',
 
   // NY
   // State or State + Utility:

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -126,7 +126,7 @@ export const ALL_PROGRAMS = [
   'co_yWElectricAssociation_rebateProgram',
 
   // CT
-  // State
+  // State: DEEP
   'ct_cheapr',
   // Energize CT
   'ct_energizeCtHomeEnergySolutions',

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -5,6 +5,9 @@
   "authorities": {
     "ct-eversource": {
       "name": "Eversource"
+    },
+    "ct-deep": {
+      "name": "CT Department of Energy & Environmental Protection"
     }
   },
   "coverage": {
@@ -15,7 +18,7 @@
     "state": "CT"
   },
   "savings": {
-    "pos_rebate": 0,
+    "pos_rebate": 7250,
     "tax_credit": 0,
     "performance_rebate": 0,
     "account_credit": 0,
@@ -49,6 +52,91 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "The Home Energy Solutions program provides income-eligible households with no-cost energy assessments and incentives for weatherization services."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate",
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "ct-deep",
+      "program": "Connecticut Hydrogen and Electric Automobile Purchase Rebate",
+      "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
+      "item": {
+        "type": "used_electric_vehicle",
+        "name": "Used Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 3000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$3,000 rebate for a qualifying used electric vehicle for income-qualifying individuals."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "state",
+      "authority": "ct-deep",
+      "program": "Connecticut Hydrogen and Electric Automobile Purchase Rebate",
+      "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2250
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$2,250 rebate for a qualifying new electric vehicle."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "state",
+      "authority": "ct-deep",
+      "program": "Connecticut Hydrogen and Electric Automobile Purchase Rebate",
+      "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "Bonus $2,000 off a qualifying new electric vehicle for income-eligible individuals."
     },
     {
       "type": "rebate",


### PR DESCRIPTION
Also fixed the wording of some descriptions to better differentiate between the incentives, as suggested by testing feedback.

**Test Plan**
Updated the low income test fixture since they are now eligible for the new EV incentives as well.