### PR TITLE
Validate spreadsheets first in spreadsheet-to-json flow.

### DIFF
--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -6,15 +6,39 @@ import minimist from 'minimist';
 import path from 'path';
 
 import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../src/data/low_income_thresholds';
-import { STATE_SCHEMA, StateIncentive } from '../src/data/state_incentives';
+import {
+  CollectedFields,
+  STATE_SCHEMA,
+  StateIncentive,
+} from '../src/data/state_incentives';
 import { LOCALIZABLE_STRING_SCHEMA } from '../src/data/types/localizable-string';
 import { FILES, IncentiveFile } from './incentive-spreadsheet-registry';
+import { flatToNestedValidate } from './lib/format-converter';
 import { FIELD_MAPPINGS, VALUE_MAPPINGS } from './lib/spreadsheet-mappings';
 import { SpreadsheetStandardizer } from './lib/spreadsheet-standardizer';
 
 const ajv = new Ajv({ allErrors: true });
 
 const validate = ajv.addSchema(LOCALIZABLE_STRING_SCHEMA).compile(STATE_SCHEMA);
+
+function writeJson(
+  valid: string,
+  validPath: string,
+  invalid: string,
+  invalidPath: string,
+) {
+  const dir = path.dirname(validPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+  fs.writeFileSync(validPath, valid, 'utf-8');
+  if (invalid.length === 0) {
+    if (fs.existsSync(invalidPath)) {
+      // Clear any previous versions if we have no invalid records.
+      fs.unlinkSync(invalidPath);
+    }
+  } else {
+    fs.writeFileSync(invalidPath, invalid, 'utf-8');
+  }
+}
 
 async function convertToJson(
   state: string,
@@ -40,41 +64,47 @@ async function convertToJson(
     strict,
     lowIncome ? LOW_INCOME_THRESHOLDS_BY_AUTHORITY : null,
   );
-  const invalids: Record<string, string | number | boolean | object>[] = [];
+
+  const standardized = rows.map(standardizer.standardize.bind(standardizer));
+
+  const [valids, invalids] = flatToNestedValidate(standardized);
+  if (invalids.length > 0) {
+    writeJson(
+      JSON.stringify(valids, null, 2) + '\n',
+      file.filepath.replace('.json', '_raw.json'),
+      JSON.stringify(invalids, null, 2) + '\n',
+      file.filepath.replace('.json', '_raw_invalid.json'),
+    );
+    throw new Error(
+      'Invalid spreadsheet records found. See raw.json and raw_invalid.json files to debug before converting to API-friendly JSON.',
+    );
+  }
+
+  type StateIncentivesWithErrors = Partial<StateIncentive> & {
+    errors: object[];
+  };
+  const invalid_jsons: StateIncentivesWithErrors[] = [];
   const jsons: StateIncentive[] = [];
-  rows.forEach((row: Record<string, string>) => {
-    const standardized = standardizer.standardize(row);
-    const refined = standardizer.refineCollectedData(state, standardized);
+
+  valids.forEach((row: CollectedFields) => {
+    const refined = standardizer.refineCollectedData(state, row);
     if (!validate(refined)) {
+      const invalid = refined as StateIncentivesWithErrors;
       if (validate.errors !== undefined && validate.errors !== null) {
-        refined.errors = validate.errors;
+        invalid.errors = validate.errors;
       }
-      invalids.push(refined);
+      invalid_jsons.push(invalid);
     } else {
       jsons.push(refined);
     }
   });
 
-  const dir = path.dirname(file.filepath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
-  fs.writeFileSync(
+  writeJson(
+    JSON.stringify(jsons, null, 2) + '\n',
     file.filepath,
-    JSON.stringify(jsons, null, 2) + '\n', // include newline to satisfy prettier
-    'utf-8',
+    JSON.stringify(invalid_jsons, null, 2) + '\n',
+    file.filepath.replace('.json', '_invalid.json'),
   );
-  const invalidsFilePath = file.filepath.replace('.json', '_invalid.json');
-  if (invalids.length === 0) {
-    if (fs.existsSync(invalidsFilePath)) {
-      // Clear any previous versions if we have no invalid records.
-      fs.unlinkSync(invalidsFilePath);
-    }
-  } else {
-    fs.writeFileSync(
-      invalidsFilePath,
-      JSON.stringify(invalids, null, 2) + '\n', // include newline to satisfy prettier
-      'utf-8',
-    );
-  }
 }
 
 (async function () {

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -109,6 +109,8 @@ export class SpreadsheetStandardizer {
     record: CollectedFields,
   ): Partial<StateIncentive> {
     const authorityName = createAuthorityName(state, record.authority_name);
+    // Pass-through fields are those in CollectedFields that appear in the
+    // refined StateIncentive verbatim. Everything else needs some processing.
     const output: Partial<StateIncentive> = _.pick(record, PASS_THROUGH_FIELDS);
     output.authority = authorityName;
     output.program = createProgramName(

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { LowIncomeThresholdsMap } from '../../src/data/low_income_thresholds';
 import {
   CollectedFields,
+  FIELD_ORDER,
   LowIncomeAuthority,
   PASS_THROUGH_FIELDS,
   StateIncentive,
@@ -144,7 +145,13 @@ export class SpreadsheetStandardizer {
       }
     }
 
-    return output;
+    // Enforce a specific property order on the output for better debugging.
+    return Object.fromEntries(
+      FIELD_ORDER.map((key: string) => [
+        key,
+        key in output ? output[key as keyof typeof output] : undefined,
+      ]).filter(([, val]) => val !== undefined),
+    );
   }
 
   retrieveLowIncomeProgram(

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -1,4 +1,11 @@
+import _ from 'lodash';
 import { LowIncomeThresholdsMap } from '../../src/data/low_income_thresholds';
+import {
+  CollectedFields,
+  LowIncomeAuthority,
+  PASS_THROUGH_FIELDS,
+  StateIncentive,
+} from '../../src/data/state_incentives';
 import {
   createAuthorityName,
   createProgramName,
@@ -98,40 +105,26 @@ export class SpreadsheetStandardizer {
   // That record may still fail ajv schema validation later.
   refineCollectedData(
     state: string,
-    record: Record<string, string>,
-  ): Record<string, string | number | object | boolean> {
+    record: CollectedFields,
+  ): Partial<StateIncentive> {
     const authorityName = createAuthorityName(state, record.authority_name);
-    const output: Record<string, string | number | object | boolean> = {
-      id: record.id,
-      authority_type: record.authority_type,
-      authority: authorityName,
-      type: record.payment_methods.split(',')[0],
-      payment_methods: record.payment_methods.split(',').map(x => x.trim()),
-      item: record.item,
-      program: createProgramName(
-        state,
-        record.authority_name,
-        record.program_title,
-      ),
-      amount: this.createAmount(record),
-      owner_status: record.owner_status.split(',').map(x => x.trim()),
-      short_description: {
-        en: standardizeDescription(record['short_description.en']),
-      },
+    const output: Partial<StateIncentive> = _.pick(record, PASS_THROUGH_FIELDS);
+    output.authority = authorityName;
+    output.program = createProgramName(
+      state,
+      record.authority_name,
+      record.program_title,
+    );
+    output.short_description = {
+      en: standardizeDescription(record.short_description.en),
     };
-    if (
-      record.program_start_raw !== undefined &&
-      record.program_start_raw !== ''
-    ) {
+    if (record.program_start_raw && record.program_start_raw !== '') {
       output.start_date = +parseDateToYear(record.program_start_raw);
     }
-    if (record.program_end_raw !== undefined && record.program_end_raw !== '') {
+    if (record.program_end_raw && record.program_end_raw !== '') {
       output.end_date = +parseDateToYear(record.program_end_raw);
     }
-    if (
-      record.bonus_description !== undefined &&
-      record.bonus_description !== ''
-    ) {
+    if (record.bonus_description && record.bonus_description !== '') {
       output.bonus_available = true;
     }
     if (this.lowIncomeThresholds && isPlausibleLowIncomeRow(record)) {
@@ -140,7 +133,7 @@ export class SpreadsheetStandardizer {
         state,
       );
       if (low_income_program) {
-        output.low_income = authorityName;
+        output.low_income = low_income_program;
       } else if (low_income_program === undefined) {
         // This is checked up front by the caller rather than
         // at the row level to avoid spamming error messages.
@@ -154,40 +147,18 @@ export class SpreadsheetStandardizer {
     return output;
   }
 
-  retrieveLowIncomeProgram(authority: string, state: string) {
+  retrieveLowIncomeProgram(
+    authority: string,
+    state: string,
+  ): LowIncomeAuthority | undefined | null {
     if (this.lowIncomeThresholds![state] === undefined) {
       return undefined;
     }
-    return authority in this.lowIncomeThresholds![state];
-  }
-
-  createAmount(input: Record<string, string>): Record<string, number | string> {
-    const amount: Record<string, number | string> = {
-      type: input['amount.type'],
-      number: +cleanDollars(input['amount.number']),
-    };
-    if (
-      input['amount.representative'] !== undefined &&
-      input['amount.representative'] !== ''
-    ) {
-      amount.representative = +cleanDollars(input['amount.representative']);
+    if (authority in this.lowIncomeThresholds![state]) {
+      return authority as LowIncomeAuthority;
+    } else {
+      return null;
     }
-    if (
-      input['amount.minimum'] !== undefined &&
-      input['amount.minimum'] !== ''
-    ) {
-      amount.minimum = +cleanDollars(input['amount.minimum']);
-    }
-    if (
-      input['amount.maximum'] !== undefined &&
-      input['amount.maximum'] !== ''
-    ) {
-      amount.maximum = +cleanDollars(input['amount.maximum']);
-    }
-    if (input['amount.unit'] !== undefined && input['amount.unit'] !== '') {
-      amount.unit = input['amount.unit'];
-    }
-    return amount;
   }
 }
 
@@ -216,16 +187,13 @@ function standardizeDescription(desc: string): string {
   return desc;
 }
 
-function isPlausibleLowIncomeRow(record: Record<string, string>) {
-  if (
-    record.income_restrictions !== undefined &&
-    record.income_restrictions !== ''
-  ) {
+function isPlausibleLowIncomeRow(record: CollectedFields) {
+  if (record.income_restrictions && record.income_restrictions !== '') {
     return true;
   }
   if (
-    record.short_description !== undefined &&
-    record.short_description.toLowerCase().includes('income')
+    record.short_description?.en &&
+    record.short_description.en.toLowerCase().includes('income')
   ) {
     return true;
   }

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -198,6 +198,7 @@ export const STATE_SCHEMA: JSONSchemaType<StateIncentive> = {
     ...incentivePropertySchema,
   },
   required: requiredProperties,
+  additionalProperties: false,
 } as const;
 
 /******************************************************************************/

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -172,6 +172,30 @@ const incentivePropertySchema = {
   ...derivedIncentivePropertySchema,
 };
 
+// We specify field order which helps when debugging records.
+// This type forces all top-level fields to appear.
+const fieldOrder: {
+  [Key in keyof typeof incentivePropertySchema]: undefined;
+} = {
+  id: undefined,
+  agi_max_limit: undefined,
+  agi_min_limit: undefined,
+  authority_type: undefined,
+  authority: undefined,
+  payment_methods: undefined,
+  item: undefined,
+  program: undefined,
+  amount: undefined,
+  owner_status: undefined,
+  short_description: undefined,
+  start_date: undefined,
+  end_date: undefined,
+  bonus_available: undefined,
+  low_income: undefined,
+  filing_status: undefined,
+} as const;
+export const FIELD_ORDER = Object.keys(fieldOrder);
+
 const requiredProperties = [
   'id',
   'authority',

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -143,7 +143,7 @@ const derivedIncentivePropertySchema = {
 } as const;
 
 // Collected fields that pass-through directly to our StateIncentives schema.
-const passThroughFields = [
+export const PASS_THROUGH_FIELDS = [
   'id',
   'authority_type',
   'payment_methods',
@@ -153,11 +153,11 @@ const passThroughFields = [
   'short_description',
   'filing_status',
 ] as const;
-type PassThroughField = (typeof passThroughFields)[number];
+type PassThroughField = (typeof PASS_THROUGH_FIELDS)[number];
 
 const passThroughCollectedProperties = _.pick(
   collectedIncentivePropertySchema,
-  passThroughFields,
+  PASS_THROUGH_FIELDS,
 );
 
 export type StateIncentive = Pick<CollectedFields, PassThroughField> &

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -142,7 +142,8 @@ const derivedIncentivePropertySchema = {
   low_income: { type: 'string', nullable: true },
 } as const;
 
-// Collected fields that pass-through directly to our StateIncentives schema.
+// Collected fields that pass-through directly to our StateIncentives schema
+// without any modification or processing.
 export const PASS_THROUGH_FIELDS = [
   'id',
   'authority_type',

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -1,4 +1,5 @@
 import { test } from 'tap';
+import { flatToNestedValidate } from '../../scripts/lib/format-converter';
 import {
   FIELD_MAPPINGS,
   VALUE_MAPPINGS,
@@ -51,7 +52,6 @@ test('correct row to record transformation', async tap => {
         id: 'VA-1',
         authority_type: 'utility',
         authority: 'va-appalachian-power',
-        type: 'rebate',
         item: 'heat_pump_clothes_dryer',
         payment_methods: ['rebate'],
         program:
@@ -90,9 +90,8 @@ test('correct row to record transformation', async tap => {
   );
   for (const tc of testCases) {
     const standardized = standardizer.standardize(tc.input);
-    tap.matchOnly(
-      standardizer.refineCollectedData('va', standardized),
-      tc.want,
-    );
+    const [valids, invalids] = flatToNestedValidate([standardized]);
+    tap.equal(invalids.length, 0);
+    tap.matchOnly(standardizer.refineCollectedData('va', valids[0]), tc.want);
   }
 });


### PR DESCRIPTION
This incorporates the format-converter and collected schema into the spreadsheet-to-json flow. Now we first validate that the collected data is valid under our spreadsheet schema, then take the collected data and turn it into a refined StateIncentive. This may surface some more nits in the short-term while we clean up the spreadsheets, but in the long-term is better since we can keep those spreadsheets healthy from the get-go.

It simplifies the `refineCollectedData` method since we can assumed we're working with valid collected data from the beginning. However, it did require rewriting a bit of the LowIncomeThreshold part since we could no longer just assign a string.

After this PR, I'll also pull out a stand-alone version of the CollectedFields validation that can be run on our spreadsheets on a periodic basis so we can be aware of any spreadsheet validity regressions.