### PR TITLE
Add amount minimum, remove item_type, don't accept add'l properties.

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -8,7 +8,6 @@
       "rebate"
     ],
     "item": "electric_vehicle_charger",
-    "item_type": "rebate",
     "program": "az_mohaveElectricCooperativeMohaveChargedRebates",
     "amount": {
       "type": "dollar_amount",
@@ -25,7 +24,6 @@
     "authority": "az-mohave-electric-cooperative",
     "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -50,7 +48,6 @@
       "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "rebate",
     "program": "az_mohaveElectricCooperativeMohaveHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -72,7 +69,6 @@
       "rebate"
     ],
     "item": "rooftop_solar_installation",
-    "item_type": "rebate",
     "program": "az_mohaveElectricCooperativeSunWattsRenewableEnergyAndRebateProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -94,7 +90,6 @@
       "rebate"
     ],
     "item": "battery_storage_installation",
-    "item_type": "rebate",
     "program": "az_mohaveElectricCooperativeMohaveHeatBatteryRebate",
     "amount": {
       "type": "dollar_amount",
@@ -114,7 +109,6 @@
       "pos_rebate"
     ],
     "item": "weatherization",
-    "item_type": "pos_rebate",
     "program": "az_saltRiverProjectInsulationRebate",
     "amount": {
       "type": "dollar_amount",
@@ -135,7 +129,6 @@
       "rebate"
     ],
     "item": "heat_pump_water_heater",
-    "item_type": "rebate",
     "program": "az_saltRiverProjectHeatPumpWaterHeaterRebate",
     "amount": {
       "type": "dollar_amount",
@@ -155,7 +148,6 @@
       "pos_rebate"
     ],
     "item": "electric_vehicle_charger",
-    "item_type": "pos_rebate",
     "program": "az_saltRiverProjectHomeElectricVehicleChargerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -175,7 +167,6 @@
       "rebate"
     ],
     "item": "electric_vehicle_charger",
-    "item_type": "rebate",
     "program": "az_saltRiverProjectHomeElectricVehicleChargerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -195,7 +186,6 @@
       "rebate"
     ],
     "item": "heat_pump_water_heater",
-    "item_type": "rebate",
     "program": "az_sulphurSpringsValleyElectricCooperativeHotWaterHeaterRebate",
     "amount": {
       "type": "dollar_amount",
@@ -215,7 +205,6 @@
       "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "rebate",
     "program": "az_sulphurSpringsValleyElectricCooperativeHeatPumpRebates",
     "amount": {
       "type": "dollar_amount",
@@ -235,7 +224,6 @@
       "assistance_program"
     ],
     "item": "weatherization",
-    "item_type": "assistance_program",
     "program": "az_tucsonElectricPowerWeatherizationAssistance",
     "amount": {
       "type": "percent",
@@ -256,7 +244,6 @@
       "rebate"
     ],
     "item": "heat_pump_water_heater",
-    "item_type": "rebate",
     "program": "az_tucsonElectricPowerEfficientHomeWaterHeating",
     "amount": {
       "type": "dollar_amount",
@@ -278,7 +265,6 @@
       "assistance_program"
     ],
     "item": "weatherization",
-    "item_type": "assistance_program",
     "program": "az_uniSourceEnergyServicesWeatherizationAssistance",
     "amount": {
       "type": "percent",
@@ -299,7 +285,6 @@
       "pos_rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "pos_rebate",
     "program": "az_uniSourceEnergyServicesEfficientHomeProgram",
     "amount": {
       "type": "dollar_amount",
@@ -319,7 +304,6 @@
       "pos_rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "pos_rebate",
     "program": "az_uniSourceEnergyServicesEfficientHomeProgram",
     "amount": {
       "type": "dollar_amount",

--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -48,10 +48,12 @@ const amountSchema: JSONSchemaType<Amount> = {
     type: { type: 'string', enum: Object.values(AmountType) },
     number: { type: 'number' },
     unit: { type: 'string', enum: Object.values(AmountUnit), nullable: true },
+    minimum: { type: 'number', nullable: true },
     maximum: { type: 'number', nullable: true },
     representative: { type: 'number', nullable: true },
   },
   required: ['type', 'number'],
+  additionalProperties: false,
 } as const;
 
 export const SCHEMA: JSONSchemaType<IRAIncentive[]> = {

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -48,10 +48,12 @@ const amountSchema: JSONSchemaType<Amount> = {
     type: { type: 'string', enum: Object.values(AmountType) },
     number: { type: 'number' },
     unit: { type: 'string', enum: Object.values(AmountUnit), nullable: true },
+    minimum: { type: 'number', nullable: true },
     maximum: { type: 'number', nullable: true },
     representative: { type: 'number', nullable: true },
   },
   required: ['type', 'number'],
+  additionalProperties: false,
 } as const;
 
 const incentivePropertySchema = {
@@ -120,6 +122,7 @@ export const AZ_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
       ...incentivePropertySchema,
     },
     required: requiredProperties,
+    additionalProperties: false,
   },
 } as const;
 
@@ -135,6 +138,7 @@ export const CO_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
       ...incentivePropertySchema,
     },
     required: requiredProperties,
+    additionalProperties: false,
   },
 } as const;
 

--- a/src/data/types/amount.ts
+++ b/src/data/types/amount.ts
@@ -19,21 +19,22 @@ export enum AmountUnit {
  * - dollar_amount. This must specify "number" as the exact or maximum number
  *   of dollars the incentive is for. Must not have "unit" or "representative".
  *
- *   TODO some also specify "maximum". For now this is just a marker that there
- *   is more to the incentive; it may be tiered flat amounts depending on
- *   equipment specs or some input we're not capturing, or something more
- *   complex.
+ *   TODO some also specify "minimum" or "maximum".
+ *   For now this is just a marker that there is more to the incentive; it may
+ *   be tiered flat amounts depending on equipment specs or some input we're
+ *   not capturing, or something more complex.
  *
- * - percent. Number is between 0 and 1. May also have "maximum" and
+ * - percent. Number is between 0 and 1. May also have "minimum", "maximum" and
  *   "representative". Must not have "unit".
  *
  * - dollars_per_unit. Number is dollars per unit. "unit" is required. May also
- *   have "maximum" and "representative".
+ *   have "minimum" and "maximum" and "representative".
  */
 export interface Amount {
   type: AmountType;
   number: number;
   unit?: AmountUnit;
+  minimum?: number;
   maximum?: number;
   representative?: number;
 }

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -210,7 +210,7 @@ function calculateFederalIncentivesAndSavings(
         savings.tax_credit += item.amount.representative;
       }
     } else {
-      throw new UnexpectedInputError(`Unknown item_type: ${item.type}`);
+      throw new UnexpectedInputError(`Unknown item type: ${item.type}`);
     }
   }
 

--- a/test/fixtures/test-incentives.json
+++ b/test/fixtures/test-incentives.json
@@ -5,7 +5,6 @@
     "authority": "ri-pascoag-utility-district",
     "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "account_credit",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -25,7 +24,6 @@
     "authority": "ri-pascoag-utility-district",
     "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "account_credit",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -46,7 +44,6 @@
     "authority": "ri-pascoag-utility-district",
     "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "account_credit",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -66,7 +63,6 @@
     "authority": "ri-pascoag-utility-district",
     "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "account_credit",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -85,7 +81,6 @@
     "authority": "ri-pascoag-utility-district",
     "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "account_credit",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -105,7 +100,6 @@
     "authority": "ri-pascoag-utility-district",
     "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
-    "item_type": "account_credit",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",


### PR DESCRIPTION
We didn't have `additionalProperties: false` on our incentive/amount schemas, which was letting unexpected fields creep in.

We *do* want to keep amount minimum, even though we're not using it on the frontend, as 4 different states have that field in their JSON already, so I've added it to the schema.

We want to get rid of item_type, which was deprecated and largely removed a while back.