### PR TITLE
Split local incentives into city and county types and add support for serving them.

### DIFF
--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -740,7 +740,7 @@
   },
   {
     "id": "CO-31",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -763,7 +763,7 @@
   },
   {
     "id": "CO-32",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -786,7 +786,7 @@
   },
   {
     "id": "CO-33",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -809,7 +809,7 @@
   },
   {
     "id": "CO-34",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -832,7 +832,7 @@
   },
   {
     "id": "CO-35",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -855,7 +855,7 @@
   },
   {
     "id": "CO-36",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -878,7 +878,7 @@
   },
   {
     "id": "CO-37",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -901,7 +901,7 @@
   },
   {
     "id": "CO-38",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -924,7 +924,7 @@
   },
   {
     "id": "CO-39",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -947,7 +947,7 @@
   },
   {
     "id": "CO-40",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -970,7 +970,7 @@
   },
   {
     "id": "CO-41",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -993,7 +993,7 @@
   },
   {
     "id": "CO-42",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -1016,7 +1016,7 @@
   },
   {
     "id": "CO-43",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -1039,7 +1039,7 @@
   },
   {
     "id": "CO-44",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -1062,7 +1062,7 @@
   },
   {
     "id": "CO-45",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -1085,7 +1085,7 @@
   },
   {
     "id": "CO-46",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -1109,7 +1109,7 @@
   },
   {
     "id": "CO-47",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -1133,7 +1133,7 @@
   },
   {
     "id": "CO-48",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
     "type": "pos_rebate",
     "payment_methods": [
@@ -7348,7 +7348,7 @@
   },
   {
     "id": "CO-322",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7372,7 +7372,7 @@
   },
   {
     "id": "CO-323",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7396,7 +7396,7 @@
   },
   {
     "id": "CO-324",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7420,7 +7420,7 @@
   },
   {
     "id": "CO-325",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7444,7 +7444,7 @@
   },
   {
     "id": "CO-326",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7468,7 +7468,7 @@
   },
   {
     "id": "CO-327",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7492,7 +7492,7 @@
   },
   {
     "id": "CO-328",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7516,7 +7516,7 @@
   },
   {
     "id": "CO-329",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7540,7 +7540,7 @@
   },
   {
     "id": "CO-330",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7564,7 +7564,7 @@
   },
   {
     "id": "CO-331",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7588,7 +7588,7 @@
   },
   {
     "id": "CO-332",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7612,7 +7612,7 @@
   },
   {
     "id": "CO-333",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7636,7 +7636,7 @@
   },
   {
     "id": "CO-334",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7660,7 +7660,7 @@
   },
   {
     "id": "CO-335",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7683,7 +7683,7 @@
   },
   {
     "id": "CO-336",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7707,7 +7707,7 @@
   },
   {
     "id": "CO-337",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7731,7 +7731,7 @@
   },
   {
     "id": "CO-338",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7755,7 +7755,7 @@
   },
   {
     "id": "CO-339",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7778,7 +7778,7 @@
   },
   {
     "id": "CO-340",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-city-of-boulder",
     "type": "rebate",
     "payment_methods": [
@@ -7799,7 +7799,7 @@
   },
   {
     "id": "CO-341",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7824,7 +7824,7 @@
   },
   {
     "id": "CO-342",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7849,7 +7849,7 @@
   },
   {
     "id": "CO-343",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7874,7 +7874,7 @@
   },
   {
     "id": "CO-344",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7898,7 +7898,7 @@
   },
   {
     "id": "CO-345",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7923,7 +7923,7 @@
   },
   {
     "id": "CO-346",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7948,7 +7948,7 @@
   },
   {
     "id": "CO-347",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7973,7 +7973,7 @@
   },
   {
     "id": "CO-348",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -7998,7 +7998,7 @@
   },
   {
     "id": "CO-349",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8023,7 +8023,7 @@
   },
   {
     "id": "CO-350",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8048,7 +8048,7 @@
   },
   {
     "id": "CO-351",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8072,7 +8072,7 @@
   },
   {
     "id": "CO-352",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8097,7 +8097,7 @@
   },
   {
     "id": "CO-353",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8122,7 +8122,7 @@
   },
   {
     "id": "CO-354",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8146,7 +8146,7 @@
   },
   {
     "id": "CO-355",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8171,7 +8171,7 @@
   },
   {
     "id": "CO-356",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8196,7 +8196,7 @@
   },
   {
     "id": "CO-357",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8220,7 +8220,7 @@
   },
   {
     "id": "CO-358",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8244,7 +8244,7 @@
   },
   {
     "id": "CO-359",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8268,7 +8268,7 @@
   },
   {
     "id": "CO-360",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8293,7 +8293,7 @@
   },
   {
     "id": "CO-361",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8318,7 +8318,7 @@
   },
   {
     "id": "CO-362",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8343,7 +8343,7 @@
   },
   {
     "id": "CO-363",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8367,7 +8367,7 @@
   },
   {
     "id": "CO-364",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8392,7 +8392,7 @@
   },
   {
     "id": "CO-365",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8416,7 +8416,7 @@
   },
   {
     "id": "CO-366",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -8440,7 +8440,7 @@
   },
   {
     "id": "CO-367",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-boulder-county",
     "type": "rebate",
     "payment_methods": [
@@ -10735,7 +10735,7 @@
   },
   {
     "id": "CO-469",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-avon",
     "type": "rebate",
     "payment_methods": [
@@ -10756,7 +10756,7 @@
   },
   {
     "id": "CO-470",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-avon",
     "type": "rebate",
     "payment_methods": [
@@ -10777,7 +10777,7 @@
   },
   {
     "id": "CO-471",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-avon",
     "type": "rebate",
     "payment_methods": [
@@ -10798,7 +10798,7 @@
   },
   {
     "id": "CO-472",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-eagle",
     "type": "rebate",
     "payment_methods": [
@@ -10819,7 +10819,7 @@
   },
   {
     "id": "CO-473",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-eagle",
     "type": "rebate",
     "payment_methods": [
@@ -10840,7 +10840,7 @@
   },
   {
     "id": "CO-474",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-eagle",
     "type": "rebate",
     "payment_methods": [
@@ -10861,7 +10861,7 @@
   },
   {
     "id": "CO-475",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -10882,7 +10882,7 @@
   },
   {
     "id": "CO-476",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -10903,7 +10903,7 @@
   },
   {
     "id": "CO-477",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -10924,7 +10924,7 @@
   },
   {
     "id": "CO-478",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -10945,7 +10945,7 @@
   },
   {
     "id": "CO-479",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -10966,7 +10966,7 @@
   },
   {
     "id": "CO-480",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -10987,7 +10987,7 @@
   },
   {
     "id": "CO-481",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -11008,7 +11008,7 @@
   },
   {
     "id": "CO-482",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -11029,7 +11029,7 @@
   },
   {
     "id": "CO-483",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -11050,7 +11050,7 @@
   },
   {
     "id": "CO-484",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -11071,7 +11071,7 @@
   },
   {
     "id": "CO-485",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -11092,7 +11092,7 @@
   },
   {
     "id": "CO-486",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-erie",
     "type": "rebate",
     "payment_methods": [
@@ -11113,7 +11113,7 @@
   },
   {
     "id": "CO-487",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-vail",
     "type": "rebate",
     "payment_methods": [
@@ -11134,7 +11134,7 @@
   },
   {
     "id": "CO-488",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-vail",
     "type": "rebate",
     "payment_methods": [
@@ -11155,7 +11155,7 @@
   },
   {
     "id": "CO-489",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-vail",
     "type": "rebate",
     "payment_methods": [
@@ -11176,7 +11176,7 @@
   },
   {
     "id": "CO-490",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-vail",
     "type": "rebate",
     "payment_methods": [
@@ -11199,7 +11199,7 @@
   },
   {
     "id": "CO-491",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-vail",
     "type": "rebate",
     "payment_methods": [
@@ -11221,7 +11221,7 @@
   },
   {
     "id": "CO-492",
-    "authority_type": "local",
+    "authority_type": "city",
     "authority": "co-town-of-vail",
     "type": "rebate",
     "payment_methods": [
@@ -11243,7 +11243,7 @@
   },
   {
     "id": "CO-493",
-    "authority_type": "local",
+    "authority_type": "county",
     "authority": "co-unincorporated-eagle-county",
     "type": "rebate",
     "payment_methods": [

--- a/data/authorities.json
+++ b/data/authorities.json
@@ -109,30 +109,45 @@
         "name": "YW Electric Association"
       }
     },
-    "local": {
-      "co-city-and-county-of-denver": {
-        "name": "City and County of Denver"
-      },
+    "city": {
       "co-city-of-boulder": {
-        "name": "City of Boulder"
-      },
-      "co-boulder-county": {
-        "name": "Boulder County"
+        "name": "City of Boulder",
+        "city": "Boulder",
+        "county": "Boulder"
       },
       "co-town-of-avon": {
-        "name": "Town of Avon"
+        "name": "Town of Avon",
+        "city": "Avon",
+        "county": "Eagle"
       },
       "co-town-of-eagle": {
-        "name": "Town of Eagle"
+        "name": "Town of Eagle",
+        "city": "Eagle",
+        "county": "Eagle"
       },
       "co-town-of-erie": {
-        "name": "Town of Erie"
+        "name": "Town of Erie",
+        "city": "Erie",
+        "county": "Weld"
       },
       "co-town-of-vail": {
-        "name": "Town of Vail"
+        "name": "Town of Vail",
+        "city": "Vail",
+        "county": "Eagle"
+      }
+    },
+    "county": {
+      "co-city-and-county-of-denver": {
+        "name": "City and County of Denver",
+        "county": "Denver"
+      },
+      "co-boulder-county": {
+        "name": "Boulder County",
+        "county": "Boulder"
       },
       "co-unincorporated-eagle-county": {
-        "name": "Unincorporated Eagle County"
+        "name": "Unincorporated Eagle County",
+        "county": "Eagle"
       }
     },
     "state": {
@@ -153,7 +168,6 @@
         "name": "CT Department of Energy & Environmental Protection"
       }
     },
-    "local": {},
     "utility": {
       "ct-eversource": {
         "name": "Eversource"
@@ -170,7 +184,6 @@
     }
   },
   "NY": {
-    "local": {},
     "state": {
       "ny-state-of-ny": {
         "name": "State of NY"
@@ -204,7 +217,6 @@
     }
   },
   "RI": {
-    "local": {},
     "state": {
       "ri-oer": {
         "name": "Rhode Island Office of Energy Resources",
@@ -249,7 +261,6 @@
     }
   },
   "VA": {
-    "local": {},
     "state": {},
     "utility": {
       "va-appalachian-power": {

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -19,7 +19,8 @@ import { STATES_PLUS_DC } from './types/states';
  */
 export enum AuthorityType {
   Federal = 'federal',
-  Local = 'local',
+  City = 'city',
+  County = 'county',
   State = 'state',
   Utility = 'utility',
 }
@@ -29,6 +30,8 @@ export const API_AUTHORITY_SCHEMA = {
   properties: {
     name: { type: 'string' },
     logo: API_IMAGE_SCHEMA,
+    city: { type: 'string' },
+    county: { type: 'string' },
   },
   required: ['name'],
   additionalProperties: false,
@@ -55,7 +58,8 @@ export const SCHEMA = {
     properties: {
       state: authoritiesMapSchema,
       utility: authoritiesMapSchema,
-      local: authoritiesMapSchema,
+      city: authoritiesMapSchema,
+      county: authoritiesMapSchema,
     },
     required: ['state', 'utility'],
     additionalProperties: false,
@@ -63,6 +67,7 @@ export const SCHEMA = {
   required: [],
 } as const;
 
+export type AuthoritiesByType = { [index: string]: AuthoritiesById };
 export type AuthoritiesByState = FromSchema<typeof SCHEMA>;
 
 export const AUTHORITIES_BY_STATE: AuthoritiesByState = JSON.parse(

--- a/src/lib/fetch-amis-for-address.ts
+++ b/src/lib/fetch-amis-for-address.ts
@@ -1,6 +1,6 @@
 import { Database } from 'sqlite';
 import { geocoder } from './geocoder';
-import { AMI, IncomeInfo, MFI, ZipInfo } from './income-info';
+import { AMI, GeoInfo, IncomeInfo, MFI } from './income-info';
 
 export default async function fetchAMIsForAddress(
   db: Database,
@@ -19,7 +19,7 @@ export default async function fetchAMIsForAddress(
 
   // We pull these from our database (vs geocoder) to ensure a match
   // when computing whether local incentives are eligible.
-  const supplemental = await db.get<ZipInfo>(
+  const supplemental = await db.get<GeoInfo>(
     `
     SELECT 
         city, 

--- a/src/lib/fetch-amis-for-address.ts
+++ b/src/lib/fetch-amis-for-address.ts
@@ -19,6 +19,11 @@ export default async function fetchAMIsForAddress(
 
   // We pull these from our database (vs geocoder) to ensure a match
   // when computing whether local incentives are eligible.
+  // This data is approximate, as zips can span county/city lines.
+  // We should communicate that clearly in API documentation and
+  // in frontends.
+  // https://app.asana.com/0/1204738794846444/1206454407609847
+  // tracks longer-term work in this space.
   const supplemental = await db.get<GeoInfo>(
     `
     SELECT 
@@ -29,12 +34,6 @@ export default async function fetchAMIsForAddress(
   `,
     zip,
   );
-  let city: string | undefined;
-  let county: string | undefined;
-  if (supplemental !== undefined) {
-    city = supplemental.city;
-    county = supplemental.county;
-  }
 
   const censusInfo = result.fields?.census['2010'];
 
@@ -63,8 +62,8 @@ export default async function fetchAMIsForAddress(
   const location = {
     state_id: result.address_components.state,
     zip,
-    city,
-    county,
+    city: supplemental?.city,
+    county: supplemental?.county,
   };
 
   const ami = await db.get<AMI>(

--- a/src/lib/fetch-amis-for-zip.ts
+++ b/src/lib/fetch-amis-for-zip.ts
@@ -15,7 +15,11 @@ export default async function fetchAMIsForZip(
   // confusion, use parent_zcta if it's non-blank.
   const location = await db.get<ZipInfo>(
     `
-    SELECT COALESCE(NULLIF(parent_zcta, ''), zip) as zip, state_id
+    SELECT 
+        COALESCE(NULLIF(parent_zcta, ''), zip) as zip, 
+        state_id, 
+        city, 
+        county_name as county
     FROM zips
     WHERE zip = ?
   `,

--- a/src/lib/fetch-amis-for-zip.ts
+++ b/src/lib/fetch-amis-for-zip.ts
@@ -1,5 +1,5 @@
 import { Database } from 'sqlite';
-import { AMI, IncomeInfo, MFI, ZipInfo } from './income-info';
+import { AMI, GeoInfo, IncomeInfo, MFI } from './income-info';
 
 export default async function fetchAMIsForZip(
   db: Database,
@@ -13,7 +13,7 @@ export default async function fetchAMIsForZip(
   // Such ZIPs don't contain residential addresses, so this shouldn't be an
   // issue for users who enter their actual residential ZIPs. Still, to avoid
   // confusion, use parent_zcta if it's non-blank.
-  const location = await db.get<ZipInfo>(
+  const location = await db.get<GeoInfo>(
     `
     SELECT 
         COALESCE(NULLIF(parent_zcta, ''), zip) as zip, 

--- a/src/lib/fetch-amis-for-zip.ts
+++ b/src/lib/fetch-amis-for-zip.ts
@@ -13,6 +13,12 @@ export default async function fetchAMIsForZip(
   // Such ZIPs don't contain residential addresses, so this shouldn't be an
   // issue for users who enter their actual residential ZIPs. Still, to avoid
   // confusion, use parent_zcta if it's non-blank.
+
+  // city and county are approximate, as zips can span county/city lines.
+  // We should communicate that clearly in API documentation and
+  // in frontends.
+  // https://app.asana.com/0/1204738794846444/1206454407609847
+  // tracks longer-term work in this space.
   const location = await db.get<GeoInfo>(
     `
     SELECT 

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -18,7 +18,7 @@ import {
 } from '../schemas/v1/calculator-endpoint';
 import { APISavings, addSavings, zeroSavings } from '../schemas/v1/savings';
 import { InvalidInputError, UnexpectedInputError } from './error';
-import { AMI, CompleteIncomeInfo, MFI, ZipInfo } from './income-info';
+import { AMI, CompleteIncomeInfo, GeoInfo, MFI } from './income-info';
 import {
   calculateStateIncentivesAndSavings,
   getAllStateIncentives,
@@ -50,7 +50,7 @@ type CalculatedIncentives = Omit<APICalculatorResponse, 'incentives'> & {
 };
 
 export type CalculateParams = Omit<APICalculatorRequest, 'location'>;
-export type LocationParams = Omit<ZipInfo, 'zip'>;
+export type LocationParams = Omit<GeoInfo, 'zip'>;
 
 function calculateFederalIncentivesAndSavings(
   ami: AMI,
@@ -395,7 +395,7 @@ export default function calculateIncentives(
     authorities,
     coverage,
     location: {
-      state: location.state_id,
+      state: state_id,
       city: location.city,
       county: location.county,
     },

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -18,7 +18,7 @@ import {
 } from '../schemas/v1/calculator-endpoint';
 import { APISavings, addSavings, zeroSavings } from '../schemas/v1/savings';
 import { InvalidInputError, UnexpectedInputError } from './error';
-import { AMI, CompleteIncomeInfo, MFI } from './income-info';
+import { AMI, CompleteIncomeInfo, MFI, ZipInfo } from './income-info';
 import {
   calculateStateIncentivesAndSavings,
   getAllStateIncentives,
@@ -50,6 +50,7 @@ type CalculatedIncentives = Omit<APICalculatorResponse, 'incentives'> & {
 };
 
 export type CalculateParams = Omit<APICalculatorRequest, 'location'>;
+export type LocationParams = Omit<ZipInfo, 'zip'>;
 
 function calculateFederalIncentivesAndSavings(
   ami: AMI,
@@ -227,7 +228,7 @@ function calculateFederalIncentivesAndSavings(
 }
 
 export default function calculateIncentives(
-  { location: { state_id }, ami, calculations }: CompleteIncomeInfo,
+  { location, ami, calculations }: CompleteIncomeInfo,
   request: CalculateParams,
 ): CalculatedIncentives {
   const {
@@ -237,6 +238,8 @@ export default function calculateIncentives(
     household_size,
     authority_types,
   } = request;
+
+  const state_id = location.state_id;
 
   if (!OWNER_STATUSES.has(owner_status)) {
     throw new UnexpectedInputError('Unknown owner_status');
@@ -329,16 +332,19 @@ export default function calculateIncentives(
   if (
     !authority_types ||
     authority_types.includes(AuthorityType.State) ||
-    authority_types.includes(AuthorityType.Utility)
+    authority_types.includes(AuthorityType.Utility) ||
+    authority_types.includes(AuthorityType.County) ||
+    authority_types.includes(AuthorityType.City)
   ) {
     const allStateIncentives = getAllStateIncentives(state_id, request);
     const stateIncentiveRelationships =
       getStateIncentiveRelationships(state_id);
     const state = calculateStateIncentivesAndSavings(
-      state_id,
+      location,
       request,
       allStateIncentives,
       stateIncentiveRelationships,
+      stateAuthorities,
     );
     incentives.push(...state.stateIncentives);
     savings = addSavings(savings, state.savings);
@@ -382,17 +388,17 @@ export default function calculateIncentives(
     });
   }
 
-  const location = {
-    state: state_id,
-  };
-
   return {
     is_under_80_ami: isUnder80Ami,
     is_under_150_ami: isUnder150Ami,
     is_over_150_ami: isOver150Ami,
     authorities,
     coverage,
-    location,
+    location: {
+      state: location.state_id,
+      city: location.city,
+      county: location.county,
+    },
     savings,
     incentives: sortedIncentives,
   };

--- a/src/lib/income-info.ts
+++ b/src/lib/income-info.ts
@@ -1,10 +1,11 @@
 /**
- * Corresponds to the "zips" table in sqlite. There are other columns, but
- * state_id is the only one we need.
+ * Corresponds to the "zips" table in sqlite.
  */
 export type ZipInfo = {
   state_id: string;
   zip: string;
+  city?: string;
+  county?: string;
 };
 
 /**

--- a/src/lib/income-info.ts
+++ b/src/lib/income-info.ts
@@ -1,7 +1,7 @@
 /**
  * Corresponds to the "zips" table in sqlite.
  */
-export type ZipInfo = {
+export type GeoInfo = {
   state_id: string;
   zip: string;
   city?: string;
@@ -32,13 +32,13 @@ export type MFI = {
 };
 
 export type IncomeInfo = {
-  location: ZipInfo;
+  location: GeoInfo;
   ami: AMI | undefined;
   calculations: MFI | undefined;
 };
 
 export type CompleteIncomeInfo = {
-  location: ZipInfo;
+  location: GeoInfo;
   ami: AMI;
   calculations: MFI;
 };

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -190,7 +190,7 @@ export function calculateStateIncentivesAndSavings(
     stateIncentives,
     savings,
     coverage: {
-      state: location.state_id,
+      state: stateId,
       utility: request.utility ?? null,
     },
   };

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -1,5 +1,5 @@
 import { min } from 'lodash';
-import { AuthorityType } from '../data/authorities';
+import { AuthoritiesByType, AuthorityType } from '../data/authorities';
 import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../data/low_income_thresholds';
 import {
   INCENTIVE_RELATIONSHIPS_BY_STATE,
@@ -24,7 +24,11 @@ import {
   makeIneligible,
   meetsPrerequisites,
 } from './incentive-relationship-calculation';
-import { CalculateParams, CalculatedIncentive } from './incentives-calculation';
+import {
+  CalculateParams,
+  CalculatedIncentive,
+  LocationParams,
+} from './incentives-calculation';
 
 export function getAllStateIncentives(
   stateId: string,
@@ -42,10 +46,11 @@ export function getStateIncentiveRelationships(stateId: string) {
 }
 
 export function calculateStateIncentivesAndSavings(
-  stateId: string,
+  location: LocationParams,
   request: CalculateParams,
   incentives: StateIncentive[],
   incentiveRelationships: IncentiveRelationships,
+  stateAuthorities: AuthoritiesByType,
 ): {
   stateIncentives: CalculatedIncentive[];
   savings: APISavings;
@@ -59,42 +64,12 @@ export function calculateStateIncentivesAndSavings(
     };
   }
 
-  const includeState =
-    !request.authority_types ||
-    request.authority_types.includes(AuthorityType.State);
-  const includeUtility =
-    !request.authority_types ||
-    request.authority_types.includes(AuthorityType.Utility);
-
+  const stateId = location.state_id;
   const eligibleIncentives = new Map<string, StateIncentive>();
   const ineligibleIncentives = new Map<string, StateIncentive>();
 
   for (const item of incentives) {
-    if (request.items && !request.items.includes(item.item)) {
-      // Don't include an incentive at all if the query is filtering by item and
-      // this doesn't match.
-      continue;
-    }
-
-    if (item.authority_type === AuthorityType.State && !includeState) {
-      // Don't include state incentives at all if they weren't requested, not
-      // even as "ineligible" incentives.
-      continue;
-    }
-
-    if (
-      item.authority_type === AuthorityType.Utility &&
-      (!includeUtility || item.authority !== request.utility)
-    ) {
-      // Don't include utility incentives at all if they weren't requested, or
-      // if they're for the wrong utility.
-      continue;
-    }
-
-    if (item.authority_type === AuthorityType.Local) {
-      // TODO: support serving Local incentives
-      // This allows keeping them in our JSON datasets, but for now
-      // we always ignore them.
+    if (skipBasedOnRequestParams(item, request, location, stateAuthorities)) {
       continue;
     }
 
@@ -215,7 +190,7 @@ export function calculateStateIncentivesAndSavings(
     stateIncentives,
     savings,
     coverage: {
-      state: stateId,
+      state: location.state_id,
       utility: request.utility ?? null,
     },
   };
@@ -243,4 +218,66 @@ function transformItems(
     transformed.push(transformedItem);
   }
   return transformed;
+}
+
+function skipBasedOnRequestParams(
+  item: StateIncentive,
+  request: CalculateParams,
+  location: LocationParams,
+  stateAuthorities: AuthoritiesByType,
+) {
+  if (
+    request.authority_types &&
+    !request.authority_types.includes(item.authority_type)
+  ) {
+    // Skip all utilities that are not of the requested authority type(s).
+    return true;
+  }
+
+  if (request.items && !request.items.includes(item.item)) {
+    // Don't include an incentive at all if the query is filtering by item and
+    // this doesn't match.
+    return true;
+  }
+
+  if (
+    item.authority_type === AuthorityType.Utility &&
+    item.authority !== request.utility
+  ) {
+    // Don't include utility incentives at all if they weren't requested, or
+    // if they're for the wrong utility.
+    return true;
+  }
+
+  if (item.authority_type === AuthorityType.County) {
+    // Skip if we didn't get location data.
+    if (location.county === undefined) return true;
+
+    // We have tests to ensure county authorities are registered.
+    const authorityDetails = stateAuthorities.county![item.authority];
+    if (authorityDetails.county !== location.county) {
+      return true;
+    }
+  }
+
+  if (item.authority_type === AuthorityType.City) {
+    // We have to match on both city and county since more than one
+    // municipalities can have the same name within the same state.
+
+    // Skip if we didn't get location data.
+    if (location.city === undefined || location.county === undefined) {
+      return true;
+    }
+
+    // We have tests to ensure city authorities are registered.
+    const authorityDetails = stateAuthorities.city![item.authority];
+
+    if (
+      authorityDetails.city !== location.city ||
+      authorityDetails.county !== location.county
+    ) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -249,6 +249,11 @@ function skipBasedOnRequestParams(
     return true;
   }
 
+  // County and City incentives are approximate and prone to
+  // false positives, since zip codes to not map 1:1 to counties
+  // and cities.
+  // https://app.asana.com/0/1204738794846444/1206454407609847
+  // tracks long-term work in this space.
   if (item.authority_type === AuthorityType.County) {
     // Skip if we didn't get location data.
     if (location.county === undefined) return true;

--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -1,6 +1,6 @@
 import { AUTHORITIES_BY_STATE, Authority } from '../data/authorities';
 import { isStateIncluded } from '../data/types/states';
-import { ZipInfo } from './income-info';
+import { GeoInfo } from './income-info';
 
 /**
  * Find the utilities that may serve the given location. False positives are
@@ -14,7 +14,7 @@ import { ZipInfo } from './income-info';
  * TODO this is very not scalable to nationwide coverage!
  */
 export function getUtilitiesForLocation(
-  location: ZipInfo,
+  location: GeoInfo,
   includeBeta: boolean,
 ): {
   [id: string]: Authority;

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -52,6 +52,16 @@ export const API_RESPONSE_LOCATION_SCHEMA = {
       description:
         'The two-letter abbreviation for the state, district, or territory of the location submitted in the request.',
     },
+    city: {
+      type: 'string',
+      description:
+        'The city name as determined by looking up the zip code in our database.',
+    },
+    county: {
+      type: 'string',
+      description:
+        'The county name as determined by looking up the zip code in our database.',
+    },
   },
   required: ['state'],
   additionalProperties: false,

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -159,10 +159,31 @@ test('state incentives JSON files match schemas', async tap => {
         `amount is invalid (${stateId}, id ${incentive.id}, index ${index})`,
       );
       tap.hasProp(
-        authorities[incentive.authority_type as 'state' | 'utility' | 'local']!,
+        authorities[
+          incentive.authority_type as 'state' | 'utility' | 'county' | 'city'
+        ]!,
         incentive.authority,
         `nonexistent authority (${stateId}, id ${incentive.id}, index ${index})`,
       );
+      if (incentive.authority_type === AuthorityType.County) {
+        tap.hasProp(
+          authorities[incentive.authority_type]![incentive.authority],
+          'county',
+          'must define county attribute on corresponding authority for incentives with county authority type',
+        );
+      }
+      if (incentive.authority_type === AuthorityType.City) {
+        tap.hasProp(
+          authorities[incentive.authority_type]![incentive.authority],
+          'county',
+          'must define county attribute on corresponding authority for incentives with city authority type (county is used for matching)',
+        );
+        tap.hasProp(
+          authorities[incentive.authority_type]![incentive.authority],
+          'city',
+          'must define city attribute on corresponding authority for incentives with city authority type',
+        );
+      }
 
       // Allow duplicate incentive IDs if we split one incentive into multiple due
       // to tax filing status
@@ -178,7 +199,8 @@ test("launched states do not have any values that we don't support in the fronte
   STATE_INCENTIVE_TESTS.forEach(([state, , data]) => {
     if (LAUNCHED_STATES.includes(state)) {
       for (const incentive of data) {
-        tap.not(incentive.authority_type, AuthorityType.Local);
+        tap.not(incentive.authority_type, AuthorityType.City);
+        tap.not(incentive.authority_type, AuthorityType.County);
 
         tap.notOk(
           BETA_ITEMS.includes(incentive.item),

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -169,19 +169,19 @@ test('state incentives JSON files match schemas', async tap => {
         tap.hasProp(
           authorities[incentive.authority_type]![incentive.authority],
           'county',
-          'must define county attribute on corresponding authority for incentives with county authority type',
+          `must define county attribute on corresponding authority ${incentive.authority} for incentives with county authority type`,
         );
       }
       if (incentive.authority_type === AuthorityType.City) {
         tap.hasProp(
           authorities[incentive.authority_type]![incentive.authority],
           'county',
-          'must define county attribute on corresponding authority for incentives with city authority type (county is used for matching)',
+          `must define county attribute on corresponding authority ${incentive.authority} for incentives with city authority type (county is used for matching)`,
         );
         tap.hasProp(
           authorities[incentive.authority_type]![incentive.authority],
           'city',
-          'must define city attribute on corresponding authority for incentives with city authority type',
+          `must define city attribute on corresponding authority ${incentive.authority} for incentives with city authority type`,
         );
       }
 
@@ -199,6 +199,7 @@ test("launched states do not have any values that we don't support in the fronte
   STATE_INCENTIVE_TESTS.forEach(([state, , data]) => {
     if (LAUNCHED_STATES.includes(state)) {
       for (const incentive of data) {
+        // TODO: remove once City/County incentives have been beta-tested.
         tap.not(incentive.authority_type, AuthorityType.City);
         tap.not(incentive.authority_type, AuthorityType.County);
 

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -17,7 +17,9 @@
     "utility": null
   },
   "location": {
-    "state": "RI"
+    "state": "RI",
+    "city": "Block Island",
+    "county": "Washington"
   },
   "savings": {
     "pos_rebate": 14000,

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -31,7 +31,9 @@
     "utility": "ri-rhode-island-energy"
   },
   "location": {
-    "state": "RI"
+    "state": "RI",
+    "city": "Providence",
+    "county": "Providence"
   },
   "savings": {
     "pos_rebate": 0,

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -8,7 +8,9 @@
     "utility": null
   },
   "location": {
-    "state": "PA"
+    "state": "PA",
+    "city": "Pittsburgh",
+    "county": "Allegheny"
   },
   "savings": {
     "pos_rebate": 14000,

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -8,7 +8,9 @@
     "utility": null
   },
   "location": {
-    "state": "CO"
+    "state": "CO",
+    "city": "Denver",
+    "county": "Denver"
   },
   "savings": {
     "pos_rebate": 14000,

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -12,7 +12,9 @@
     "utility": "az-tucson-electric-power"
   },
   "location": {
-    "state": "AZ"
+    "state": "AZ",
+    "city": "Tucson",
+    "county": "Pima"
   },
   "savings": {
     "pos_rebate": 0,

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -12,7 +12,9 @@
     "utility": "az-uni-source-energy-services"
   },
   "location": {
-    "state": "AZ"
+    "state": "AZ",
+    "city": "Tucson",
+    "county": "Pima"
   },
   "savings": {
     "pos_rebate": 1550,

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -21,7 +21,9 @@
     "utility": "co-walking-mountains"
   },
   "location": {
-    "state": "CO"
+    "state": "CO",
+    "city": "Vail",
+    "county": "Eagle"
   },
   "savings": {
     "pos_rebate": 0,

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -15,7 +15,9 @@
     "utility": "ct-eversource"
   },
   "location": {
-    "state": "CT"
+    "state": "CT",
+    "city": "Bloomfield",
+    "county": "Hartford"
   },
   "savings": {
     "pos_rebate": 7250,

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -18,7 +18,9 @@
     "utility": "ny-pseg-long-island"
   },
   "location": {
-    "state": "NY"
+    "state": "NY",
+    "city": "Hewlett",
+    "county": "Nassau"
   },
   "savings": {
     "pos_rebate": 5040,

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -12,7 +12,9 @@
     "utility": "va-dominion-energy"
   },
   "location": {
-    "state": "VA"
+    "state": "VA",
+    "city": "Fairfax",
+    "county": "Fairfax"
   },
   "savings": {
     "pos_rebate": 0,

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -18,7 +18,9 @@
     "utility": "vt-burlington-electric-department"
   },
   "location": {
-    "state": "VT"
+    "state": "VT",
+    "city": "Burlington",
+    "county": "Chittenden"
   },
   "savings": {
     "pos_rebate": 9850,

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -18,7 +18,7 @@ import { TEST_INCENTIVES } from '../mocks/state-incentives';
 // This checks incentive eligibility with no relationship logic included.
 test('basic test for supplying test incentive data to calculation logic', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Homeowner,
       household_income: 120000,
@@ -29,6 +29,7 @@ test('basic test for supplying test incentive data to calculation logic', async 
       include_beta_states: false,
     },
     TEST_INCENTIVES,
+    {},
     {},
   );
   t.ok(data);
@@ -42,7 +43,7 @@ test('basic test for supplying test incentive data to calculation logic', async 
 
 test('test calculation with no incentives', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Homeowner,
       household_income: 120000,
@@ -54,6 +55,7 @@ test('test calculation with no incentives', async t => {
     },
     [],
     TEST_INCENTIVE_RELATIONSHIPS,
+    {},
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 0);
@@ -70,7 +72,7 @@ test('test calculation with no incentives', async t => {
 //    not eligible for C, they can still be eligible for F.
 test('test incentive relationship logic', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Renter,
       household_income: 120000,
@@ -82,6 +84,7 @@ test('test incentive relationship logic', async t => {
     },
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS,
+    {},
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
@@ -106,7 +109,7 @@ test('test incentive relationship logic', async t => {
 // 5) E supersedes F, so they are not eligible for F.
 test('test more complex incentive relationship logic', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Renter,
       household_income: 120000,
@@ -118,6 +121,7 @@ test('test more complex incentive relationship logic', async t => {
     },
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_2,
+    {},
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
@@ -145,7 +149,7 @@ test('test more complex incentive relationship logic', async t => {
 // 4) F is not affected by the relationships, so they are eligible for F.
 test('test incentive relationship and combined max value logic', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Renter,
       household_income: 120000,
@@ -157,6 +161,7 @@ test('test incentive relationship and combined max value logic', async t => {
     },
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
+    {},
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
@@ -225,7 +230,7 @@ test('test incentive relationship and permanent ineligibility criteria', async t
 //    A and C, they will remain eligible for E.
 test('test nested incentive relationship logic', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Renter,
       household_income: 120000,
@@ -237,6 +242,7 @@ test('test nested incentive relationship logic', async t => {
     },
     TEST_INCENTIVES,
     TEST_NESTED_INCENTIVE_RELATIONSHIPS,
+    {},
   );
   t.ok(data);
   for (const incentive of data.stateIncentives) {
@@ -254,7 +260,7 @@ test('test nested incentive relationship logic', async t => {
 // savings value is $200.
 test('test combined maximum savings logic', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Renter,
       household_income: 120000,
@@ -266,6 +272,7 @@ test('test combined maximum savings logic', async t => {
     },
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
+    {},
   );
   t.ok(data);
   // Check that the user is eligible for B, E, and F.

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -191,7 +191,7 @@ test('test incentive relationship and combined max value logic', async t => {
 // 4) F is not affected by the relationships, so they are eligible for F.
 test('test incentive relationship and permanent ineligibility criteria', async t => {
   const data = calculateStateIncentivesAndSavings(
-    'RI',
+    { state_id: 'RI' },
     {
       owner_status: OwnerStatus.Renter,
       household_income: 140000,
@@ -203,6 +203,7 @@ test('test incentive relationship and permanent ineligibility criteria', async t
     },
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
+    {},
   );
 
   t.ok(data);


### PR DESCRIPTION
City and County are different kinds of local authorities and the logic for matching them is different, so we split them here and add support for serving them in the API (previously they've been filtered out).

Summary of algorithm:
1. When looking up location information, use the zip code to return a county and city for the request, not just a state ID.
2. Require that for any incentive with a county/city authority type, that authority has county and possibly city attributes defined in authorities.json. This is enforced in tests.
3. For county incentives, the request county and authority county need to match. For city incentives, both the county *and* city attributes need to match, because there can be multiple cities with the same name in a state.

I can add documentation in a README about how to do #2, but want to make sure we are okay with this approach first.