### PR TITLE
Remove savings from API v1

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -47,6 +47,7 @@ export type CalculatedIncentive = (IRAIncentive | StateIncentive) & {
  */
 type CalculatedIncentives = Omit<APICalculatorResponse, 'incentives'> & {
   incentives: CalculatedIncentive[];
+  /** Only used in v0 for now */
   savings: APISavings;
 };
 

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -47,6 +47,7 @@ export type CalculatedIncentive = (IRAIncentive | StateIncentive) & {
  */
 type CalculatedIncentives = Omit<APICalculatorResponse, 'incentives'> & {
   incentives: CalculatedIncentive[];
+  savings: APISavings;
 };
 
 export type CalculateParams = Omit<APICalculatorRequest, 'location'>;

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -9,7 +9,6 @@ import {
   API_REQUEST_LOCATION_SCHEMA,
   API_RESPONSE_LOCATION_SCHEMA,
 } from './location';
-import { API_SAVINGS_SCHEMA } from './savings';
 
 const API_CALCULATOR_REQUEST_SCHEMA = {
   title: 'APICalculatorRequest',
@@ -112,7 +111,6 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
     'authorities',
     'coverage',
     'location',
-    'savings',
     'incentives',
   ],
   properties: {
@@ -131,7 +129,6 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
     },
     coverage: API_COVERAGE_SCHEMA,
     location: API_RESPONSE_LOCATION_SCHEMA,
-    savings: API_SAVINGS_SCHEMA,
     incentives: {
       type: 'array',
       items: { $ref: 'APIIncentive' },

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -21,13 +21,6 @@
     "city": "Block Island",
     "county": "Washington"
   },
-  "savings": {
-    "pos_rebate": 14000,
-    "tax_credit": 4036,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 5500
-  },
   "incentives": [
     {
       "type": "pos_rebate",

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -35,13 +35,6 @@
     "city": "Providence",
     "county": "Providence"
   },
-  "savings": {
-    "pos_rebate": 0,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 16100
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -12,13 +12,6 @@
     "city": "Pittsburgh",
     "county": "Allegheny"
   },
-  "savings": {
-    "pos_rebate": 14000,
-    "tax_credit": 5836,
-    "performance_rebate": 4000,
-    "account_credit": 0,
-    "rebate": 0
-  },
   "incentives": [
     {
       "type": "pos_rebate",

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -12,13 +12,6 @@
     "city": "Denver",
     "county": "Denver"
   },
-  "savings": {
-    "pos_rebate": 14000,
-    "tax_credit": 5836,
-    "performance_rebate": 8000,
-    "account_credit": 0,
-    "rebate": 0
-  },
   "incentives": [
     {
       "type": "pos_rebate",

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -16,13 +16,6 @@
     "city": "Tucson",
     "county": "Pima"
   },
-  "savings": {
-    "pos_rebate": 0,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 400
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -16,13 +16,6 @@
     "city": "Tucson",
     "county": "Pima"
   },
-  "savings": {
-    "pos_rebate": 1550,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 0
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -25,13 +25,6 @@
     "city": "Vail",
     "county": "Eagle"
   },
-  "savings": {
-    "pos_rebate": 0,
-    "tax_credit": 7500,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 0
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -19,13 +19,6 @@
     "city": "Bloomfield",
     "county": "Hartford"
   },
-  "savings": {
-    "pos_rebate": 7250,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 1650
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -22,13 +22,6 @@
     "city": "Hewlett",
     "county": "Nassau"
   },
-  "savings": {
-    "pos_rebate": 5040,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 1000
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -16,13 +16,6 @@
     "city": "Fairfax",
     "county": "Fairfax"
   },
-  "savings": {
-    "pos_rebate": 0,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 625
-  },
   "incentives": [
     {
       "type": "assistance_program",

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -22,13 +22,6 @@
     "city": "Burlington",
     "county": "Chittenden"
   },
-  "savings": {
-    "pos_rebate": 9850,
-    "tax_credit": 0,
-    "performance_rebate": 0,
-    "account_credit": 0,
-    "rebate": 3900
-  },
   "incentives": [
     {
       "type": "assistance_program",


### PR DESCRIPTION
## Description

These aren't being used in the frontend, and we've long known they're
a bit iffy in various ways. v0 is untouched.

Task to remove from API: https://app.asana.com/0/1204738794846444/1206540986137853

Old task to remove from frontend, where we discussed some of the problems:
https://app.asana.com/0/1205057814651000/1205608789805592/f

## Test Plan

`yarn test`, look at fixture changes.
