### PR TITLE
Rename spreadsheet standardizer methods.

### DIFF
--- a/scripts/generate-misc-state-data.ts
+++ b/scripts/generate-misc-state-data.ts
@@ -24,7 +24,7 @@ async function generate(state: string, file: IncentiveFile) {
 
   const authorityProgramManager = new AuthorityAndProgramUpdater(state);
   rows.forEach((row: Record<string, string>) => {
-    const renamed = converter.convertFieldNames(row);
+    const renamed = converter.standardize(row);
     authorityProgramManager.addRow(renamed);
   });
 

--- a/scripts/generate-misc-state-data.ts
+++ b/scripts/generate-misc-state-data.ts
@@ -16,7 +16,7 @@ async function generate(state: string, file: IncentiveFile) {
   // For now this is always on since we need to ID this columns
   // accurately to do the rest of the work.
   const strict_mode = true;
-  const converter = new SpreadsheetStandardizer(
+  const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
     {},
     strict_mode,
@@ -24,8 +24,8 @@ async function generate(state: string, file: IncentiveFile) {
 
   const authorityProgramManager = new AuthorityAndProgramUpdater(state);
   rows.forEach((row: Record<string, string>) => {
-    const renamed = converter.standardize(row);
-    authorityProgramManager.addRow(renamed);
+    const standardized = standardizer.standardize(row);
+    authorityProgramManager.addRow(standardized);
   });
 
   authorityProgramManager.updateProgramsTs();

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -34,7 +34,7 @@ async function convertToJson(
     from_line: file.headerRowNumber ?? 1,
   });
 
-  const converter = new SpreadsheetStandardizer(
+  const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
     VALUE_MAPPINGS,
     strict,
@@ -43,15 +43,15 @@ async function convertToJson(
   const invalids: Record<string, string | number | boolean | object>[] = [];
   const jsons: StateIncentive[] = [];
   rows.forEach((row: Record<string, string>) => {
-    const renamed = converter.standardize(row);
-    const standardized = converter.refineCollectedData(state, renamed);
-    if (!validate(standardized)) {
+    const standardized = standardizer.standardize(row);
+    const refined = standardizer.refineCollectedData(state, standardized);
+    if (!validate(refined)) {
       if (validate.errors !== undefined && validate.errors !== null) {
-        standardized.errors = validate.errors;
+        refined.errors = validate.errors;
       }
-      invalids.push(standardized);
+      invalids.push(refined);
     } else {
-      jsons.push(standardized);
+      jsons.push(refined);
     }
   });
 

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -43,8 +43,8 @@ async function convertToJson(
   const invalids: Record<string, string | number | boolean | object>[] = [];
   const jsons: StateIncentive[] = [];
   rows.forEach((row: Record<string, string>) => {
-    const renamed = converter.convertFieldNames(row);
-    const standardized = converter.recordToStandardValues(state, renamed);
+    const renamed = converter.standardize(row);
+    const standardized = converter.refineCollectedData(state, renamed);
     if (!validate(standardized)) {
       if (validate.errors !== undefined && validate.errors !== null) {
         standardized.errors = validate.errors;

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -77,7 +77,7 @@ export class SpreadsheetStandardizer {
   }
 
   // Convert a row with possible column aliases to a canonical column name.
-  convertFieldNames(input: Record<string, string>): Record<string, string> {
+  standardize(input: Record<string, string>): Record<string, string> {
     const output: Record<string, string> = {};
     for (const key in input) {
       const cleaned = cleanFieldName(key);
@@ -93,9 +93,10 @@ export class SpreadsheetStandardizer {
     return output;
   }
 
-  // Try to convert a row with non-standard values to standard ones.
-  // Failure means the row will still fail a2j schema validation later.
-  recordToStandardValues(
+  // Take a collected data record, filter to a subset of fields, do some
+  // additional processing/derivation, and return a refined record.
+  // That record may still fail ajv schema validation later.
+  refineCollectedData(
     state: string,
     record: Record<string, string>,
   ): Record<string, string | number | object | boolean> {

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -89,10 +89,7 @@ test('correct row to record transformation', async tap => {
     fakeIncomeThresholds,
   );
   for (const tc of testCases) {
-    const renamed = columnConverter.convertFieldNames(tc.input);
-    tap.matchOnly(
-      columnConverter.recordToStandardValues('va', renamed),
-      tc.want,
-    );
+    const renamed = columnConverter.standardize(tc.input);
+    tap.matchOnly(columnConverter.refineCollectedData('va', renamed), tc.want);
   }
 });

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -82,14 +82,17 @@ test('correct row to record transformation', async tap => {
       },
     },
   };
-  const columnConverter = new SpreadsheetStandardizer(
+  const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
     VALUE_MAPPINGS,
     true,
     fakeIncomeThresholds,
   );
   for (const tc of testCases) {
-    const renamed = columnConverter.standardize(tc.input);
-    tap.matchOnly(columnConverter.refineCollectedData('va', renamed), tc.want);
+    const standardized = standardizer.standardize(tc.input);
+    tap.matchOnly(
+      standardizer.refineCollectedData('va', standardized),
+      tc.want,
+    );
   }
 });

--- a/test/scripts/spreadsheet-standardizer.test.ts
+++ b/test/scripts/spreadsheet-standardizer.test.ts
@@ -12,14 +12,14 @@ test('correctly rename columns in strict mode', tap => {
     true,
   );
   tap.matchOnly(
-    converter.convertFieldNames({ old_name: 'foo' }),
+    converter.standardize({ old_name: 'foo' }),
     { new_name: 'foo' },
     'standard rename',
   );
 
   converter = new SpreadsheetStandardizer({ new_name: ['old_name'] }, {}, true);
   tap.throws(() => {
-    converter.convertFieldNames({ old_name: 'foo', unrelated_name: 'bar' });
+    converter.standardize({ old_name: 'foo', unrelated_name: 'bar' });
   }, 'Error on field not in map in strict mode');
 
   tap.end();
@@ -32,7 +32,7 @@ test('correctly rename columns in non-strict mode', tap => {
     false,
   );
   tap.matchOnly(
-    converter.convertFieldNames({ old_name: 'foo' }),
+    converter.standardize({ old_name: 'foo' }),
     { new_name: 'foo' },
     'standard rename',
   );
@@ -43,7 +43,7 @@ test('correctly rename columns in non-strict mode', tap => {
     false,
   );
   tap.matchOnly(
-    converter.convertFieldNames({ old_name: 'foo', unrelated_name: 'bar' }),
+    converter.standardize({ old_name: 'foo', unrelated_name: 'bar' }),
     { new_name: 'foo', unrelated_name: 'bar' },
     'preserves extraneous column in non-strict mode',
   );
@@ -58,7 +58,7 @@ test('Rename columns using punctuation characters and unusual spacing', tap => {
     true,
   );
   tap.matchOnly(
-    converter.convertFieldNames({
+    converter.standardize({
       'Unclean  original(name  with weird chars    )': 'Column Value',
     }),
     { new_name: 'Column Value' },
@@ -79,7 +79,7 @@ test('Rename values', tap => {
     false,
   );
   tap.matchOnly(
-    converter.convertFieldNames({
+    converter.standardize({
       column: 'possible_alias',
       column_with_cleaning: 'Alias With Spaces * and Chars *',
     }),
@@ -91,7 +91,7 @@ test('Rename values', tap => {
 test('Cleans dollars and deals with owner_status Both', tap => {
   const converter = new SpreadsheetStandardizer({}, {}, false);
   tap.matchOnly(
-    converter.convertFieldNames({
+    converter.standardize({
       'amount.number': '$50',
       owner_status: 'Both',
     }),
@@ -143,7 +143,7 @@ test('representative example', tap => {
     'Financing Details': '',
   };
 
-  tap.matchOnly(converter.convertFieldNames(input), {
+  tap.matchOnly(converter.standardize(input), {
     id: 'VA-1',
     data_urls: 'https://takechargeva.com/programs/for-your-home',
     authority_type: 'utility',

--- a/test/scripts/spreadsheet-standardizer.test.ts
+++ b/test/scripts/spreadsheet-standardizer.test.ts
@@ -6,44 +6,48 @@ import {
 import { SpreadsheetStandardizer } from '../../scripts/lib/spreadsheet-standardizer';
 
 test('correctly rename columns in strict mode', tap => {
-  let converter = new SpreadsheetStandardizer(
+  let standardizer = new SpreadsheetStandardizer(
     { new_name: ['old_name'] },
     {},
     true,
   );
   tap.matchOnly(
-    converter.standardize({ old_name: 'foo' }),
+    standardizer.standardize({ old_name: 'foo' }),
     { new_name: 'foo' },
     'standard rename',
   );
 
-  converter = new SpreadsheetStandardizer({ new_name: ['old_name'] }, {}, true);
+  standardizer = new SpreadsheetStandardizer(
+    { new_name: ['old_name'] },
+    {},
+    true,
+  );
   tap.throws(() => {
-    converter.standardize({ old_name: 'foo', unrelated_name: 'bar' });
+    standardizer.standardize({ old_name: 'foo', unrelated_name: 'bar' });
   }, 'Error on field not in map in strict mode');
 
   tap.end();
 });
 
 test('correctly rename columns in non-strict mode', tap => {
-  let converter = new SpreadsheetStandardizer(
+  let standardizer = new SpreadsheetStandardizer(
     { new_name: ['old_name'] },
     {},
     false,
   );
   tap.matchOnly(
-    converter.standardize({ old_name: 'foo' }),
+    standardizer.standardize({ old_name: 'foo' }),
     { new_name: 'foo' },
     'standard rename',
   );
 
-  converter = new SpreadsheetStandardizer(
+  standardizer = new SpreadsheetStandardizer(
     { new_name: ['old_name'] },
     {},
     false,
   );
   tap.matchOnly(
-    converter.standardize({ old_name: 'foo', unrelated_name: 'bar' }),
+    standardizer.standardize({ old_name: 'foo', unrelated_name: 'bar' }),
     { new_name: 'foo', unrelated_name: 'bar' },
     'preserves extraneous column in non-strict mode',
   );
@@ -52,13 +56,13 @@ test('correctly rename columns in non-strict mode', tap => {
 });
 
 test('Rename columns using punctuation characters and unusual spacing', tap => {
-  const converter = new SpreadsheetStandardizer(
+  const standardizer = new SpreadsheetStandardizer(
     { new_name: ['unclean original name with weird chars'] },
     {},
     true,
   );
   tap.matchOnly(
-    converter.standardize({
+    standardizer.standardize({
       'Unclean  original(name  with weird chars    )': 'Column Value',
     }),
     { new_name: 'Column Value' },
@@ -68,7 +72,7 @@ test('Rename columns using punctuation characters and unusual spacing', tap => {
 });
 
 test('Rename values', tap => {
-  const converter = new SpreadsheetStandardizer(
+  const standardizer = new SpreadsheetStandardizer(
     {},
     {
       column: { canonical_value: ['possible_alias'] },
@@ -79,7 +83,7 @@ test('Rename values', tap => {
     false,
   );
   tap.matchOnly(
-    converter.standardize({
+    standardizer.standardize({
       column: 'possible_alias',
       column_with_cleaning: 'Alias With Spaces * and Chars *',
     }),
@@ -89,9 +93,9 @@ test('Rename values', tap => {
 });
 
 test('Cleans dollars and deals with owner_status Both', tap => {
-  const converter = new SpreadsheetStandardizer({}, {}, false);
+  const standardizer = new SpreadsheetStandardizer({}, {}, false);
   tap.matchOnly(
-    converter.standardize({
+    standardizer.standardize({
       'amount.number': '$50',
       owner_status: 'Both',
     }),
@@ -101,7 +105,7 @@ test('Cleans dollars and deals with owner_status Both', tap => {
 });
 
 test('representative example', tap => {
-  const converter = new SpreadsheetStandardizer(
+  const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
     VALUE_MAPPINGS,
     true,
@@ -143,7 +147,7 @@ test('representative example', tap => {
     'Financing Details': '',
   };
 
-  tap.matchOnly(converter.standardize(input), {
+  tap.matchOnly(standardizer.standardize(input), {
     id: 'VA-1',
     data_urls: 'https://takechargeva.com/programs/for-your-home',
     authority_type: 'utility',


### PR DESCRIPTION
We have a clearer separation of concerns in the spreadsheet to json flow (and it will get clearer in subsequent CLs). That flow does:

1. Standardizes column and value names (and formats)
2. Converts formats from csv to json (coming soon)
3. Does some additional processing/derivation to take a collected/raw record to the version we actually save

I'm doing some method and variable renaming now to reflect this and to declutter some upcoming changes.