### PR TITLE
Add format-converter to bridge from csv-parse to our collected schema.

### DIFF
--- a/scripts/lib/format-converter.ts
+++ b/scripts/lib/format-converter.ts
@@ -1,0 +1,90 @@
+import Ajv from 'ajv';
+import {
+  COLLECTED_DATA_SCHEMA,
+  CollectedFields,
+} from '../../src/data/state_incentives';
+import { LOCALIZABLE_STRING_SCHEMA } from '../../src/data/types/localizable-string';
+
+const ajv = new Ajv({ allErrors: true, coerceTypes: 'array' });
+
+// Could be generated from CollectedFields, filtering to array types.
+const ARRAY_FIELDS = ['data_urls', 'payment_methods', 'owner_status'];
+
+const validate = ajv
+  .addSchema(LOCALIZABLE_STRING_SCHEMA)
+  .compile(COLLECTED_DATA_SCHEMA);
+
+// Call this function to perform validation on the json.
+// This returns a tuple of valid and invalid records.
+// To convert without validation, call csvToJson directly.
+export function csvToJsonValidate(
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  rows: any[],
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  arrayCols: string[] = ARRAY_FIELDS,
+): [CollectedFields[], Record<string, string | object>[]] {
+  const valids: CollectedFields[] = [];
+  const invalids: Record<string, string | object>[] = [];
+  for (const json of csvToJson(rows, arrayCols)) {
+    if (!validate(json)) {
+      if (validate.errors !== undefined && validate.errors !== null) {
+        json.errors = validate.errors;
+      }
+      invalids.push(json);
+    } else {
+      valids.push(json);
+    }
+  }
+  return [valids, invalids];
+}
+
+// Converts records from csv to json format without validation.
+// Nesting is possible using dot-syntax in the column name.
+//
+// segmented.column.name with value val becomes:
+// {
+//   segmented: {
+//     column: {
+//       name: val
+//     {
+//   }
+// }
+export function csvToJson(
+  // lint disable required for the output of csv-parse.
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  rows: any[],
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  arrayCols: string[] = ARRAY_FIELDS,
+): Record<string, string | string[] | object>[] {
+  type NestedKeyVal = { [index: string]: NestedKeyVal };
+
+  const objs: Record<string, string | string[] | object>[] = [];
+  for (const row of rows) {
+    const data: NestedKeyVal = {};
+    for (const columnName in row) {
+      let val = row[columnName];
+      if (val === '') continue;
+      if (arrayCols.includes(columnName)) {
+        // Assume comma-delimited array and split into components.
+        val = val.split(',').map((s: string) => s.trim());
+      }
+
+      const chunks = columnName.split('.');
+      let dest = data;
+      if (chunks.length === 1) {
+        dest[chunks[0]] = val;
+      } else {
+        for (const chunk of chunks.slice(0, -1)) {
+          if (!(chunk in dest)) {
+            const subobj: NestedKeyVal = {};
+            dest[chunk] = subobj;
+          }
+          dest = dest[chunk];
+        }
+        dest[chunks.at(-1)!] = val;
+      }
+    }
+    objs.push(data);
+  }
+  return objs;
+}

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -58,7 +58,7 @@ export type CollectedFields = {
 
 const collectedIncentivePropertySchema = {
   id: { type: 'string' },
-  data_urls: { type: 'string' },
+  data_urls: { type: 'array', items: { type: 'string' } },
   authority_type: { type: 'string', enum: Object.values(AuthorityType) },
   authority_name: { type: 'string' },
   program_title: { type: 'string' },
@@ -98,6 +98,21 @@ const collectedIncentivePropertySchema = {
   questions: { type: 'string', nullable: true },
   serve_in_api: { type: 'boolean', nullable: true },
 } as const;
+const requiredCollectedFields = [
+  'id',
+  'data_urls',
+  'authority_type',
+  'authority_name',
+  'program_title',
+  'program_url',
+  'item',
+  'short_description',
+  'program_status',
+  'payment_methods',
+  'rebate_value',
+  'amount',
+  'owner_status',
+] as const;
 
 // DerivedFields and its schema are associated with data not directly collected
 // in the main spreadsheets. They may have a close relationship with collected
@@ -168,6 +183,15 @@ const requiredProperties = [
   'owner_status',
   'short_description',
 ] as const;
+
+export const COLLECTED_DATA_SCHEMA: JSONSchemaType<CollectedFields> = {
+  type: 'object',
+  properties: {
+    ...collectedIncentivePropertySchema,
+  },
+  required: requiredCollectedFields,
+  additionalProperties: false,
+} as const;
 
 export const STATE_SCHEMA: JSONSchemaType<StateIncentive> = {
   type: 'object',

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -190,7 +190,6 @@ export const COLLECTED_DATA_SCHEMA: JSONSchemaType<CollectedFields> = {
     ...collectedIncentivePropertySchema,
   },
   required: requiredCollectedFields,
-  additionalProperties: false,
 } as const;
 
 export const STATE_SCHEMA: JSONSchemaType<StateIncentive> = {

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -65,7 +65,7 @@ test('validation work', tap => {
     item: 'heat_pump_clothes_dryer',
     item_if_selected_other: '',
     'short_description.en':
-      'Receive up to $50 rebate for an Energy Start certified electric ventless or vented clothes dryer from an approved retailer.',
+      'Receive up to $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
     program_status: 'Active',
     program_start_raw: '1/1/2022',
     program_end_raw: '12/31/2026',

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -1,0 +1,97 @@
+import _ from 'lodash';
+import { test } from 'tap';
+import {
+  csvToJson,
+  csvToJsonValidate,
+} from '../../scripts/lib/format-converter';
+
+test('empty fields are removed', tap => {
+  const objs = [
+    {
+      basicProperty: 'foo',
+      removedProperty: '',
+    },
+  ];
+  tap.matchOnly(csvToJson(objs), [
+    { basicProperty: 'foo' },
+  ]);
+  tap.end();
+});
+
+test('array fields are split up', tap => {
+  const objs = [
+    {
+      basicProperty: 'foo',
+      arrayProperty: 'bar,baz',
+    },
+  ];
+  tap.matchOnly(csvToJson(objs, ['arrayProperty']), [
+    { basicProperty: 'foo', arrayProperty: ['bar', 'baz'] },
+  ]);
+  tap.end();
+});
+
+test('nested columns properly expanded', tap => {
+  const objs = [
+    {
+      unnested: 'foo',
+      'nested.array': 'bar,baz',
+      'nested.flat': 'qux',
+      'deeply.nested.flat': 'quux',
+    },
+  ];
+  tap.matchOnly(csvToJson(objs, ['nested.array']), [
+    {
+      unnested: 'foo',
+      nested: {
+        array: ['bar', 'baz'],
+        flat: 'qux',
+      },
+      deeply: { nested: { flat: 'quux' } },
+    },
+  ]);
+  tap.end();
+});
+
+test('validation work', tap => {
+  const fullInput = {
+    id: 'VA-1',
+    data_urls: 'https://takechargeva.com/programs/for-your-home',
+    authority_type: 'utility',
+    authority_name: 'Appalachian Power',
+    program_title: 'Take Charge Virginia Efficient Products Program',
+    program_url:
+      'https://takechargeva.com/programs/for-your-home/efficient-products-program-appliances',
+    item: 'heat_pump_clothes_dryer',
+    item_if_selected_other: '',
+    'short_description.en':
+      'Receive up to $50 rebate for an Energy Start certified electric ventless or vented clothes dryer from an approved retailer.',
+    program_status: 'Active',
+    program_start_raw: '1/1/2022',
+    program_end_raw: '12/31/2026',
+    payment_methods: 'rebate',
+    rebate_value: '50',
+    'amount.type': 'dollar_amount',
+    'amount.number': '50',
+    'amount.unit': '',
+    'amount.minimum': '',
+    'amount.maximum': '50',
+    'amount.representative': '',
+    bonus_description: '',
+    equipment_standards_restrictions: 'Must be ENERGY STAR certified.',
+    equipment_capacity_restrictions: '',
+    contractor_restrictions: '',
+    income_restrictions: '',
+    filing_status: '',
+    owner_status: 'homeowner',
+    other_restrictions:
+      'Customers can only apply for one rebate of this type per calendar year.',
+    stacking_details: '',
+    financing_details: '',
+  };
+  const partialInput: Partial<typeof fullInput> = _.omit(fullInput, 'id');
+  const [valid, invalid] = csvToJsonValidate([fullInput, partialInput]);
+  tap.equal(valid.length, 1);
+  tap.equal(invalid.length, 1);
+  tap.end();
+});

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import { test } from 'tap';
 import {
-  csvToJson,
-  csvToJsonValidate,
+  flatToNested,
+  flatToNestedValidate,
 } from '../../scripts/lib/format-converter';
 
 test('empty fields are removed', tap => {
@@ -12,7 +12,7 @@ test('empty fields are removed', tap => {
       removedProperty: '',
     },
   ];
-  tap.matchOnly(csvToJson(objs), [
+  tap.matchOnly(flatToNested(objs), [
     { basicProperty: 'foo' },
   ]);
   tap.end();
@@ -25,7 +25,7 @@ test('array fields are split up', tap => {
       arrayProperty: 'bar,baz',
     },
   ];
-  tap.matchOnly(csvToJson(objs, ['arrayProperty']), [
+  tap.matchOnly(flatToNested(objs, ['arrayProperty']), [
     { basicProperty: 'foo', arrayProperty: ['bar', 'baz'] },
   ]);
   tap.end();
@@ -40,7 +40,7 @@ test('nested columns properly expanded', tap => {
       'deeply.nested.flat': 'quux',
     },
   ];
-  tap.matchOnly(csvToJson(objs, ['nested.array']), [
+  tap.matchOnly(flatToNested(objs, ['nested.array']), [
     {
       unnested: 'foo',
       nested: {
@@ -92,7 +92,7 @@ test('validation work', tap => {
   // Take a valid record; make an invalid copy by removing a field.
   // Then verify that one record is valid and one is not.
   const partialInput: Partial<typeof fullInput> = _.omit(fullInput, 'id');
-  const [valid, invalid] = csvToJsonValidate([fullInput, partialInput]);
+  const [valid, invalid] = flatToNestedValidate([fullInput, partialInput]);
   tap.equal(valid.length, 1);
   tap.equal(invalid.length, 1);
   tap.end();

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -89,6 +89,8 @@ test('validation work', tap => {
     stacking_details: '',
     financing_details: '',
   };
+  // Take a valid record; make an invalid copy by removing a field.
+  // Then verify that one record is valid and one is not.
   const partialInput: Partial<typeof fullInput> = _.omit(fullInput, 'id');
   const [valid, invalid] = csvToJsonValidate([fullInput, partialInput]);
   tap.equal(valid.length, 1);

--- a/test/scripts/spreadsheet-standardizer.test.ts
+++ b/test/scripts/spreadsheet-standardizer.test.ts
@@ -122,7 +122,7 @@ test('representative example', tap => {
     'Technology*': 'Heat Pump Dryers / Clothes Dryer',
     "Technology (If selected 'Other')": '',
     'Program Description (guideline)':
-      'Receive up to $50 rebate for an Energy Start certified electric ventless or vented clothes dryer from an approved retailer.',
+      'Receive up to $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
     'Program Status': 'Active',
     'Program Start (MM/DD/YYYY)': '1/1/2022',
     'Program End (MM/DD/YYYY)': '12/31/2026',
@@ -158,7 +158,7 @@ test('representative example', tap => {
     item: 'heat_pump_clothes_dryer',
     item_if_selected_other: '',
     'short_description.en':
-      'Receive up to $50 rebate for an Energy Start certified electric ventless or vented clothes dryer from an approved retailer.',
+      'Receive up to $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
     program_status: 'active',
     program_start_raw: '1/1/2022',
     program_end_raw: '12/31/2026',


### PR DESCRIPTION
This is not integrated yet – that is an upcoming PR.

I was tempted to call these methods csvToJson, but really csv-parse has already converted csv to json; it's just a flat object that we can't do interesting things with. These methods "inflate" that object and optionally validate it.

I noticed an error or two in the previous schema as testing, so those are fixed here.