### PR TITLE
Add supported columns, add alphabetization of authorities.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ This script covers:
 Usage:
 `node build/scripts/generate-misc-state-data.js <state_id>`
 
-After running, you may need to edit these files to put states in alphabetical order. Note that running this script twice will paste the same values twice.
+After running, you may need to edit the program files to put states in alphabetical order. The authorities file is already alphabetically sorted. Note that running this script twice will paste the same values twice.
 
 It's recommended to also define low-income thresholds in `data/low_income_thresholds.json` for your state to save time in the next step.
 

--- a/scripts/incentive-spreadsheet-registry.ts
+++ b/scripts/incentive-spreadsheet-registry.ts
@@ -36,7 +36,8 @@ export const FILES: { [ident: string]: IncentiveFile } = {
   },
   AZ: {
     filepath: 'data/AZ/incentives.json',
-    sheetUrl: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQEGP5ZcMknLdHAqBAeCUtdkNPtS0CiFzQzoM4bdbLWYqC_30j1lHLeJhMSKElFRuwRdrgcd46Gl54j/pub?gid=995688950&single=true&output=csv',
+    sheetUrl:
+      'https://docs.google.com/spreadsheets/d/e/2PACX-1vQEGP5ZcMknLdHAqBAeCUtdkNPtS0CiFzQzoM4bdbLWYqC_30j1lHLeJhMSKElFRuwRdrgcd46Gl54j/pub?gid=995688950&single=true&output=csv',
     headerRowNumber: 2,
     idHeader: 'ID',
     enHeader: 'Program Description (style guide)',

--- a/scripts/incentive-spreadsheet-registry.ts
+++ b/scripts/incentive-spreadsheet-registry.ts
@@ -34,4 +34,11 @@ export const FILES: { [ident: string]: IncentiveFile } = {
     enHeader: 'Program Description (style guide)',
     esHeader: 'Program Description (Spanish)',
   },
+  AZ: {
+    filepath: 'data/AZ/incentives.json',
+    sheetUrl: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQEGP5ZcMknLdHAqBAeCUtdkNPtS0CiFzQzoM4bdbLWYqC_30j1lHLeJhMSKElFRuwRdrgcd46Gl54j/pub?gid=995688950&single=true&output=csv',
+    headerRowNumber: 2,
+    idHeader: 'ID',
+    enHeader: 'Program Description (style guide)',
+  },
 };

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { Project } from 'ts-morph';
+
 const project = new Project({
   tsConfigFilePath: 'tsconfig.json',
 });

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -17,60 +17,6 @@ const wordSeparators =
 const capital_plus_lower = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD][a-zà-ÿ]/g;
 const capitals = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD]+/g;
 
-const stateAbbreviationArray: readonly string[] = [
-  'AL',
-  'AK',
-  'AZ',
-  'AR',
-  'CA',
-  'CO',
-  'CT',
-  'DE',
-  'DC',
-  'FL',
-  'GA',
-  'HI',
-  'ID',
-  'IL',
-  'IN',
-  'IA',
-  'KS',
-  'KY',
-  'LA',
-  'ME',
-  'MD',
-  'MA',
-  'MI',
-  'MN',
-  'MS',
-  'MO',
-  'MT',
-  'NE',
-  'NV',
-  'NH',
-  'NJ',
-  'NM',
-  'NY',
-  'NC',
-  'ND',
-  'OH',
-  'OK',
-  'OR',
-  'PA',
-  'RI',
-  'SC',
-  'SD',
-  'TN',
-  'TX',
-  'UT',
-  'VT',
-  'VA',
-  'WA',
-  'WV',
-  'WI',
-  'WY',
-];
-
 function kebabCase(str: string) {
   // replace word starts with space + lower case equivalent for later parsing
   // 1) treat cap + lower as start of new word
@@ -128,8 +74,17 @@ export function createProgramName(
   );
 }
 
+export function sortJsonAlphabeticallyByStateKey(json: StateToAuthorityMap) {
+  const ordered = Object.keys(json).sort().reduce((obj, key) => {
+    obj[key] = json[key];
+    return obj;
+  },  {} as StateToAuthorityMap);
+  return ordered;
+  }
+
 type AuthorityKey = string;
 type ProgramKey = string;
+type StateKey = string;
 type Authority = {
   name: string;
   authority_type: string;
@@ -142,6 +97,10 @@ type ProgramMap = {
 
 type AuthorityMap = {
   [index: AuthorityKey]: Authority;
+};
+
+type StateToAuthorityMap = {
+  [index: StateKey]: AuthorityMap;
 };
 
 export class AuthorityAndProgramUpdater {
@@ -212,20 +171,14 @@ export class AuthorityAndProgramUpdater {
         };
     }
 
-    // Reset file first.
-    fs.writeFileSync(AUTHORITIES_JSON_FILE, '', 'utf-8');
-    // Go through list of state abbreviations and then write them, if entries exist.
-    for (const entry_state of stateAbbreviationArray) {
-      if (json[entry_state] !== undefined) {
-        const obj: AuthorityMap = {};
-        obj[entry_state] = json[entry_state];
-        fs.appendFileSync(
-          AUTHORITIES_JSON_FILE,
-          JSON.stringify(obj, null, 2),
-          'utf-8',
-        );
-      }
-    }
+    const ordered_json = sortJsonAlphabeticallyByStateKey(json);
+
+    fs.writeFileSync(
+      AUTHORITIES_JSON_FILE,
+      JSON.stringify(ordered_json, null, 2),
+      'utf-8',
+    );
+   
   }
 
   updateProgramsTs() {

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -17,10 +17,59 @@ const wordSeparators =
 const capital_plus_lower = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD][a-zà-ÿ]/g;
 const capitals = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD]+/g;
 
-const stateAbbreviationArray: readonly string[] = ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT',
- 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA',
- 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 
- 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'];
+const stateAbbreviationArray: readonly string[] = [
+  'AL',
+  'AK',
+  'AZ',
+  'AR',
+  'CA',
+  'CO',
+  'CT',
+  'DE',
+  'DC',
+  'FL',
+  'GA',
+  'HI',
+  'ID',
+  'IL',
+  'IN',
+  'IA',
+  'KS',
+  'KY',
+  'LA',
+  'ME',
+  'MD',
+  'MA',
+  'MI',
+  'MN',
+  'MS',
+  'MO',
+  'MT',
+  'NE',
+  'NV',
+  'NH',
+  'NJ',
+  'NM',
+  'NY',
+  'NC',
+  'ND',
+  'OH',
+  'OK',
+  'OR',
+  'PA',
+  'RI',
+  'SC',
+  'SD',
+  'TN',
+  'TX',
+  'UT',
+  'VT',
+  'VA',
+  'WA',
+  'WV',
+  'WI',
+  'WY',
+];
 
 function kebabCase(str: string) {
   // replace word starts with space + lower case equivalent for later parsing
@@ -163,23 +212,19 @@ export class AuthorityAndProgramUpdater {
         };
     }
 
-    // Reset file first. 
-    fs.writeFileSync(
-      AUTHORITIES_JSON_FILE,
-      "",
-      'utf-8',
-    );
+    // Reset file first.
+    fs.writeFileSync(AUTHORITIES_JSON_FILE, '', 'utf-8');
     // Go through list of state abbreviations and then write them, if entries exist.
     for (const entry_state of stateAbbreviationArray) {
       if (json[entry_state] !== undefined) {
-        let obj: any = {};
+        const obj: AuthorityMap = {};
         obj[entry_state] = json[entry_state];
         fs.appendFileSync(
           AUTHORITIES_JSON_FILE,
           JSON.stringify(obj, null, 2),
           'utf-8',
         );
-        }
+      }
     }
   }
 

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -17,6 +17,11 @@ const wordSeparators =
 const capital_plus_lower = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD][a-zà-ÿ]/g;
 const capitals = /[A-ZÀ-Ý\u00C0-\u00D6\u00D9-\u00DD]+/g;
 
+const stateAbbreviationArray: readonly string[] = ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT',
+ 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA',
+ 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 
+ 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'];
+
 function kebabCase(str: string) {
   // replace word starts with space + lower case equivalent for later parsing
   // 1) treat cap + lower as start of new word
@@ -157,11 +162,25 @@ export class AuthorityAndProgramUpdater {
           name: authority.name,
         };
     }
+
+    // Reset file first. 
     fs.writeFileSync(
       AUTHORITIES_JSON_FILE,
-      JSON.stringify(json, null, 2),
+      "",
       'utf-8',
     );
+    // Go through list of state abbreviations and then write them, if entries exist.
+    for (const entry_state of stateAbbreviationArray) {
+      if (json[entry_state] !== undefined) {
+        let obj: any = {};
+        obj[entry_state] = json[entry_state];
+        fs.appendFileSync(
+          AUTHORITIES_JSON_FILE,
+          JSON.stringify(obj, null, 2),
+          'utf-8',
+        );
+        }
+    }
   }
 
   updateProgramsTs() {

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { Project } from 'ts-morph';
-
 const project = new Project({
   tsConfigFilePath: 'tsconfig.json',
 });
@@ -74,13 +73,17 @@ export function createProgramName(
   );
 }
 
-export function sortJsonAlphabeticallyByStateKey(json: StateToAuthorityMap) {
-  const ordered = Object.keys(json).sort().reduce((obj, key) => {
-    obj[key] = json[key];
-    return obj;
-  },  {} as StateToAuthorityMap);
+export function sortJsonAlphabeticallyByStateKey(
+  json: StateToAuthorityTypeMap,
+) {
+  const ordered = Object.keys(json)
+    .sort()
+    .reduce((obj, key) => {
+      obj[key] = json[key];
+      return obj;
+    }, {} as StateToAuthorityTypeMap);
   return ordered;
-  }
+}
 
 type AuthorityKey = string;
 type ProgramKey = string;
@@ -99,8 +102,16 @@ type AuthorityMap = {
   [index: AuthorityKey]: Authority;
 };
 
-type StateToAuthorityMap = {
-  [index: StateKey]: AuthorityMap;
+// These types encapsulate how we parse and then re-write JSON to the data/authorities.json file.
+type JsonAuthorities = {
+  [index: AuthorityKey]: { name: string };
+};
+type AuthorityType = string;
+type AuthorityTypeMap = {
+  [index: AuthorityType]: JsonAuthorities;
+};
+export type StateToAuthorityTypeMap = {
+  [index: StateKey]: AuthorityTypeMap;
 };
 
 export class AuthorityAndProgramUpdater {
@@ -149,7 +160,9 @@ export class AuthorityAndProgramUpdater {
   }
 
   updateAuthoritiesJson() {
-    const json = JSON.parse(fs.readFileSync(AUTHORITIES_JSON_FILE, 'utf-8'));
+    const json: StateToAuthorityTypeMap = JSON.parse(
+      fs.readFileSync(AUTHORITIES_JSON_FILE, 'utf-8'),
+    );
     const stateUpper = this.state.toUpperCase();
     if (stateUpper in json) {
       throw new Error(
@@ -178,7 +191,6 @@ export class AuthorityAndProgramUpdater {
       JSON.stringify(ordered_json, null, 2),
       'utf-8',
     );
-   
   }
 
   updateProgramsTs() {

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -33,8 +33,6 @@ export const FIELD_MAPPINGS: { [index: string]: string[] } = {
   // This contains notes about why we might not serve a record in the API.
   // It may not appear in all spreadsheets.
   editorial_notes: ['Editorial Notes'],
-  bonus_details: ['Bonus Details'],
-  questions: ['Questions'],
 };
 
 // Note: this is from alias to canonical name, which is the reverse of

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -33,6 +33,8 @@ export const FIELD_MAPPINGS: { [index: string]: string[] } = {
   // This contains notes about why we might not serve a record in the API.
   // It may not appear in all spreadsheets.
   editorial_notes: ['Editorial Notes'],
+  bonus_details: ['Bonus Details'],
+  questions: ['Questions'],
 };
 
 // Note: this is from alias to canonical name, which is the reverse of

--- a/test/scripts/authority-and-program-updater.test.ts
+++ b/test/scripts/authority-and-program-updater.test.ts
@@ -1,0 +1,106 @@
+import { test } from 'tap';
+import {
+  sortJsonAlphabeticallyByStateKey,
+  StateToAuthorityTypeMap,
+} from '../../scripts/lib/authority-and-program-updater';
+
+test('correctly sort state authority information by state', tap => {
+  const unordered_json: StateToAuthorityTypeMap = {
+    CT: {
+      state: {
+        'ct-deep': {
+          name: 'CT Department of Energy & Environmental Protection',
+        },
+      },
+      utility: {
+        'ct-eversource': {
+          name: 'Eversource',
+        },
+        'ct-other-source': {
+          name: 'Othersource',
+        },
+      },
+    },
+    AZ: {
+      state: {},
+      utility: {
+        'az-mohave-electric-cooperative': {
+          name: 'Mohave Electric Cooperative',
+        },
+        'az-salt-river-project': {
+          name: 'Salt River Project',
+        },
+        'az-sulphur-springs-valley-electric-cooperative': {
+          name: 'Sulphur Springs Valley Electric Cooperative',
+        },
+        'az-tucson-electric-power': {
+          name: 'Tucson Electric Power',
+        },
+        'az-uni-source-energy-services': {
+          name: 'UniSource Energy Services',
+        },
+      },
+    },
+    VA: {
+      state: {},
+      utility: {
+        'va-appalachian-power': {
+          name: 'Appalachian Power',
+        },
+        'va-dominion-energy': {
+          name: 'Dominion Energy',
+        },
+      },
+    },
+  };
+  const ordered_json: StateToAuthorityTypeMap = {
+    AZ: {
+      state: {},
+      utility: {
+        'az-mohave-electric-cooperative': {
+          name: 'Mohave Electric Cooperative',
+        },
+        'az-salt-river-project': {
+          name: 'Salt River Project',
+        },
+        'az-sulphur-springs-valley-electric-cooperative': {
+          name: 'Sulphur Springs Valley Electric Cooperative',
+        },
+        'az-tucson-electric-power': {
+          name: 'Tucson Electric Power',
+        },
+        'az-uni-source-energy-services': {
+          name: 'UniSource Energy Services',
+        },
+      },
+    },
+    CT: {
+      state: {
+        'ct-deep': {
+          name: 'CT Department of Energy & Environmental Protection',
+        },
+      },
+      utility: {
+        'ct-eversource': {
+          name: 'Eversource',
+        },
+        'ct-other-source': {
+          name: 'Othersource',
+        },
+      },
+    },
+    VA: {
+      state: {},
+      utility: {
+        'va-appalachian-power': {
+          name: 'Appalachian Power',
+        },
+        'va-dominion-energy': {
+          name: 'Dominion Energy',
+        },
+      },
+    },
+  };
+  tap.matchOnly(ordered_json, sortJsonAlphabeticallyByStateKey(unordered_json));
+  tap.end();
+});


### PR DESCRIPTION
Added two more supported columns from incentive-a-thon spreadsheet, and added alphabetization of authorities' file. Typical json sorting wasn't successful as the key's name was the value to sort by, which wouldn't parse when defining the sort function.

That being said, a generalized alphabetization solution for both programs and authorities is also being experimented with, but this simpler solution is viable due to incentive calculation being sorted by state locations of incentives.

Programs still need to be sorted, and README details this.