### PR TITLE
Add incentives missed by JSON script

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -64,6 +64,48 @@
     }
   },
   {
+    "id": "AZ-5",
+    "authority_type": "utility",
+    "authority": "az-mohave-electric-cooperative",
+    "type": "rebate",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "rooftop_solar_installation",
+    "item_type": "rebate",
+    "program": "az_mohaveElectricCooperativeSunWattsRenewableEnergyAndRebateProgram",
+    "amount": {
+      "type": "dollars_per_unit",
+      "unit": "watt",
+      "number": 0.05,
+      "maximum": 2500
+    },
+    "owner_status": ["homeowner"],
+    "short_description": {
+      "en": "Rebate up to $2500 for residential photovoltaic and wind system installation."
+    }
+  },
+  {
+    "id": "AZ-6",
+    "authority_type": "utility",
+    "authority": "az-mohave-electric-cooperative",
+    "type": "rebate",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "battery_storage",
+    "item_type": "rebate",
+    "program": "az_mohaveElectricCooperativeMohaveHeatBatteryRebate",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 500
+    },
+    "owner_status": ["homeowner"],
+    "short_description": {
+      "en": "Rebate of $500 for each minimum usable capacity battery unit of 5 kWh, installed on or after Jan 9, 2022."
+    }
+  },
+  {
     "id": "AZ-7",
     "authority_type": "utility",
     "authority": "az-salt-river-project",
@@ -226,5 +268,66 @@
     },
     "start_date": 2023,
     "end_date": 2023
+  },
+  {
+    "id": "AZ-21",
+    "authority_type": "utility",
+    "authority": "az-uni-source-energy-services",
+    "type": "pos_rebate",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "item": "weatherization",
+    "item_type": "assistance_program",
+    "program": "az_uniSourceEnergyServicesWeatherizationAssistance",
+    "amount": {
+      "type": "percent",
+      "number": 1
+    },
+    "owner_status": ["homeowner"],
+    "short_description": {
+      "en": "Assistance available for energy efficient retrofitting to homes of income-qualifying customers."
+    },
+    "low_income": "default"
+  },
+  {
+    "id": "AZ-22",
+    "authority_type": "utility",
+    "authority": "az-uni-source-energy-services",
+    "type": "pos_rebate",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "item_type": "pos_rebate",
+    "program": "az_uniSourceEnergyServicesEfficientHomeProgram",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 900
+    },
+    "owner_status": ["homeowner"],
+    "short_description": {
+      "en": "Up to $900 rebate for retiring an existing, qualified system and installing an Energy Star heat pump/AC purchase via a qualified contractor."
+    }
+  },
+  {
+    "id": "AZ-23",
+    "authority_type": "utility",
+    "authority": "az-uni-source-energy-services",
+    "type": "pos_rebate",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "item_type": "pos_rebate",
+    "program": "az_uniSourceEnergyServicesEfficientHomeProgram",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 650
+    },
+    "owner_status": ["homeowner"],
+    "short_description": {
+      "en": "Up to $650 rebate for an Energy Star heat pump/AC purchase and installation through a qualified contractor."
+    }
   }
 ]

--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -273,9 +273,9 @@
     "id": "AZ-21",
     "authority_type": "utility",
     "authority": "az-uni-source-energy-services",
-    "type": "pos_rebate",
+    "type": "assistance_program",
     "payment_methods": [
-      "pos_rebate"
+      "assistance_program"
     ],
     "item": "weatherization",
     "item_type": "assistance_program",

--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -93,7 +93,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "item": "battery_storage",
+    "item": "battery_storage_installation",
     "item_type": "rebate",
     "program": "az_mohaveElectricCooperativeMohaveHeatBatteryRebate",
     "amount": {

--- a/data/programs.json
+++ b/data/programs.json
@@ -57,7 +57,7 @@
       "en": "https://www.mohaveelectric.com/energy-solutions/rebates/heat-pump-rebate/"
     }
   },
-  "az_mohaveElectricCooperativesunWattsRenewableEnergyAndRebateProgram": {
+  "az_mohaveElectricCooperativeSunWattsRenewableEnergyAndRebateProgram": {
     "name": {
       "en": "SunWatts Renewable Energy and Rebate Program"
     },
@@ -111,6 +111,14 @@
     },
     "url": {
       "en": "https://www.ssvec.org/programs/rebates.php"
+    }
+  },
+  "az_sunWattsRenewableEnergyAndRebateProgram": {
+    "name": {
+      "en": "SunWatts Renewable Energy and Rebate Program"
+    },
+    "url": {
+      "en": "https://www.mohaveelectric.com/energy-solutions/renewable-energy/sunwatts-renewable-energy-program"
     }
   },
   "az_tucsonElectricPowerEfficientHomeProgram": {

--- a/data/programs.json
+++ b/data/programs.json
@@ -113,14 +113,6 @@
       "en": "https://www.ssvec.org/programs/rebates.php"
     }
   },
-  "az_sunWattsRenewableEnergyAndRebateProgram": {
-    "name": {
-      "en": "SunWatts Renewable Energy and Rebate Program"
-    },
-    "url": {
-      "en": "https://www.mohaveelectric.com/energy-solutions/renewable-energy/sunwatts-renewable-energy-program"
-    }
-  },
   "az_tucsonElectricPowerEfficientHomeProgram": {
     "name": {
       "en": "Efficient Home Program"

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -60,6 +60,20 @@ curl \
 &utility=az-tucson-electric-power" \
   | jq . > test/fixtures/v1-az-85701-state-utility-lowincome.json
 
+# TODO: Remove beta states argument when AZ is fully launched.
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=85701\
+&include_beta_states=true\
+&owner_status=homeowner\
+&household_income=28000\
+&tax_filing=joint\
+&household_size=1\
+&authority_types=state\
+&authority_types=utility\
+&utility=az-uni-source-energy-services" \
+  | jq . > test/fixtures/v1-az-85702-state-utility-lowincome.json
+
 # TODO: Remove beta states argument when CT is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -63,7 +63,7 @@ curl \
 # TODO: Remove beta states argument when AZ is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=85701\
+?location\[zip\]=85702\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=28000\

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -15,7 +15,7 @@ export const ALL_PROGRAMS = [
   // Mohave Electric Cooperative
   'az_mohaveElectricCooperativeMohaveChargedRebates',
   'az_mohaveElectricCooperativeMohaveHeatPumpRebate',
-  'az_mohaveElectricCooperativesunWattsRenewableEnergyAndRebateProgram',
+  'az_mohaveElectricCooperativeSunWattsRenewableEnergyAndRebateProgram',
   'az_mohaveElectricCooperativeMohaveHeatBatteryRebate',
   // Salt River Project
   'az_saltRiverProjectInsulationRebate',

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -1,0 +1,107 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "az-uni-source-energy-services": {
+      "name": "UniSource Energy Services"
+    }
+  },
+  "coverage": {
+    "state": "AZ",
+    "utility": "az-uni-source-energy-services"
+  },
+  "location": {
+    "state": "AZ"
+  },
+  "savings": {
+    "pos_rebate": 1550,
+    "tax_credit": 0,
+    "performance_rebate": 0,
+    "account_credit": 0,
+    "rebate": 0
+  },
+  "incentives": [
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "az-uni-source-energy-services",
+      "program": "Weatherization assistance",
+      "program_url": "https://www.uesaz.com/weatherization-assistance/",
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 1
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "Assistance available for energy efficient retrofitting to homes of income-qualifying customers."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "az-uni-source-energy-services",
+      "program": "Efficient Home Program",
+      "program_url": "https://www.uesaz.com/efficient-home-program/",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 900
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "Up to $900 rebate for retiring an existing, qualified system and installing an Energy Star heat pump/AC purchase via a qualified contractor."
+    },
+    {
+      "type": "pos_rebate",
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "az-uni-source-energy-services",
+      "program": "Efficient Home Program",
+      "program_url": "https://www.uesaz.com/efficient-home-program/",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 650
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "Up to $650 rebate for an Energy Star heat pump/AC purchase and installation through a qualified contractor."
+    }
+  ]
+}

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -23,9 +23,9 @@
   },
   "incentives": [
     {
-      "type": "pos_rebate",
+      "type": "assistance_program",
       "payment_methods": [
-        "pos_rebate"
+        "assistance_program"
       ],
       "authority_type": "utility",
       "authority": "az-uni-source-energy-services",

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -1,0 +1,5 @@
+{
+  "statusCode": 500,
+  "error": "Internal Server Error",
+  "message": "\"name\" is required!"
+}

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -1,5 +1,0 @@
-{
-  "statusCode": 500,
-  "error": "Internal Server Error",
-  "message": "\"name\" is required!"
-}

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -117,7 +117,7 @@ test('response with state and item filtering is valid and correct', async t => {
   );
 });
 
-// AZ low income test
+// AZ low income test for Tuscon Electric utility.
 test('AZ low income response with state and utility filtering is valid and correct', async t => {
   await validateResponse(
     t,
@@ -136,6 +136,24 @@ test('AZ low income response with state and utility filtering is valid and corre
   );
 });
 
+// AZ low income test for UniSource utility.
+test('AZ low income response with state and utility filtering is valid and correct', async t => {
+  await validateResponse(
+    t,
+    {
+      location: { zip: '85702' },
+      owner_status: 'homeowner',
+      household_size: 1,
+      household_income: 28000,
+      tax_filing: 'joint',
+      authority_types: ['state', 'utility'],
+      utility: 'az-uni-source-energy-services',
+      // TODO: Remove when AZ is fully launched.
+      include_beta_states: true,
+    },
+    './test/fixtures/v1-az-85702-state-utility-lowincome.json',
+  );
+});
 // CT low income test
 test('CT low income response with state and utility filtering is valid and correct', async t => {
   await validateResponse(

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -118,7 +118,7 @@ test('response with state and item filtering is valid and correct', async t => {
 });
 
 // AZ low income test for Tuscon Electric utility.
-test('AZ low income response with state and utility filtering is valid and correct', async t => {
+test('AZ low income response with state and utility filtering for Tuscon Electric is valid and correct', async t => {
   await validateResponse(
     t,
     {
@@ -137,7 +137,7 @@ test('AZ low income response with state and utility filtering is valid and corre
 });
 
 // AZ low income test for UniSource utility.
-test('AZ low income response with state and utility filtering is valid and correct', async t => {
+test('AZ low income response with state and utility filtering for UniSource is valid and correct', async t => {
   await validateResponse(
     t,
     {


### PR DESCRIPTION
Adds some incentives that were mislabeled by collector as "Other" that actually fit into one of our supported categories, and fix some redundant program names generated by the script.