### PR TITLE
Remove type from v1 schema.

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -3,7 +3,6 @@
     "id": "AZ-1",
     "authority_type": "utility",
     "authority": "az-mohave-electric-cooperative",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -22,7 +21,6 @@
     "id": "AZ-2",
     "authority_type": "utility",
     "authority": "az-mohave-electric-cooperative",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -43,7 +41,6 @@
     "id": "AZ-3",
     "authority_type": "utility",
     "authority": "az-mohave-electric-cooperative",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -64,7 +61,6 @@
     "id": "AZ-5",
     "authority_type": "utility",
     "authority": "az-mohave-electric-cooperative",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -85,7 +81,6 @@
     "id": "AZ-6",
     "authority_type": "utility",
     "authority": "az-mohave-electric-cooperative",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -104,7 +99,6 @@
     "id": "AZ-7",
     "authority_type": "utility",
     "authority": "az-salt-river-project",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -124,7 +118,6 @@
     "id": "AZ-8",
     "authority_type": "utility",
     "authority": "az-salt-river-project",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -143,7 +136,6 @@
     "id": "AZ-9",
     "authority_type": "utility",
     "authority": "az-salt-river-project",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -162,7 +154,6 @@
     "id": "AZ-10",
     "authority_type": "utility",
     "authority": "az-salt-river-project",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -181,7 +172,6 @@
     "id": "AZ-11",
     "authority_type": "utility",
     "authority": "az-sulphur-springs-valley-electric-cooperative",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -200,7 +190,6 @@
     "id": "AZ-14",
     "authority_type": "utility",
     "authority": "az-sulphur-springs-valley-electric-cooperative",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -219,7 +208,6 @@
     "id": "AZ-18",
     "authority_type": "utility",
     "authority": "az-tucson-electric-power",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -239,7 +227,6 @@
     "id": "AZ-19",
     "authority_type": "utility",
     "authority": "az-tucson-electric-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -260,7 +247,6 @@
     "id": "AZ-21",
     "authority_type": "utility",
     "authority": "az-uni-source-energy-services",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -280,7 +266,6 @@
     "id": "AZ-22",
     "authority_type": "utility",
     "authority": "az-uni-source-energy-services",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -299,7 +284,6 @@
     "id": "AZ-23",
     "authority_type": "utility",
     "authority": "az-uni-source-energy-services",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -3,7 +3,6 @@
     "id": "CO-1",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -27,7 +26,6 @@
     "id": "CO-2",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -52,7 +50,6 @@
     "id": "CO-3",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -77,7 +74,6 @@
     "id": "CO-4",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -102,7 +98,6 @@
     "id": "CO-5",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -127,7 +122,6 @@
     "id": "CO-6",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -152,7 +146,6 @@
     "id": "CO-7",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -176,7 +169,6 @@
     "id": "CO-8",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -200,7 +192,6 @@
     "id": "CO-9",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -224,7 +215,6 @@
     "id": "CO-10",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -249,7 +239,6 @@
     "id": "CO-11",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -274,7 +263,6 @@
     "id": "CO-12",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -299,7 +287,6 @@
     "id": "CO-13",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -324,7 +311,6 @@
     "id": "CO-14",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -349,7 +335,6 @@
     "id": "CO-15",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -374,7 +359,6 @@
     "id": "CO-16",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -398,7 +382,6 @@
     "id": "CO-17",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -423,7 +406,6 @@
     "id": "CO-18",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -448,7 +430,6 @@
     "id": "CO-19",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -473,7 +454,6 @@
     "id": "CO-20",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -497,7 +477,6 @@
     "id": "CO-21",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -521,7 +500,6 @@
     "id": "CO-22",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -545,7 +523,6 @@
     "id": "CO-23",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -569,7 +546,6 @@
     "id": "CO-24",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -594,7 +570,6 @@
     "id": "CO-25",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -620,7 +595,6 @@
     "id": "CO-26",
     "authority_type": "utility",
     "authority": "co-black-hills-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -646,7 +620,6 @@
     "id": "CO-27",
     "authority_type": "utility",
     "authority": "co-colorado-springs-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -670,7 +643,6 @@
     "id": "CO-28",
     "authority_type": "utility",
     "authority": "co-colorado-springs-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -694,7 +666,6 @@
     "id": "CO-29",
     "authority_type": "utility",
     "authority": "co-colorado-springs-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -718,7 +689,6 @@
     "id": "CO-30",
     "authority_type": "utility",
     "authority": "co-colorado-springs-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -742,7 +712,6 @@
     "id": "CO-31",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -765,7 +734,6 @@
     "id": "CO-32",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -788,7 +756,6 @@
     "id": "CO-33",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -811,7 +778,6 @@
     "id": "CO-34",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -834,7 +800,6 @@
     "id": "CO-35",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -857,7 +822,6 @@
     "id": "CO-36",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -880,7 +844,6 @@
     "id": "CO-37",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -903,7 +866,6 @@
     "id": "CO-38",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -926,7 +888,6 @@
     "id": "CO-39",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -949,7 +910,6 @@
     "id": "CO-40",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -972,7 +932,6 @@
     "id": "CO-41",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -995,7 +954,6 @@
     "id": "CO-42",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1018,7 +976,6 @@
     "id": "CO-43",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1041,7 +998,6 @@
     "id": "CO-44",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1064,7 +1020,6 @@
     "id": "CO-45",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1087,7 +1042,6 @@
     "id": "CO-46",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1111,7 +1065,6 @@
     "id": "CO-47",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1135,7 +1088,6 @@
     "id": "CO-48",
     "authority_type": "county",
     "authority": "co-city-and-county-of-denver",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1158,7 +1110,6 @@
     "id": "CO-49",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1181,7 +1132,6 @@
     "id": "CO-50",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1204,7 +1154,6 @@
     "id": "CO-51",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1227,7 +1176,6 @@
     "id": "CO-52",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1250,7 +1198,6 @@
     "id": "CO-53",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1273,7 +1220,6 @@
     "id": "CO-54",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1296,7 +1242,6 @@
     "id": "CO-55",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1318,7 +1263,6 @@
     "id": "CO-56",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1341,7 +1285,6 @@
     "id": "CO-57",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1364,7 +1307,6 @@
     "id": "CO-58",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1387,7 +1329,6 @@
     "id": "CO-59",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1410,7 +1351,6 @@
     "id": "CO-60",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1433,7 +1373,6 @@
     "id": "CO-61",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1456,7 +1395,6 @@
     "id": "CO-62",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1479,7 +1417,6 @@
     "id": "CO-63",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1501,7 +1438,6 @@
     "id": "CO-64",
     "authority_type": "utility",
     "authority": "co-longmont-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1524,7 +1460,6 @@
     "id": "CO-65",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1547,7 +1482,6 @@
     "id": "CO-66",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1570,7 +1504,6 @@
     "id": "CO-67",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1593,7 +1526,6 @@
     "id": "CO-68",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1616,7 +1548,6 @@
     "id": "CO-69",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1639,7 +1570,6 @@
     "id": "CO-70",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1662,7 +1592,6 @@
     "id": "CO-71",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1684,7 +1613,6 @@
     "id": "CO-72",
     "authority_type": "utility",
     "authority": "co-estes-park-power-and-communications",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1707,7 +1635,6 @@
     "id": "CO-73",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1730,7 +1657,6 @@
     "id": "CO-74",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1753,7 +1679,6 @@
     "id": "CO-75",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1776,7 +1701,6 @@
     "id": "CO-76",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1799,7 +1723,6 @@
     "id": "CO-77",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1822,7 +1745,6 @@
     "id": "CO-78",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1845,7 +1767,6 @@
     "id": "CO-79",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1867,7 +1788,6 @@
     "id": "CO-80",
     "authority_type": "utility",
     "authority": "co-loveland-water-and-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1890,7 +1810,6 @@
     "id": "CO-81",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1913,7 +1832,6 @@
     "id": "CO-82",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1936,7 +1854,6 @@
     "id": "CO-83",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1959,7 +1876,6 @@
     "id": "CO-84",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -1982,7 +1898,6 @@
     "id": "CO-85",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2005,7 +1920,6 @@
     "id": "CO-86",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2028,7 +1942,6 @@
     "id": "CO-87",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2050,7 +1963,6 @@
     "id": "CO-88",
     "authority_type": "utility",
     "authority": "co-platte-river-power-authority",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2073,7 +1985,6 @@
     "id": "CO-89",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2096,7 +2007,6 @@
     "id": "CO-90",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2119,7 +2029,6 @@
     "id": "CO-91",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2140,7 +2049,6 @@
     "id": "CO-92",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2163,7 +2071,6 @@
     "id": "CO-93",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2186,7 +2093,6 @@
     "id": "CO-94",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2209,7 +2115,6 @@
     "id": "CO-95",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2232,7 +2137,6 @@
     "id": "CO-96",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2255,7 +2159,6 @@
     "id": "CO-97",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2278,7 +2181,6 @@
     "id": "CO-98",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2301,7 +2203,6 @@
     "id": "CO-99",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2323,7 +2224,6 @@
     "id": "CO-100",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2346,7 +2246,6 @@
     "id": "CO-101",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2369,7 +2268,6 @@
     "id": "CO-102",
     "authority_type": "utility",
     "authority": "co-empire-electric-association-and-tri-state-generation-and-transmission-association-inc",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2392,7 +2290,6 @@
     "id": "CO-103",
     "authority_type": "state",
     "authority": "co-energy-outreach-colorado",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -2415,7 +2312,6 @@
     "id": "CO-104",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2438,7 +2334,6 @@
     "id": "CO-105",
     "authority_type": "utility",
     "authority": "co-fort-collins-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2461,7 +2356,6 @@
     "id": "CO-106",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2482,7 +2376,6 @@
     "id": "CO-107",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2503,7 +2396,6 @@
     "id": "CO-108",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2524,7 +2416,6 @@
     "id": "CO-109",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2546,7 +2437,6 @@
     "id": "CO-110",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2569,7 +2459,6 @@
     "id": "CO-111",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2592,7 +2481,6 @@
     "id": "CO-112",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2615,7 +2503,6 @@
     "id": "CO-113",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2637,7 +2524,6 @@
     "id": "CO-114",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2658,7 +2544,6 @@
     "id": "CO-115",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2679,7 +2564,6 @@
     "id": "CO-116",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2701,7 +2585,6 @@
     "id": "CO-117",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2723,7 +2606,6 @@
     "id": "CO-118",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2745,7 +2627,6 @@
     "id": "CO-119",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2768,7 +2649,6 @@
     "id": "CO-120",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2791,7 +2671,6 @@
     "id": "CO-121",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2814,7 +2693,6 @@
     "id": "CO-122",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2837,7 +2715,6 @@
     "id": "CO-123",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2860,7 +2737,6 @@
     "id": "CO-124",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2883,7 +2759,6 @@
     "id": "CO-125",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2905,7 +2780,6 @@
     "id": "CO-126",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2926,7 +2800,6 @@
     "id": "CO-127",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2950,7 +2823,6 @@
     "id": "CO-128",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2973,7 +2845,6 @@
     "id": "CO-129",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -2996,7 +2867,6 @@
     "id": "CO-130",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3019,7 +2889,6 @@
     "id": "CO-131",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3042,7 +2911,6 @@
     "id": "CO-132",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3065,7 +2933,6 @@
     "id": "CO-133",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3088,7 +2955,6 @@
     "id": "CO-134",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3111,7 +2977,6 @@
     "id": "CO-135",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3134,7 +2999,6 @@
     "id": "CO-136",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3157,7 +3021,6 @@
     "id": "CO-137",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3178,7 +3041,6 @@
     "id": "CO-138",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3199,7 +3061,6 @@
     "id": "CO-139",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3220,7 +3081,6 @@
     "id": "CO-140",
     "authority_type": "utility",
     "authority": "co-gunnison-county-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3241,7 +3101,6 @@
     "id": "CO-141",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3262,7 +3121,6 @@
     "id": "CO-142",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3283,7 +3141,6 @@
     "id": "CO-143",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3304,7 +3161,6 @@
     "id": "CO-144",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3325,7 +3181,6 @@
     "id": "CO-145",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3346,7 +3201,6 @@
     "id": "CO-146",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3367,7 +3221,6 @@
     "id": "CO-147",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3388,7 +3241,6 @@
     "id": "CO-148",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3409,7 +3261,6 @@
     "id": "CO-149",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3432,7 +3283,6 @@
     "id": "CO-150",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3453,7 +3303,6 @@
     "id": "CO-151",
     "authority_type": "utility",
     "authority": "co-holy-cross-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3476,7 +3325,6 @@
     "id": "CO-152",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3499,7 +3347,6 @@
     "id": "CO-153",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3522,7 +3369,6 @@
     "id": "CO-154",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3544,7 +3390,6 @@
     "id": "CO-155",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3566,7 +3411,6 @@
     "id": "CO-156",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3589,7 +3433,6 @@
     "id": "CO-157",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3610,7 +3453,6 @@
     "id": "CO-158",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3632,7 +3474,6 @@
     "id": "CO-159",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3654,7 +3495,6 @@
     "id": "CO-160",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3676,7 +3516,6 @@
     "id": "CO-161",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3698,7 +3537,6 @@
     "id": "CO-162",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3720,7 +3558,6 @@
     "id": "CO-163",
     "authority_type": "utility",
     "authority": "co-la-plata-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3742,7 +3579,6 @@
     "id": "CO-164",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3765,7 +3601,6 @@
     "id": "CO-165",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3786,7 +3621,6 @@
     "id": "CO-166",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3807,7 +3641,6 @@
     "id": "CO-167",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3828,7 +3661,6 @@
     "id": "CO-168",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3849,7 +3681,6 @@
     "id": "CO-169",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3871,7 +3702,6 @@
     "id": "CO-170",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3892,7 +3722,6 @@
     "id": "CO-171",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3914,7 +3743,6 @@
     "id": "CO-172",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3936,7 +3764,6 @@
     "id": "CO-173",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3959,7 +3786,6 @@
     "id": "CO-174",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -3982,7 +3808,6 @@
     "id": "CO-175",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4003,7 +3828,6 @@
     "id": "CO-176",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4024,7 +3848,6 @@
     "id": "CO-177",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4047,7 +3870,6 @@
     "id": "CO-178",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4070,7 +3892,6 @@
     "id": "CO-179",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4093,7 +3914,6 @@
     "id": "CO-180",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4116,7 +3936,6 @@
     "id": "CO-181",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4139,7 +3958,6 @@
     "id": "CO-182",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4163,7 +3981,6 @@
     "id": "CO-183",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4185,7 +4002,6 @@
     "id": "CO-184",
     "authority_type": "utility",
     "authority": "co-morgan-county-rea",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -4207,7 +4023,6 @@
     "id": "CO-185",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4229,7 +4044,6 @@
     "id": "CO-186",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4251,7 +4065,6 @@
     "id": "CO-187",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4275,7 +4088,6 @@
     "id": "CO-188",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4298,7 +4110,6 @@
     "id": "CO-189",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4322,7 +4133,6 @@
     "id": "CO-190",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4345,7 +4155,6 @@
     "id": "CO-191",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4368,7 +4177,6 @@
     "id": "CO-192",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4392,7 +4200,6 @@
     "id": "CO-193",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4416,7 +4223,6 @@
     "id": "CO-194",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4438,7 +4244,6 @@
     "id": "CO-195",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4460,7 +4265,6 @@
     "id": "CO-196",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4484,7 +4288,6 @@
     "id": "CO-197",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4508,7 +4311,6 @@
     "id": "CO-198",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4533,7 +4335,6 @@
     "id": "CO-199",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4557,7 +4358,6 @@
     "id": "CO-200",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4581,7 +4381,6 @@
     "id": "CO-201",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4606,7 +4405,6 @@
     "id": "CO-202",
     "authority_type": "utility",
     "authority": "co-mountain-view-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -4629,7 +4427,6 @@
     "id": "CO-203",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4651,7 +4448,6 @@
     "id": "CO-204",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4673,7 +4469,6 @@
     "id": "CO-205",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4697,7 +4492,6 @@
     "id": "CO-206",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4719,7 +4513,6 @@
     "id": "CO-207",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4741,7 +4534,6 @@
     "id": "CO-208",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4763,7 +4555,6 @@
     "id": "CO-209",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4785,7 +4576,6 @@
     "id": "CO-210",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4809,7 +4599,6 @@
     "id": "CO-211",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4833,7 +4622,6 @@
     "id": "CO-212",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4857,7 +4645,6 @@
     "id": "CO-213",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4881,7 +4668,6 @@
     "id": "CO-214",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4905,7 +4691,6 @@
     "id": "CO-215",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4929,7 +4714,6 @@
     "id": "CO-216",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4953,7 +4737,6 @@
     "id": "CO-217",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4977,7 +4760,6 @@
     "id": "CO-218",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5001,7 +4783,6 @@
     "id": "CO-219",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5025,7 +4806,6 @@
     "id": "CO-220",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5049,7 +4829,6 @@
     "id": "CO-221",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5072,7 +4851,6 @@
     "id": "CO-222",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5095,7 +4873,6 @@
     "id": "CO-223",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5118,7 +4895,6 @@
     "id": "CO-224",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5140,7 +4916,6 @@
     "id": "CO-225",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5162,7 +4937,6 @@
     "id": "CO-226",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5184,7 +4958,6 @@
     "id": "CO-227",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5206,7 +4979,6 @@
     "id": "CO-228",
     "authority_type": "utility",
     "authority": "co-poudre-valley-rea",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -5228,7 +5000,6 @@
     "id": "CO-229",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5251,7 +5022,6 @@
     "id": "CO-230",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5274,7 +5044,6 @@
     "id": "CO-231",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5297,7 +5066,6 @@
     "id": "CO-232",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5322,7 +5090,6 @@
     "id": "CO-233",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5347,7 +5114,6 @@
     "id": "CO-234",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5372,7 +5138,6 @@
     "id": "CO-235",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5397,7 +5162,6 @@
     "id": "CO-236",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5422,7 +5186,6 @@
     "id": "CO-237",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5447,7 +5210,6 @@
     "id": "CO-238",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5472,7 +5234,6 @@
     "id": "CO-239",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5495,7 +5256,6 @@
     "id": "CO-240",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5518,7 +5278,6 @@
     "id": "CO-241",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5542,7 +5301,6 @@
     "id": "CO-242",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5566,7 +5324,6 @@
     "id": "CO-243",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5590,7 +5347,6 @@
     "id": "CO-244",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5614,7 +5370,6 @@
     "id": "CO-245",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5638,7 +5393,6 @@
     "id": "CO-246",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5662,7 +5416,6 @@
     "id": "CO-247",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5686,7 +5439,6 @@
     "id": "CO-248",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5710,7 +5462,6 @@
     "id": "CO-249",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5734,7 +5485,6 @@
     "id": "CO-250",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5758,7 +5508,6 @@
     "id": "CO-251",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5782,7 +5531,6 @@
     "id": "CO-252",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5806,7 +5554,6 @@
     "id": "CO-253",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5830,7 +5577,6 @@
     "id": "CO-254",
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -5855,7 +5601,6 @@
     "id": "CO-255",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -5878,7 +5623,6 @@
     "id": "CO-256",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -5900,7 +5644,6 @@
     "id": "CO-257",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -5922,7 +5665,6 @@
     "id": "CO-258",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -5943,7 +5685,6 @@
     "id": "CO-259",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -5964,7 +5705,6 @@
     "id": "CO-260",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -5985,7 +5725,6 @@
     "id": "CO-261",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6006,7 +5745,6 @@
     "id": "CO-262",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6027,7 +5765,6 @@
     "id": "CO-263",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -6050,7 +5787,6 @@
     "id": "CO-264",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6072,7 +5808,6 @@
     "id": "CO-265",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6095,7 +5830,6 @@
     "id": "CO-266",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6118,7 +5852,6 @@
     "id": "CO-267",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6141,7 +5874,6 @@
     "id": "CO-268",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6164,7 +5896,6 @@
     "id": "CO-269",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6187,7 +5918,6 @@
     "id": "CO-270",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6210,7 +5940,6 @@
     "id": "CO-271",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6232,7 +5961,6 @@
     "id": "CO-272",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6255,7 +5983,6 @@
     "id": "CO-273",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6278,7 +6005,6 @@
     "id": "CO-274",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6301,7 +6027,6 @@
     "id": "CO-275",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6324,7 +6049,6 @@
     "id": "CO-276",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6347,7 +6071,6 @@
     "id": "CO-277",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6370,7 +6093,6 @@
     "id": "CO-278",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6392,7 +6114,6 @@
     "id": "CO-279",
     "authority_type": "utility",
     "authority": "co-san-miguel-power-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6414,7 +6135,6 @@
     "id": "CO-280",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6435,7 +6155,6 @@
     "id": "CO-281",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6456,7 +6175,6 @@
     "id": "CO-282",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6479,7 +6197,6 @@
     "id": "CO-283",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6501,7 +6218,6 @@
     "id": "CO-284",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6523,7 +6239,6 @@
     "id": "CO-285",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6545,7 +6260,6 @@
     "id": "CO-286",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6567,7 +6281,6 @@
     "id": "CO-287",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6589,7 +6302,6 @@
     "id": "CO-288",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6610,7 +6322,6 @@
     "id": "CO-289",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6632,7 +6343,6 @@
     "id": "CO-290",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6654,7 +6364,6 @@
     "id": "CO-291",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6677,7 +6386,6 @@
     "id": "CO-292",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6698,7 +6406,6 @@
     "id": "CO-293",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6719,7 +6426,6 @@
     "id": "CO-294",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6742,7 +6448,6 @@
     "id": "CO-295",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6766,7 +6471,6 @@
     "id": "CO-296",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6789,7 +6493,6 @@
     "id": "CO-297",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6812,7 +6515,6 @@
     "id": "CO-298",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6835,7 +6537,6 @@
     "id": "CO-299",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6858,7 +6559,6 @@
     "id": "CO-300",
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
-    "type": "unknown",
     "payment_methods": [
       "unknown"
     ],
@@ -6880,7 +6580,6 @@
     "id": "CO-301",
     "authority_type": "utility",
     "authority": "co-tri-state-g-t",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6902,7 +6601,6 @@
     "id": "CO-302",
     "authority_type": "utility",
     "authority": "co-tri-state-g-t",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6924,7 +6622,6 @@
     "id": "CO-303",
     "authority_type": "utility",
     "authority": "co-tri-state-g-t",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6946,7 +6643,6 @@
     "id": "CO-304",
     "authority_type": "utility",
     "authority": "co-tri-state-g-t",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6967,7 +6663,6 @@
     "id": "CO-305",
     "authority_type": "utility",
     "authority": "co-united-power",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -6989,7 +6684,6 @@
     "id": "CO-306",
     "authority_type": "utility",
     "authority": "co-united-power",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -7010,7 +6704,6 @@
     "id": "CO-307",
     "authority_type": "utility",
     "authority": "co-united-power",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -7031,7 +6724,6 @@
     "id": "CO-308",
     "authority_type": "utility",
     "authority": "co-united-power",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -7052,7 +6744,6 @@
     "id": "CO-309",
     "authority_type": "utility",
     "authority": "co-united-power",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -7073,7 +6764,6 @@
     "id": "CO-310",
     "authority_type": "utility",
     "authority": "co-united-power",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -7094,7 +6784,6 @@
     "id": "CO-311",
     "authority_type": "utility",
     "authority": "co-xcel-energy",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7117,7 +6806,6 @@
     "id": "CO-312",
     "authority_type": "utility",
     "authority": "co-xcel-energy",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7140,7 +6828,6 @@
     "id": "CO-313",
     "authority_type": "utility",
     "authority": "co-xcel-energy",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7164,7 +6851,6 @@
     "id": "CO-314",
     "authority_type": "utility",
     "authority": "co-xcel-energy",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7187,7 +6873,6 @@
     "id": "CO-315",
     "authority_type": "utility",
     "authority": "co-xcel-energy",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7210,7 +6895,6 @@
     "id": "CO-316",
     "authority_type": "state",
     "authority": "co-colorado-energy-office",
-    "type": "tax_credit",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7233,7 +6917,6 @@
     "id": "CO-317",
     "authority_type": "state",
     "authority": "co-colorado-energy-office",
-    "type": "tax_credit",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7257,7 +6940,6 @@
     "id": "CO-318",
     "authority_type": "state",
     "authority": "co-colorado-energy-office",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7280,7 +6962,6 @@
     "id": "CO-319",
     "authority_type": "state",
     "authority": "co-colorado-energy-office",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7303,7 +6984,6 @@
     "id": "CO-320",
     "authority_type": "state",
     "authority": "co-state-of-colorado",
-    "type": "tax_credit",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7327,7 +7007,6 @@
     "id": "CO-321",
     "authority_type": "state",
     "authority": "co-state-of-colorado",
-    "type": "tax_credit",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7350,7 +7029,6 @@
     "id": "CO-322",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7374,7 +7052,6 @@
     "id": "CO-323",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7398,7 +7075,6 @@
     "id": "CO-324",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7422,7 +7098,6 @@
     "id": "CO-325",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7446,7 +7121,6 @@
     "id": "CO-326",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7470,7 +7144,6 @@
     "id": "CO-327",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7494,7 +7167,6 @@
     "id": "CO-328",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7518,7 +7190,6 @@
     "id": "CO-329",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7542,7 +7213,6 @@
     "id": "CO-330",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7566,7 +7236,6 @@
     "id": "CO-331",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7590,7 +7259,6 @@
     "id": "CO-332",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7614,7 +7282,6 @@
     "id": "CO-333",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7638,7 +7305,6 @@
     "id": "CO-334",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7662,7 +7328,6 @@
     "id": "CO-335",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7685,7 +7350,6 @@
     "id": "CO-336",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7709,7 +7373,6 @@
     "id": "CO-337",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7733,7 +7396,6 @@
     "id": "CO-338",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7757,7 +7419,6 @@
     "id": "CO-339",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7780,7 +7441,6 @@
     "id": "CO-340",
     "authority_type": "city",
     "authority": "co-city-of-boulder",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7801,7 +7461,6 @@
     "id": "CO-341",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7826,7 +7485,6 @@
     "id": "CO-342",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7851,7 +7509,6 @@
     "id": "CO-343",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7876,7 +7533,6 @@
     "id": "CO-344",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7900,7 +7556,6 @@
     "id": "CO-345",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7925,7 +7580,6 @@
     "id": "CO-346",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7950,7 +7604,6 @@
     "id": "CO-347",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -7975,7 +7628,6 @@
     "id": "CO-348",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8000,7 +7652,6 @@
     "id": "CO-349",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8025,7 +7676,6 @@
     "id": "CO-350",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8050,7 +7700,6 @@
     "id": "CO-351",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8074,7 +7723,6 @@
     "id": "CO-352",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8099,7 +7747,6 @@
     "id": "CO-353",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8124,7 +7771,6 @@
     "id": "CO-354",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8148,7 +7794,6 @@
     "id": "CO-355",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8173,7 +7818,6 @@
     "id": "CO-356",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8198,7 +7842,6 @@
     "id": "CO-357",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8222,7 +7865,6 @@
     "id": "CO-358",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8246,7 +7888,6 @@
     "id": "CO-359",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8270,7 +7911,6 @@
     "id": "CO-360",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8295,7 +7935,6 @@
     "id": "CO-361",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8320,7 +7959,6 @@
     "id": "CO-362",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8345,7 +7983,6 @@
     "id": "CO-363",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8369,7 +8006,6 @@
     "id": "CO-364",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8394,7 +8030,6 @@
     "id": "CO-365",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8418,7 +8053,6 @@
     "id": "CO-366",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8442,7 +8076,6 @@
     "id": "CO-367",
     "authority_type": "county",
     "authority": "co-boulder-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8466,7 +8099,6 @@
     "id": "CO-368",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8488,7 +8120,6 @@
     "id": "CO-369",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8510,7 +8141,6 @@
     "id": "CO-370",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8533,7 +8163,6 @@
     "id": "CO-371",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8556,7 +8185,6 @@
     "id": "CO-372",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8579,7 +8207,6 @@
     "id": "CO-373",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8601,7 +8228,6 @@
     "id": "CO-374",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8623,7 +8249,6 @@
     "id": "CO-375",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8647,7 +8272,6 @@
     "id": "CO-376",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8672,7 +8296,6 @@
     "id": "CO-377",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8694,7 +8317,6 @@
     "id": "CO-378",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8716,7 +8338,6 @@
     "id": "CO-379",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8738,7 +8359,6 @@
     "id": "CO-380",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8760,7 +8380,6 @@
     "id": "CO-381",
     "authority_type": "utility",
     "authority": "co-glenwood-springs-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8782,7 +8401,6 @@
     "id": "CO-382",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8807,7 +8425,6 @@
     "id": "CO-383",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8832,7 +8449,6 @@
     "id": "CO-384",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8857,7 +8473,6 @@
     "id": "CO-385",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8882,7 +8497,6 @@
     "id": "CO-386",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8907,7 +8521,6 @@
     "id": "CO-387",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8932,7 +8545,6 @@
     "id": "CO-388",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8957,7 +8569,6 @@
     "id": "CO-389",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -8980,7 +8591,6 @@
     "id": "CO-390",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9004,7 +8614,6 @@
     "id": "CO-391",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9028,7 +8637,6 @@
     "id": "CO-392",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9051,7 +8659,6 @@
     "id": "CO-393",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9076,7 +8683,6 @@
     "id": "CO-394",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9101,7 +8707,6 @@
     "id": "CO-395",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9126,7 +8731,6 @@
     "id": "CO-396",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9149,7 +8753,6 @@
     "id": "CO-397",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9173,7 +8776,6 @@
     "id": "CO-398",
     "authority_type": "utility",
     "authority": "co-highline-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9197,7 +8799,6 @@
     "id": "CO-399",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9218,7 +8819,6 @@
     "id": "CO-400",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9240,7 +8840,6 @@
     "id": "CO-401",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9262,7 +8861,6 @@
     "id": "CO-402",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9284,7 +8882,6 @@
     "id": "CO-403",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9306,7 +8903,6 @@
     "id": "CO-404",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9328,7 +8924,6 @@
     "id": "CO-405",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9350,7 +8945,6 @@
     "id": "CO-406",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9372,7 +8966,6 @@
     "id": "CO-407",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9394,7 +8987,6 @@
     "id": "CO-408",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9416,7 +9008,6 @@
     "id": "CO-409",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9437,7 +9028,6 @@
     "id": "CO-410",
     "authority_type": "utility",
     "authority": "co-kc-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9458,7 +9048,6 @@
     "id": "CO-411",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9481,7 +9070,6 @@
     "id": "CO-412",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9504,7 +9092,6 @@
     "id": "CO-413",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9527,7 +9114,6 @@
     "id": "CO-414",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9550,7 +9136,6 @@
     "id": "CO-415",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9572,7 +9157,6 @@
     "id": "CO-416",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9594,7 +9178,6 @@
     "id": "CO-417",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9617,7 +9200,6 @@
     "id": "CO-418",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9638,7 +9220,6 @@
     "id": "CO-419",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9659,7 +9240,6 @@
     "id": "CO-420",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9680,7 +9260,6 @@
     "id": "CO-421",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9701,7 +9280,6 @@
     "id": "CO-422",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9722,7 +9300,6 @@
     "id": "CO-423",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9744,7 +9321,6 @@
     "id": "CO-424",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9766,7 +9342,6 @@
     "id": "CO-425",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9788,7 +9363,6 @@
     "id": "CO-426",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9810,7 +9384,6 @@
     "id": "CO-427",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9832,7 +9405,6 @@
     "id": "CO-428",
     "authority_type": "utility",
     "authority": "co-mountain-parks-electric",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -9853,7 +9425,6 @@
     "id": "CO-429",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9876,7 +9447,6 @@
     "id": "CO-430",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9897,7 +9467,6 @@
     "id": "CO-431",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9918,7 +9487,6 @@
     "id": "CO-432",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9939,7 +9507,6 @@
     "id": "CO-433",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9960,7 +9527,6 @@
     "id": "CO-434",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -9982,7 +9548,6 @@
     "id": "CO-435",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10003,7 +9568,6 @@
     "id": "CO-436",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10025,7 +9589,6 @@
     "id": "CO-437",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10047,7 +9610,6 @@
     "id": "CO-438",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10070,7 +9632,6 @@
     "id": "CO-439",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10093,7 +9654,6 @@
     "id": "CO-440",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10114,7 +9674,6 @@
     "id": "CO-441",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10135,7 +9694,6 @@
     "id": "CO-442",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10158,7 +9716,6 @@
     "id": "CO-443",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10181,7 +9738,6 @@
     "id": "CO-444",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10204,7 +9760,6 @@
     "id": "CO-445",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10227,7 +9782,6 @@
     "id": "CO-446",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10250,7 +9804,6 @@
     "id": "CO-447",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10274,7 +9827,6 @@
     "id": "CO-448",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10296,7 +9848,6 @@
     "id": "CO-449",
     "authority_type": "utility",
     "authority": "co-san-luis-valley-rec",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10318,7 +9869,6 @@
     "id": "CO-450",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10339,7 +9889,6 @@
     "id": "CO-451",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10360,7 +9909,6 @@
     "id": "CO-452",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10381,7 +9929,6 @@
     "id": "CO-453",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10402,7 +9949,6 @@
     "id": "CO-454",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10424,7 +9970,6 @@
     "id": "CO-455",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10446,7 +9991,6 @@
     "id": "CO-456",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10468,7 +10012,6 @@
     "id": "CO-457",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10490,7 +10033,6 @@
     "id": "CO-458",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -10512,7 +10054,6 @@
     "id": "CO-459",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10534,7 +10075,6 @@
     "id": "CO-460",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10557,7 +10097,6 @@
     "id": "CO-461",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10580,7 +10119,6 @@
     "id": "CO-462",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10603,7 +10141,6 @@
     "id": "CO-463",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10626,7 +10163,6 @@
     "id": "CO-464",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10649,7 +10185,6 @@
     "id": "CO-465",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10672,7 +10207,6 @@
     "id": "CO-466",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10693,7 +10227,6 @@
     "id": "CO-467",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10715,7 +10248,6 @@
     "id": "CO-468",
     "authority_type": "utility",
     "authority": "co-sangre-de-cristo-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10737,7 +10269,6 @@
     "id": "CO-469",
     "authority_type": "city",
     "authority": "co-town-of-avon",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10758,7 +10289,6 @@
     "id": "CO-470",
     "authority_type": "city",
     "authority": "co-town-of-avon",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10779,7 +10309,6 @@
     "id": "CO-471",
     "authority_type": "city",
     "authority": "co-town-of-avon",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10800,7 +10329,6 @@
     "id": "CO-472",
     "authority_type": "city",
     "authority": "co-town-of-eagle",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10821,7 +10349,6 @@
     "id": "CO-473",
     "authority_type": "city",
     "authority": "co-town-of-eagle",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10842,7 +10369,6 @@
     "id": "CO-474",
     "authority_type": "city",
     "authority": "co-town-of-eagle",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10863,7 +10389,6 @@
     "id": "CO-475",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10884,7 +10409,6 @@
     "id": "CO-476",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10905,7 +10429,6 @@
     "id": "CO-477",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10926,7 +10449,6 @@
     "id": "CO-478",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10947,7 +10469,6 @@
     "id": "CO-479",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10968,7 +10489,6 @@
     "id": "CO-480",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -10989,7 +10509,6 @@
     "id": "CO-481",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11010,7 +10529,6 @@
     "id": "CO-482",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11031,7 +10549,6 @@
     "id": "CO-483",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11052,7 +10569,6 @@
     "id": "CO-484",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11073,7 +10589,6 @@
     "id": "CO-485",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11094,7 +10609,6 @@
     "id": "CO-486",
     "authority_type": "city",
     "authority": "co-town-of-erie",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11115,7 +10629,6 @@
     "id": "CO-487",
     "authority_type": "city",
     "authority": "co-town-of-vail",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11136,7 +10649,6 @@
     "id": "CO-488",
     "authority_type": "city",
     "authority": "co-town-of-vail",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11157,7 +10669,6 @@
     "id": "CO-489",
     "authority_type": "city",
     "authority": "co-town-of-vail",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11178,7 +10689,6 @@
     "id": "CO-490",
     "authority_type": "city",
     "authority": "co-town-of-vail",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11201,7 +10711,6 @@
     "id": "CO-491",
     "authority_type": "city",
     "authority": "co-town-of-vail",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11223,7 +10732,6 @@
     "id": "CO-492",
     "authority_type": "city",
     "authority": "co-town-of-vail",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11245,7 +10753,6 @@
     "id": "CO-493",
     "authority_type": "county",
     "authority": "co-unincorporated-eagle-county",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11268,7 +10775,6 @@
     "id": "CO-494",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -11290,7 +10796,6 @@
     "id": "CO-495",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11312,7 +10817,6 @@
     "id": "CO-496",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11334,7 +10838,6 @@
     "id": "CO-497",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11356,7 +10859,6 @@
     "id": "CO-498",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11378,7 +10880,6 @@
     "id": "CO-499",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11400,7 +10901,6 @@
     "id": "CO-500",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11422,7 +10922,6 @@
     "id": "CO-501",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11444,7 +10943,6 @@
     "id": "CO-502",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11466,7 +10964,6 @@
     "id": "CO-503",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11488,7 +10985,6 @@
     "id": "CO-504",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11510,7 +11006,6 @@
     "id": "CO-505",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11532,7 +11027,6 @@
     "id": "CO-506",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11555,7 +11049,6 @@
     "id": "CO-507",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11578,7 +11071,6 @@
     "id": "CO-508",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11601,7 +11093,6 @@
     "id": "CO-509",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11624,7 +11115,6 @@
     "id": "CO-510",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11647,7 +11137,6 @@
     "id": "CO-511",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11670,7 +11159,6 @@
     "id": "CO-512",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11693,7 +11181,6 @@
     "id": "CO-513",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11716,7 +11203,6 @@
     "id": "CO-514",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11739,7 +11225,6 @@
     "id": "CO-515",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11762,7 +11247,6 @@
     "id": "CO-516",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11785,7 +11269,6 @@
     "id": "CO-517",
     "authority_type": "utility",
     "authority": "co-walking-mountains",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11808,7 +11291,6 @@
     "id": "CO-518",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11829,7 +11311,6 @@
     "id": "CO-519",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11850,7 +11331,6 @@
     "id": "CO-520",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11873,7 +11353,6 @@
     "id": "CO-521",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11896,7 +11375,6 @@
     "id": "CO-522",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11919,7 +11397,6 @@
     "id": "CO-523",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11942,7 +11419,6 @@
     "id": "CO-524",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11965,7 +11441,6 @@
     "id": "CO-525",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -11988,7 +11463,6 @@
     "id": "CO-526",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12011,7 +11485,6 @@
     "id": "CO-527",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12032,7 +11505,6 @@
     "id": "CO-528",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12053,7 +11525,6 @@
     "id": "CO-529",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12074,7 +11545,6 @@
     "id": "CO-530",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12095,7 +11565,6 @@
     "id": "CO-531",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12116,7 +11585,6 @@
     "id": "CO-532",
     "authority_type": "utility",
     "authority": "co-white-river-electric-association",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -12138,7 +11606,6 @@
     "id": "CO-533",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12160,7 +11627,6 @@
     "id": "CO-534",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12183,7 +11649,6 @@
     "id": "CO-535",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12206,7 +11671,6 @@
     "id": "CO-536",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12227,7 +11691,6 @@
     "id": "CO-537",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12250,7 +11713,6 @@
     "id": "CO-538",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12272,7 +11734,6 @@
     "id": "CO-539",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12294,7 +11755,6 @@
     "id": "CO-540",
     "authority_type": "utility",
     "authority": "co-yw-electric-association",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],

--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -3,7 +3,6 @@
     "id": "CT-1",
     "authority_type": "utility",
     "authority": "ct-eversource",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -26,7 +25,6 @@
     "id": "CT-2",
     "authority_type": "utility",
     "authority": "ct-eversource",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -51,7 +49,6 @@
     "id": "CT-3",
     "authority_type": "utility",
     "authority": "ct-eversource",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -74,7 +71,6 @@
     "id": "CT-4",
     "authority_type": "utility",
     "authority": "ct-united-illuminating-company",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -97,7 +93,6 @@
     "id": "CT-5",
     "authority_type": "utility",
     "authority": "ct-groton-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -123,7 +118,6 @@
     "id": "CT-6",
     "authority_type": "utility",
     "authority": "ct-groton-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -146,7 +140,6 @@
     "id": "CT-7",
     "authority_type": "utility",
     "authority": "ct-groton-utilities",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -167,7 +160,6 @@
     "id": "CT-8",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -190,7 +182,6 @@
     "id": "CT-9",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -215,7 +206,6 @@
     "id": "CT-10",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -240,7 +230,6 @@
     "id": "CT-11",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -265,7 +254,6 @@
     "id": "CT-12",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -290,7 +278,6 @@
     "id": "CT-13",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -313,7 +300,6 @@
     "id": "CT-15",
     "authority_type": "utility",
     "authority": "ct-united-illuminating-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -338,7 +324,6 @@
     "id": "CT-16",
     "authority_type": "utility",
     "authority": "ct-united-illuminating-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -363,7 +348,6 @@
     "id": "CT-17",
     "authority_type": "utility",
     "authority": "ct-united-illuminating-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -386,7 +370,6 @@
     "id": "CT-20",
     "authority_type": "utility",
     "authority": "ct-eversource",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -411,7 +394,6 @@
     "id": "CT-24",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -436,7 +418,6 @@
     "id": "CT-25",
     "authority_type": "utility",
     "authority": "ct-eversource",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -459,7 +440,6 @@
     "id": "CT-26",
     "authority_type": "utility",
     "authority": "ct-eversource",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -482,7 +462,6 @@
     "id": "CT-27",
     "authority_type": "utility",
     "authority": "ct-united-illuminating-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -505,7 +484,6 @@
     "id": "CT-28",
     "authority_type": "utility",
     "authority": "ct-united-illuminating-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -528,7 +506,6 @@
     "id": "CT-29",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -552,7 +529,6 @@
     "id": "CT-30",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -576,7 +552,6 @@
     "id": "CT-31",
     "authority_type": "utility",
     "authority": "ct-norwich-public-utilities",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -599,7 +574,6 @@
     "id": "CT-32",
     "authority_type": "state",
     "authority": "ct-deep",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -621,7 +595,6 @@
     "id": "CT-33",
     "authority_type": "state",
     "authority": "ct-deep",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -644,7 +617,6 @@
     "id": "CT-34",
     "authority_type": "state",
     "authority": "ct-deep",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate",
       "rebate"

--- a/data/NY/incentives.json
+++ b/data/NY/incentives.json
@@ -3,7 +3,6 @@
     "id": "NY-1",
     "authority_type": "utility",
     "authority": "ny-central-hudson-gas-and-electric",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate",
       "rebate"
@@ -27,7 +26,6 @@
     "id": "NY-2",
     "authority_type": "utility",
     "authority": "ny-central-hudson-gas-and-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -49,7 +47,6 @@
     "id": "NY-3",
     "authority_type": "utility",
     "authority": "ny-central-hudson-gas-and-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -71,7 +68,6 @@
     "id": "NY-4",
     "authority_type": "utility",
     "authority": "ny-consolidated-edison",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -94,7 +90,6 @@
     "id": "NY-5",
     "authority_type": "utility",
     "authority": "ny-consolidated-edison",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -117,7 +112,6 @@
     "id": "NY-6",
     "authority_type": "utility",
     "authority": "ny-consolidated-edison",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -140,7 +134,6 @@
     "id": "NY-7",
     "authority_type": "utility",
     "authority": "ny-consolidated-edison",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -162,7 +155,6 @@
     "id": "NY-10",
     "authority_type": "utility",
     "authority": "ny-pseg-long-island",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate",
       "rebate"
@@ -184,7 +176,6 @@
     "id": "NY-11",
     "authority_type": "utility",
     "authority": "ny-pseg-long-island",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -207,7 +198,6 @@
     "id": "NY-12",
     "authority_type": "utility",
     "authority": "ny-pseg-long-island",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -228,7 +218,6 @@
     "id": "NY-13",
     "authority_type": "utility",
     "authority": "ny-pseg-long-island",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -249,7 +238,6 @@
     "id": "NY-14",
     "authority_type": "utility",
     "authority": "ny-pseg-long-island",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -270,7 +258,6 @@
     "id": "NY-15",
     "authority_type": "utility",
     "authority": "ny-pseg-long-island",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -293,7 +280,6 @@
     "id": "NY-16",
     "authority_type": "state",
     "authority": "ny-state-of-ny",
-    "type": "tax_credit",
     "payment_methods": [
       "tax_credit"
     ],
@@ -315,7 +301,6 @@
     "id": "NY-17",
     "authority_type": "state",
     "authority": "ny-state-of-ny",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -339,7 +324,6 @@
     "id": "NY-18",
     "authority_type": "utility",
     "authority": "ny-national-grid",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -361,7 +345,6 @@
     "id": "NY-19",
     "authority_type": "utility",
     "authority": "ny-nys-electric-and-gas",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -383,7 +366,6 @@
     "id": "NY-24",
     "authority_type": "utility",
     "authority": "ny-rochester-gas-and-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -405,7 +387,6 @@
     "id": "NY-20",
     "authority_type": "utility",
     "authority": "ny-orange-and-rockland",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -427,7 +408,6 @@
     "id": "NY-21",
     "authority_type": "utility",
     "authority": "ny-national-grid",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -448,7 +428,6 @@
     "id": "NY-22",
     "authority_type": "utility",
     "authority": "ny-nys-electric-and-gas",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -469,7 +448,6 @@
     "id": "NY-23",
     "authority_type": "utility",
     "authority": "ny-rochester-gas-and-electric",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -490,7 +468,6 @@
     "id": "NY-25",
     "authority_type": "utility",
     "authority": "ny-orange-and-rockland",
-    "type": "pos_rebate",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -511,7 +488,6 @@
     "id": "NY-26",
     "authority_type": "state",
     "authority": "ny-nyserda",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -3,7 +3,6 @@
     "id": "RI-1",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -27,7 +26,6 @@
     "id": "RI-2",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -50,7 +48,6 @@
     "id": "RI-3",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -72,7 +69,6 @@
     "id": "RI-4",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
     "payment_methods": [
       "account_credit"
     ],
@@ -96,7 +92,6 @@
     "id": "RI-5",
     "authority_type": "utility",
     "authority": "ri-block-island-power-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -119,7 +114,6 @@
     "id": "RI-6",
     "authority_type": "utility",
     "authority": "ri-block-island-power-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -142,7 +136,6 @@
     "id": "RI-7",
     "authority_type": "utility",
     "authority": "ri-block-island-power-company",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -166,7 +159,6 @@
     "id": "RI-9",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -189,7 +181,6 @@
     "id": "RI-11",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -213,7 +204,6 @@
     "id": "RI-10",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -236,7 +226,6 @@
     "id": "RI-12",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -260,7 +249,6 @@
     "id": "RI-19",
     "authority_type": "utility",
     "authority": "ri-rhode-island-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -283,7 +271,6 @@
     "id": "RI-20",
     "authority_type": "utility",
     "authority": "ri-rhode-island-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -306,7 +293,6 @@
     "id": "RI-21",
     "authority_type": "state",
     "authority": "ri-commerce-corp",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -332,7 +318,6 @@
     "id": "RI-22",
     "authority_type": "utility",
     "authority": "ri-rhode-island-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -356,7 +341,6 @@
     "id": "RI-27",
     "authority_type": "utility",
     "authority": "ri-rhode-island-energy",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -379,7 +363,6 @@
     "id": "RI-14",
     "authority_type": "state",
     "authority": "ri-dhs",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -403,7 +386,6 @@
     "id": "RI-30",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -427,7 +409,6 @@
     "id": "RI-31",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -451,7 +432,6 @@
     "id": "RI-32",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -473,7 +453,6 @@
     "id": "RI-33",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -495,7 +474,6 @@
     "id": "RI-34",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -518,7 +496,6 @@
     "id": "RI-35",
     "authority_type": "state",
     "authority": "ri-oer",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],

--- a/data/VA/incentives.json
+++ b/data/VA/incentives.json
@@ -3,7 +3,6 @@
     "id": "VA-1",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -26,7 +25,6 @@
     "id": "VA-2",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -49,7 +47,6 @@
     "id": "VA-3",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -72,7 +69,6 @@
     "id": "VA-4",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -95,7 +91,6 @@
     "id": "VA-5",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -116,7 +111,6 @@
     "id": "VA-6",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -139,7 +133,6 @@
     "id": "VA-7",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -160,7 +153,6 @@
     "id": "VA-8",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -183,7 +175,6 @@
     "id": "VA-10",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -206,7 +197,6 @@
     "id": "VA-13",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -228,7 +218,6 @@
     "id": "VA-14",
     "authority_type": "utility",
     "authority": "va-appalachian-power",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],
@@ -250,7 +239,6 @@
     "id": "VA-15",
     "authority_type": "utility",
     "authority": "va-dominion-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -272,7 +260,6 @@
     "id": "VA-16",
     "authority_type": "utility",
     "authority": "va-dominion-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -295,7 +282,6 @@
     "id": "VA-17",
     "authority_type": "utility",
     "authority": "va-dominion-energy",
-    "type": "rebate",
     "payment_methods": [
       "rebate"
     ],
@@ -316,7 +302,6 @@
     "id": "VA-18",
     "authority_type": "utility",
     "authority": "va-dominion-energy",
-    "type": "assistance_program",
     "payment_methods": [
       "assistance_program"
     ],

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -3,7 +3,6 @@
     "id": "VT-1",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -27,7 +26,6 @@
     "id": "VT-2",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -50,7 +48,6 @@
     "id": "VT-3",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -75,7 +72,6 @@
     "id": "VT-4",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -100,7 +96,6 @@
     "id": "VT-5",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -124,7 +119,6 @@
     "id": "VT-6",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "pos_rebate",
     "item": "heat_pump_clothes_dryer",
     "payment_methods": [
       "pos_rebate"
@@ -147,7 +141,6 @@
     "id": "VT-7",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "pos_rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "pos_rebate"
@@ -170,7 +163,6 @@
     "id": "VT-8",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -193,7 +185,6 @@
     "id": "VT-9",
     "authority_type": "utility",
     "authority": "vt-green-mountain-power",
-    "type": "pos_rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "pos_rebate"
@@ -215,7 +206,6 @@
     "id": "VT-10",
     "authority_type": "utility",
     "authority": "vt-green-mountain-power",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -238,7 +228,6 @@
     "id": "VT-11",
     "authority_type": "utility",
     "authority": "vt-vppsa",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -261,7 +250,6 @@
     "id": "VT-12",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -285,7 +273,6 @@
     "id": "VT-13",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -310,7 +297,6 @@
     "id": "VT-16",
     "authority_type": "utility",
     "authority": "vt-vermont-electric-coop",
-    "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "account_credit"
@@ -333,7 +319,6 @@
     "id": "VT-17",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -355,7 +340,6 @@
     "id": "VT-18",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "pos_rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "pos_rebate"
@@ -378,7 +362,6 @@
     "id": "VT-19",
     "authority_type": "utility",
     "authority": "vt-green-mountain-power",
-    "type": "pos_rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "pos_rebate"
@@ -400,7 +383,6 @@
     "id": "VT-20",
     "authority_type": "utility",
     "authority": "vt-green-mountain-power",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -424,7 +406,6 @@
     "id": "VT-21",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -447,7 +428,6 @@
     "id": "VT-22",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -469,7 +449,6 @@
     "id": "VT-23",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -493,7 +472,6 @@
     "id": "VT-24",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -517,7 +495,6 @@
     "id": "VT-25",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "rebate"
@@ -542,7 +519,6 @@
     "id": "VT-26",
     "authority_type": "utility",
     "authority": "vt-vermont-electric-coop",
-    "type": "account_credit",
     "item": "heat_pump_air_conditioner_heater",
     "payment_methods": [
       "account_credit"
@@ -564,7 +540,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -590,7 +565,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -617,7 +591,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -643,7 +616,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -670,7 +642,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -696,7 +667,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -723,7 +693,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -749,7 +718,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -776,7 +744,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -802,7 +769,6 @@
     "id": "VT-27",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate",
@@ -829,7 +795,6 @@
     "id": "VT-28",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "used_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -853,7 +818,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -879,7 +843,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -906,7 +869,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -932,7 +894,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -959,7 +920,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -985,7 +945,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -1012,7 +971,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -1038,7 +996,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -1065,7 +1022,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -1091,7 +1047,6 @@
     "id": "VT-29",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "new_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -1118,7 +1073,6 @@
     "id": "VT-30",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "pos_rebate",
     "item": "used_electric_vehicle",
     "payment_methods": [
       "pos_rebate"
@@ -1143,7 +1097,6 @@
     "id": "VT-31",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "electric_vehicle_charger",
     "payment_methods": [
       "rebate"
@@ -1166,7 +1119,6 @@
     "id": "VT-32",
     "authority_type": "utility",
     "authority": "vt-vermont-electric-coop",
-    "type": "assistance_program",
     "item": "electric_vehicle_charger",
     "payment_methods": [
       "assistance_program"
@@ -1188,7 +1140,6 @@
     "id": "VT-33",
     "authority_type": "utility",
     "authority": "vt-vermont-electric-coop",
-    "type": "account_credit",
     "item": "electric_vehicle_charger",
     "payment_methods": [
       "account_credit"
@@ -1211,7 +1162,6 @@
     "id": "VT-34",
     "authority_type": "utility",
     "authority": "vt-green-mountain-power",
-    "type": "assistance_program",
     "item": "electric_vehicle_charger",
     "payment_methods": [
       "assistance_program"
@@ -1234,7 +1184,6 @@
     "id": "VT-35",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "assistance_program",
     "item": "electric_vehicle_charger",
     "payment_methods": [
       "assistance_program"
@@ -1257,7 +1206,6 @@
     "id": "VT-36",
     "authority_type": "utility",
     "authority": "vt-vppsa",
-    "type": "assistance_program",
     "item": "electric_vehicle_charger",
     "payment_methods": [
       "assistance_program"
@@ -1280,7 +1228,6 @@
     "id": "VT-37",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "geothermal_heating_installation",
     "payment_methods": [
       "rebate"
@@ -1304,7 +1251,6 @@
     "id": "VT-38",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "geothermal_heating_installation",
     "payment_methods": [
       "rebate"
@@ -1328,7 +1274,6 @@
     "id": "VT-39",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "geothermal_heating_installation",
     "payment_methods": [
       "rebate"
@@ -1352,7 +1297,6 @@
     "id": "VT-40",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "geothermal_heating_installation",
     "payment_methods": [
       "rebate"
@@ -1375,7 +1319,6 @@
     "id": "VT-41",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "pos_rebate",
     "item": "heat_pump_water_heater",
     "payment_methods": [
       "pos_rebate",
@@ -1399,7 +1342,6 @@
     "id": "VT-42",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "heat_pump_water_heater",
     "payment_methods": [
       "rebate"
@@ -1423,7 +1365,6 @@
     "id": "VT-43",
     "authority_type": "utility",
     "authority": "vt-burlington-electric-department",
-    "type": "rebate",
     "item": "heat_pump_water_heater",
     "payment_methods": [
       "rebate"
@@ -1447,7 +1388,6 @@
     "id": "VT-45",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "heat_pump_water_heater",
     "payment_methods": [
       "rebate"
@@ -1471,7 +1411,6 @@
     "id": "VT-49",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"
@@ -1494,7 +1433,6 @@
     "id": "VT-50",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"
@@ -1517,7 +1455,6 @@
     "id": "VT-51",
     "authority_type": "state",
     "authority": "vt-ev",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"
@@ -1541,7 +1478,6 @@
     "id": "VT-52",
     "authority_type": "state",
     "authority": "vt-state-of-vermont",
-    "type": "assistance_program",
     "item": "weatherization",
     "payment_methods": [
       "assistance_program"
@@ -1563,7 +1499,6 @@
     "id": "VT-53",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"
@@ -1585,7 +1520,6 @@
     "id": "VT-54",
     "authority_type": "utility",
     "authority": "vt-washington-electric-coop",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"
@@ -1608,7 +1542,6 @@
     "id": "VT-55",
     "authority_type": "utility",
     "authority": "vt-vermont-gas-service",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"
@@ -1631,7 +1564,6 @@
     "id": "VT-56",
     "authority_type": "utility",
     "authority": "vt-vermont-gas-service",
-    "type": "rebate",
     "item": "weatherization",
     "payment_methods": [
       "rebate"

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -72,6 +72,7 @@ const collectedIncentivePropertySchema = {
   payment_methods: {
     type: 'array',
     items: { type: 'string', enum: Object.values(PaymentMethod) },
+    minItems: 1,
   },
   rebate_value: { type: 'string' },
   amount: AMOUNT_SCHEMA,
@@ -88,6 +89,7 @@ const collectedIncentivePropertySchema = {
   owner_status: {
     type: 'array',
     items: { type: 'string', enum: Object.values(OwnerStatus) },
+    minItems: 1,
   },
   other_restrictions: { type: 'string', nullable: true },
   stacking_details: { type: 'string', nullable: true },

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -107,7 +107,6 @@ export type DerivedFields = {
   agi_max_limit?: number;
   agi_min_limit?: number;
   authority: string;
-  type: PaymentMethod; // Deprecated; we are switching to use payment_methods instead
   program: string;
   bonus_available?: boolean;
   start_date: number;
@@ -119,7 +118,6 @@ const derivedIncentivePropertySchema = {
   agi_max_limit: { type: 'integer', nullable: true },
   agi_min_limit: { type: 'integer', nullable: true },
   authority: { type: 'string' },
-  type: { type: 'string', enum: Object.values(PaymentMethod) },
   program: { type: 'string', enum: ALL_PROGRAMS },
   bonus_available: { type: 'boolean', nullable: true },
   start_date: { type: 'number' },
@@ -161,7 +159,6 @@ const requiredProperties = [
   'id',
   'authority',
   'authority_type',
-  'type',
   'payment_methods',
   'item',
   'program',

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -183,7 +183,7 @@ export function calculateStateIncentivesAndSavings(
       combinedValue.remainingValue -= amount;
     }
 
-    savings[item.type] += amount;
+    savings[item.payment_methods[0]] += amount;
   });
 
   return {

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -146,11 +146,11 @@ export default async function (
 
         const pos_rebate_incentives = result.incentives.filter(
           i =>
-            i.type === PaymentMethod.PosRebate ||
-            i.type === PaymentMethod.PerformanceRebate,
+            i.payment_methods[0] === PaymentMethod.PosRebate ||
+            i.payment_methods[0] === PaymentMethod.PerformanceRebate,
         ) as IRAIncentive[];
         let tax_credit_incentives = result.incentives.filter(
-          i => i.type === PaymentMethod.TaxCredit,
+          i => i.payment_methods[0] === PaymentMethod.TaxCredit,
         ) as IRAIncentive[];
 
         // Website Calculator backwards compatiblity from v1 data:

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -27,6 +27,7 @@ export const API_INCENTIVE_SCHEMA = {
         type: 'string',
         enum: Object.values(PaymentMethod),
       },
+      minItems: 1,
     },
     authority_type: {
       type: 'string',
@@ -85,6 +86,7 @@ export const API_INCENTIVE_SCHEMA = {
         type: 'string',
         enum: Object.values(OwnerStatus),
       },
+      minItems: 1,
     },
     start_date: {
       type: 'number',

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -11,7 +11,6 @@ export const API_INCENTIVE_SCHEMA = {
   $id: 'APIIncentive',
   type: 'object',
   required: [
-    'type',
     'payment_methods',
     'authority_type',
     'program',
@@ -22,10 +21,6 @@ export const API_INCENTIVE_SCHEMA = {
     'end_date',
   ],
   properties: {
-    type: {
-      type: 'string',
-      enum: Object.values(PaymentMethod),
-    },
     payment_methods: {
       type: 'array',
       items: {

--- a/test/fixtures/test-incentives.json
+++ b/test/fixtures/test-incentives.json
@@ -3,7 +3,9 @@
     "id": "A",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
+    "payment_methods": [
+      "account_credit"
+    ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
@@ -22,7 +24,9 @@
     "id": "B",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
+    "payment_methods": [
+      "account_credit"
+    ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
@@ -42,7 +46,9 @@
     "id": "C",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
+    "payment_methods": [
+      "account_credit"
+    ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
@@ -61,7 +67,9 @@
     "id": "D",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
+    "payment_methods": [
+      "account_credit"
+    ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
@@ -79,7 +87,9 @@
     "id": "E",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
+    "payment_methods": [
+      "account_credit"
+    ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
@@ -98,7 +108,9 @@
     "id": "F",
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
-    "type": "account_credit",
+    "payment_methods": [
+      "account_credit"
+    ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -23,7 +23,6 @@
   },
   "incentives": [
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -49,7 +48,6 @@
       "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -76,7 +74,6 @@
       "short_description": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -105,7 +102,6 @@
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -133,7 +129,6 @@
       "short_description": "Up to $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -161,7 +156,6 @@
       "short_description": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -189,7 +183,6 @@
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -37,7 +37,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -65,7 +64,6 @@
       "short_description": "Weatherization Assistance Program reduces energy costs for households that meet LIHEAP criteria. If you qualify, there's no cost to you."
     },
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -92,7 +90,6 @@
       "short_description": "Income-Eligible Energy Savings Program makes your home healthier, more comfortable and more affordable. If you qualify, there's no cost to you."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -119,7 +116,6 @@
       "short_description": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -147,7 +143,6 @@
       "short_description": "Depending on your income, 100% of the cost to install a heat pump water heater, including up to $3,000 towards related electric service upgrades."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -176,7 +171,6 @@
       "short_description": "Up to $10,000 to install a ground source (geothermal) heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -205,7 +199,6 @@
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -234,7 +227,6 @@
       "short_description": "$150+ back on installation of heat pump, depending on size. Additional funding available to replace electric baseboard resistance heating."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -264,7 +256,6 @@
       "short_description": "10-25% back on installation costs up to $5,000. Includes electricity-generating solar panels and solar domestic hot water technologies."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -292,7 +283,6 @@
       "short_description": "Up to $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -320,7 +310,6 @@
       "short_description": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -348,7 +337,6 @@
       "short_description": "Additional $1,500 towards a used EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers. First-come, first-served."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -376,7 +364,6 @@
       "short_description": "Up to $1,000 back after purchase or lease of a used EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -403,7 +390,6 @@
       "short_description": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -431,7 +417,6 @@
       "short_description": "Up to $600 back on a qualifying electric heat pump water heater when replacing an existing electric water heater or installing in a new home."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -458,7 +443,6 @@
       "short_description": "Additional $500 for an electrical service upgrade at the same time as installation of a heat pump or heat pump water heater."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -14,7 +14,6 @@
   },
   "incentives": [
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -40,7 +39,6 @@
       "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -65,7 +63,6 @@
       "short_description": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%."
     },
     {
-      "type": "performance_rebate",
       "payment_methods": [
         "performance_rebate"
       ],
@@ -90,7 +87,6 @@
       "short_description": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -115,7 +111,6 @@
       "short_description": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -140,7 +135,6 @@
       "short_description": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -165,7 +159,6 @@
       "short_description": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -191,7 +184,6 @@
       "short_description": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -217,7 +209,6 @@
       "short_description": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -243,7 +234,6 @@
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -269,7 +259,6 @@
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -295,7 +284,6 @@
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -323,7 +311,6 @@
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -351,7 +338,6 @@
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -376,7 +362,6 @@
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -401,7 +386,6 @@
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -426,7 +410,6 @@
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows, and energy audits. Yearly reset."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -452,7 +435,6 @@
       "short_description": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -14,7 +14,6 @@
   },
   "incentives": [
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -40,7 +39,6 @@
       "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
     },
     {
-      "type": "performance_rebate",
       "payment_methods": [
         "performance_rebate"
       ],
@@ -65,7 +63,6 @@
       "short_description": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -90,7 +87,6 @@
       "short_description": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -115,7 +111,6 @@
       "short_description": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -140,7 +135,6 @@
       "short_description": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -165,7 +159,6 @@
       "short_description": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -191,7 +184,6 @@
       "short_description": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -217,7 +209,6 @@
       "short_description": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -243,7 +234,6 @@
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -269,7 +259,6 @@
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -295,7 +284,6 @@
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -323,7 +311,6 @@
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -351,7 +338,6 @@
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -376,7 +362,6 @@
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -401,7 +386,6 @@
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -426,7 +410,6 @@
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows, and energy audits. Yearly reset."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -452,7 +435,6 @@
       "short_description": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -18,7 +18,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -45,7 +44,6 @@
       "short_description": "Weatherization improvements for homes for limited-income customers."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -18,7 +18,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -45,7 +44,6 @@
       "short_description": "Assistance available for energy efficient retrofitting to homes of income-qualifying customers."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -72,7 +70,6 @@
       "short_description": "Up to $900 rebate for retiring an existing, qualified system and installing an Energy Star heat pump/AC purchase via a qualified contractor."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -27,7 +27,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -54,7 +53,6 @@
       "short_description": "Free Home Energy Assessment for households with income at 150% of Area Median Income or less."
     },
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -82,7 +80,6 @@
       "short_description": "Weatherization is free for qualifying low-income households. Includes a professional home audit to determine necessary energy-conserving updates."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -110,7 +107,6 @@
       "short_description": "Income-qualified Coloradans can receive a $6,000 rebate to replace old or high-emitting vehicles with a new EV or PHEV."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -138,7 +134,6 @@
       "short_description": "Income-qualified Coloradans can receive a $4,000 rebate to replace old or high-emitting vehicles with a used EV or PHEV."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -166,7 +161,6 @@
       "short_description": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -194,7 +188,6 @@
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -222,7 +215,6 @@
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -250,7 +242,6 @@
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -278,7 +269,6 @@
       "short_description": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -306,7 +296,6 @@
       "short_description": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -334,7 +323,6 @@
       "short_description": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -362,7 +350,6 @@
       "short_description": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -390,7 +377,6 @@
       "short_description": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -416,7 +402,6 @@
       "short_description": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -444,7 +429,6 @@
       "short_description": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualitying households."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -472,7 +456,6 @@
       "short_description": "Rebates of up to 25% of project costs for weatherization projects such as air/duct sealing, insulation, and more, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -500,7 +483,6 @@
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate air source heat pumps, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -528,7 +510,6 @@
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate air to water heat pumps, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -556,7 +537,6 @@
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate ground source heat pumps, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -584,7 +564,6 @@
       "short_description": "Rebates of up to 25% of project costs for qualifying ductless heat pumps, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -612,7 +591,6 @@
       "short_description": "Rebates of up to 25% of project costs for heat pump water heaters, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -640,7 +618,6 @@
       "short_description": "Rebates of up to 25% of project costs for heat pump clothes dryer, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -668,7 +645,6 @@
       "short_description": "Rebates of up to 25% of project costs for wiring projects related to electrification, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -696,7 +672,6 @@
       "short_description": "Rebates of up to 25% of project costs for panel upgrades related to electrification, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -722,7 +697,6 @@
       "short_description": "Rebates of up to 25% of project costs for WiFi-enabled smart thermostats or programmable thermostats, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -750,7 +724,6 @@
       "short_description": "Rebates of up to 25% of project costs for induction cooktops and stoves, capped annually at $3,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -779,7 +752,6 @@
       "short_description": "Rebates for solar photovoltaic installation: $250/kW from 0-6 kW, and $100/kW from 6-25 kW."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -805,7 +777,6 @@
       "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -833,7 +804,6 @@
       "short_description": "12.9% discount on battery storage systems through Colorado State tax credit and sales tax exemption."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],
@@ -861,7 +831,6 @@
       "short_description": "State tax credit of $5,000 for the purchase or lease of a new EV (max MSRP: $80,000)."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -21,7 +21,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -49,7 +48,6 @@
       "short_description": "The Home Energy Solutions program provides income-eligible households with no-cost energy assessments and incentives for weatherization services."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate",
         "rebate"
@@ -78,7 +76,6 @@
       "short_description": "$3,000 rebate for a qualifying used electric vehicle for income-qualifying individuals."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -106,7 +103,6 @@
       "short_description": "$2,250 rebate for a qualifying new electric vehicle."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -134,7 +130,6 @@
       "short_description": "Bonus $2,000 off a qualifying new electric vehicle for income-eligible individuals."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -163,7 +158,6 @@
       "short_description": "$1,500 per ton after-purchase rebate for qualifying ground source heat pumps, up to $15,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -192,7 +186,6 @@
       "short_description": "$750 per ton after-purchase rebate for qualifying air source heat pumps."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -219,7 +212,6 @@
       "short_description": "$650 off eligible Energy Star certified Heat Pump Water Heaters."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -246,7 +238,6 @@
       "short_description": "Bonus $500 off ground source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -24,7 +24,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -52,7 +51,6 @@
       "short_description": "Up to $7,500 in weatherization and health and safety services for income eligible households."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -81,7 +79,6 @@
       "short_description": "Instant rebate for $500-$2,000 off a new electric vehicle when purchased from a participating dealer. Can be combined with the federal tax credit."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate",
         "rebate"
@@ -109,7 +106,6 @@
       "short_description": "Instant or mail-in rebate for $1,000 off an eligible Energy Star certified heat pump water heater when purchased at a participating retailer."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -137,7 +133,6 @@
       "short_description": "$450 to $600 off an Energy Star certified air source heat pump when installed by an eligible contractor."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -164,7 +159,6 @@
       "short_description": "$600 off an Energy Star certified heat pump water heater when installed by a participating contractor."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -191,7 +185,6 @@
       "short_description": "$600 off an eligible high efficiency cold climate ducted heat pump system, when installed by a participating contractor."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -218,7 +211,6 @@
       "short_description": "Up to $240 off an Energy Star certified ductless mini-split heat pump system when installed by a participating contractor."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -246,7 +238,6 @@
       "short_description": "$1,000 to $4,000 in incentives available for seal and insulate packages to improve your home's comfort."
     },
     {
-      "type": "tax_credit",
       "payment_methods": [
         "tax_credit"
       ],

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -18,7 +18,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -45,7 +44,6 @@
       "short_description": "Receive no cost energy efficient weatherization upgrades for qualified income and age levels by qualified service providers."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -73,7 +71,6 @@
       "short_description": "Receive up to a $400 rebate for installing a heat pump water heater above 40 gallons in capacity."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -100,7 +97,6 @@
       "short_description": "Participate in Dominion Energy's EV charging control events using your level 2 charger and receive a $125 rebate."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -24,7 +24,6 @@
   },
   "incentives": [
     {
-      "type": "assistance_program",
       "payment_methods": [
         "assistance_program"
       ],
@@ -51,7 +50,6 @@
       "short_description": "The Weatherization Assistance Program offers free services including energy audits, insulation and air sealing for eligible income based households."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -80,7 +78,6 @@
       "short_description": "The MileageSmart program covers 25% of the upfront cost of a used high efficiency vehicle, up to $5,000, for low/moderate income car buyers."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -111,7 +108,6 @@
       "short_description": "The incentive for scrapping an eligible Internal Combustion Engine (ICE) vehicle is $5,000."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -140,7 +136,6 @@
       "short_description": "The incentive amount for scrapping an eligible Internal Combustion Engine (ICE) vehicle is $5,000 based on income eligibility."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate",
         "rebate"
@@ -172,7 +167,6 @@
       "short_description": "$5000 for a new electric vehicle or $3000 for a new plug-in hybrid vehicle."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -204,7 +198,6 @@
       "short_description": "The incentive for scrapping an eligible Internal Combustion Engine (ICE) vehicle is $2,500."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate",
         "rebate"
@@ -237,7 +230,6 @@
       "short_description": "$2500 for a new electric vehicle or $1500 for a new plug-in hybrid vehicle."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -265,7 +257,6 @@
       "short_description": "Work with a contractor to install your ducted heat pump and get a $1,000-$2,000 instant discount."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -293,7 +284,6 @@
       "short_description": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate",
         "rebate"
@@ -322,7 +312,6 @@
       "short_description": "Hire a contractor and get a $300-$600 discount from your utility or Efficiency Vermont."
     },
     {
-      "type": "pos_rebate",
       "payment_methods": [
         "pos_rebate"
       ],
@@ -350,7 +339,6 @@
       "short_description": "Receive up to $400 cash back on qualifying ENERGY STAR electric clothes dryer models."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -378,7 +366,6 @@
       "short_description": "Up to $8,750 on heat pump installation."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -406,7 +393,6 @@
       "short_description": "BED customers may receive a rebate up to $2,500 on qualifiying HPs."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -434,7 +420,6 @@
       "short_description": "Up to $900 back on qualifying level 2 charger purchased within 60 days of vehicle purchase or lease."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -462,7 +447,6 @@
       "short_description": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project cost up to $4,000."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -490,7 +474,6 @@
       "short_description": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project costs up to $9,500."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -519,7 +502,6 @@
       "short_description": "Hire a participating contractor and get up to $2,100 cash back per ton on qualifying equipment for a Ground Source HP."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -548,7 +530,6 @@
       "short_description": "BED customers may receive a post purchase rebate up to $12,000 when you install an air-to-water heat pump."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -577,7 +558,6 @@
       "short_description": "BED customers may receive a rebate up to $2,500 on qualifiying GSHPs, plus an additional $500 for a second GSHP"
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -606,7 +586,6 @@
       "short_description": "Work with an Efficiency Excellence Network contractor to install your air-to-water heat pump and get up to $6,000 back."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -634,7 +613,6 @@
       "short_description": "Income-eligible Vermonters can get a $500 bonus rebate if you work with an Efficiency Excellence Network contractor to install air-to-water heat pump."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -662,7 +640,6 @@
       "short_description": "BED customers may receive an additional $500 rebate for a second ductless HP."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -690,7 +667,6 @@
       "short_description": "Income-eligible Vermonters qualify for a $500 bonus rebate on eligible Ground Source HP."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -718,7 +694,6 @@
       "short_description": "BED customers may receive up to $800 rebate for a HPWH."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -746,7 +721,6 @@
       "short_description": "Income-eligible Vermonters/BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified air-to-water heat pump."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -774,7 +748,6 @@
       "short_description": "Income-eligible Vermonters who are BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified ducted heat pump."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -802,7 +775,6 @@
       "short_description": "Income-eligible BED customers qualify for a $400 enhanced rebate for a ductless HP."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -830,7 +802,6 @@
       "short_description": "Vermonters whose household income is at or below the moderate income guidelines qualify for a $200-$800 bonus rebate on a ducted heat pump."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -858,7 +829,6 @@
       "short_description": "Income-eligible Vermonters qualify for a $200-$1,000 bonus rebate on a ductless heat pump, depending on their utility."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],
@@ -886,7 +856,6 @@
       "short_description": "Income-eligible Vermonters may qualify for a $200 bonus rebate on HPWH."
     },
     {
-      "type": "rebate",
       "payment_methods": [
         "rebate"
       ],

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -146,13 +146,13 @@ test('correctly evaluates scenerio "Single w/ $120k Household income in the Bron
   t.equal(data.savings.performance_rebate, 4000);
 
   const pos_rebate_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.PosRebate,
+    i => i.payment_methods[0] === PaymentMethod.PosRebate,
   );
   const tax_credit_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.TaxCredit,
+    i => i.payment_methods[0] === PaymentMethod.TaxCredit,
   );
   const performance_rebate_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.PerformanceRebate,
+    i => i.payment_methods[0] === PaymentMethod.PerformanceRebate,
   );
 
   t.equal(pos_rebate_incentives.length, 7);
@@ -160,14 +160,17 @@ test('correctly evaluates scenerio "Single w/ $120k Household income in the Bron
   t.equal(performance_rebate_incentives.length, 1);
 
   // count the incentives by key used to de-dupe in UI:
-  const rebateCounts = _.countBy(pos_rebate_incentives, i => i.item + i.type);
+  const rebateCounts = _.countBy(
+    pos_rebate_incentives,
+    i => i.item + i.payment_methods[0],
+  );
   t.equal(
     Object.values(rebateCounts).every(c => c === 1),
     true,
   );
   const taxCreditCounts = _.countBy(
     tax_credit_incentives,
-    i => i.item + i.type,
+    i => i.item + i.payment_methods[0],
   );
   t.equal(
     Object.values(taxCreditCounts).every(c => c === 1),
@@ -253,13 +256,13 @@ test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k H
   t.equal(data.savings.performance_rebate, 4000);
 
   const pos_rebate_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.PosRebate,
+    i => i.payment_methods[0] === PaymentMethod.PosRebate,
   );
   const tax_credit_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.TaxCredit,
+    i => i.payment_methods[0] === PaymentMethod.TaxCredit,
   );
   const performance_rebate_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.PerformanceRebate,
+    i => i.payment_methods[0] === PaymentMethod.PerformanceRebate,
   );
 
   t.equal(pos_rebate_incentives.length, 7);
@@ -267,14 +270,17 @@ test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k H
   t.equal(performance_rebate_incentives.length, 1);
 
   // count the incentives by key used to de-dupe in UI:
-  const rebateCounts = _.countBy(pos_rebate_incentives, i => i.item + i.type);
+  const rebateCounts = _.countBy(
+    pos_rebate_incentives,
+    i => i.item + i.payment_methods[0],
+  );
   t.equal(
     Object.values(rebateCounts).every(c => c === 1),
     true,
   );
   const taxCreditCounts = _.countBy(
     tax_credit_incentives,
-    i => i.item + i.type,
+    i => i.item + i.payment_methods[0],
   );
   t.equal(
     Object.values(taxCreditCounts).every(c => c === 1),
@@ -360,13 +366,13 @@ test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in 
   t.equal(data.savings.performance_rebate, 4000);
 
   const pos_rebate_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.PosRebate,
+    i => i.payment_methods[0] === PaymentMethod.PosRebate,
   );
   const tax_credit_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.TaxCredit,
+    i => i.payment_methods[0] === PaymentMethod.TaxCredit,
   );
   const performance_rebate_incentives = data.incentives.filter(
-    i => i.type === PaymentMethod.PerformanceRebate,
+    i => i.payment_methods[0] === PaymentMethod.PerformanceRebate,
   );
 
   t.equal(pos_rebate_incentives.length, 7);
@@ -374,14 +380,17 @@ test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in 
   t.equal(performance_rebate_incentives.length, 1);
 
   // count the incentives by key used to de-dupe in UI:
-  const rebateCounts = _.countBy(pos_rebate_incentives, i => i.item + i.type);
+  const rebateCounts = _.countBy(
+    pos_rebate_incentives,
+    i => i.item + i.payment_methods[0],
+  );
   t.equal(
     Object.values(rebateCounts).every(c => c === 1),
     true,
   );
   const taxCreditCounts = _.countBy(
     tax_credit_incentives,
-    i => i.item + i.type,
+    i => i.item + i.payment_methods[0],
   );
   t.equal(
     Object.values(taxCreditCounts).every(c => c === 1),
@@ -463,7 +472,7 @@ test('correctly sorts incentives', async t => {
   });
   let prevIncentive = data.incentives[0];
   data.incentives.slice(1).forEach(incentive => {
-    if (prevIncentive.type === incentive.type) {
+    if (prevIncentive.payment_methods[0] === incentive.payment_methods[0]) {
       if (prevIncentive.amount.type === incentive.amount.type) {
         t.ok(prevIncentive.amount >= incentive.amount);
       } else {
@@ -472,8 +481,8 @@ test('correctly sorts incentives', async t => {
       }
     } else {
       // Tax credits must all be sorted at the end. Rebate types can be mixed.
-      if (prevIncentive.type === 'tax_credit') {
-        t.equal(incentive.type, 'tax_credit');
+      if (prevIncentive.payment_methods[0] === 'tax_credit') {
+        t.equal(incentive.payment_methods[0], 'tax_credit');
       }
     }
     prevIncentive = incentive;
@@ -487,7 +496,6 @@ test('correct filtering of county incentives', async t => {
     authority: 'mock-county-authority',
     start_date: 2023,
     end_date: 2024,
-    type: PaymentMethod.AccountCredit,
     payment_methods: [PaymentMethod.AccountCredit],
     item: 'heat_pump_air_conditioner_heater',
     program: 'ri_hvacAndWaterHeaterIncentives',
@@ -550,7 +558,6 @@ test('correct filtering of city incentives', async t => {
     authority: 'mock-city-authority',
     start_date: 2023,
     end_date: 2024,
-    type: PaymentMethod.AccountCredit,
     payment_methods: [PaymentMethod.AccountCredit],
     item: 'heat_pump_air_conditioner_heater',
     program: 'ri_hvacAndWaterHeaterIncentives',


### PR DESCRIPTION
Switching from `.type` to `.payment_methods[0]` in various backend calls is necessary since our CalculatedIncentive type no longer reliably has a `type` property. We could split up that type but I figured it was just easier to start using `payment_methods[0]` in the calculations anyway.

To make that safer, I added minItems requirements to the JSON schema def for payment_methods and owner_status; now those arrays can't be empty.

Tested: submitted an empty payment_methods array in one of the incentives and confirmed we got a test failure.

