### PR TITLE
Fix Vermont Incentives so we don't double up on the same incentive.

### DIFF
--- a/data/VT/incentive_relationships.json
+++ b/data/VT/incentive_relationships.json
@@ -6,6 +6,10 @@
   "exclusions": {
     "VT-56": [
       "VT-55"
+    ],
+    "VT-1": [
+      "VT-3",
+      "VT-4"
     ]
   },
   "combinations": [

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -190,28 +190,6 @@
     }
   },
   {
-    "id": "VT-9",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
-    "type": "pos_rebate",
-    "item": "heat_pump_air_conditioner_heater",
-    "payment_methods": [
-      "pos_rebate"
-    ],
-    "program": "vt_greenMountainPowerDuctedHeatPumpRebateProgram",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "GMP customers receive a $400 point of purchase discount on ducted heat pump."
-    }
-  },
-  {
     "id": "VT-10",
     "authority_type": "utility",
     "authority": "vt-green-mountain-power",
@@ -373,28 +351,6 @@
       "en": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor."
     },
     "start_date": 2021
-  },
-  {
-    "id": "VT-19",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
-    "type": "pos_rebate",
-    "item": "heat_pump_air_conditioner_heater",
-    "payment_methods": [
-      "pos_rebate"
-    ],
-    "program": "vt_greenMountainPowerDuctlessHeatPumpRebateProgram",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "GMP customers receive a $400 point of purchase discount on ductless heat pump."
-    }
   },
   {
     "id": "VT-20",

--- a/data/programs.json
+++ b/data/programs.json
@@ -875,7 +875,7 @@
   },
   "vt_efficiencyVtAirToWaterHeatPumpRebateProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Program"
+      "en": "Efficiency Vermont Air to Water Heat Pump Rebate Program"
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps"
@@ -883,15 +883,15 @@
   },
   "vt_efficiencyVtClothesDryerRebateProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Program"
+      "en": "Efficiency Vermont Clothes Dryer Rebate Program"
     },
     "url": {
-      "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-clothes-dryer-rebate-form.pdf"
+      "en": "https://www.efficiencyvermont.com/rebates/list/clothes-dryers"
     }
   },
   "vt_efficiencyVtDuctedHeatPumpRebateProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Program"
+      "en": "Efficiency Vermont Ducted Heat Pump Rebate Program"
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps"
@@ -899,7 +899,7 @@
   },
   "vt_efficiencyVtDuctlessHeatPumpRebateProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Program"
+      "en": "Efficiency Vermont Ductless Heat Pump Rebate Program"
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system"
@@ -907,23 +907,23 @@
   },
   "vt_efficiencyVtGroundSourceHeatPumpRebateProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Program"
+      "en": "Efficiency Vermont Ground Source Heat Pump Rebate Program"
     },
     "url": {
-      "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-ground-source-heat-pump-rebate-form.pdf"
+      "en": "https://www.efficiencyvermont.com/rebates/list/ground-source-heat-pumps"
     }
   },
   "vt_efficiencyVtHeatPumpWaterHeaterRebateProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Program"
+      "en": "Efficiency Vermont Heat Pump Water Heater Rebate Program"
     },
     "url": {
-      "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-heat-pump-water-heater-rebate-form.pdf"
+      "en": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters"
     }
   },
   "vt_efficiencyVtHeatPumpRebateIncomeBonusProgram": {
     "name": {
-      "en": "Efficiency Vermont Residential Energy Efficiency Rebate Income Bonus Program"
+      "en": "Efficiency Vermont Heat Pump Rebate Income Bonus Program"
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf"
@@ -942,7 +942,7 @@
       "en": "Efficiency Vermont - Residential Energy Efficiency Rebate Program (DIY Weatherization)"
     },
     "url": {
-      "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-residential-diy-weatherization-rebate-form.pdf"
+      "en": "https://www.efficiencyvermont.com/rebates/list/diy-weatherization"
     }
   },
   "vt_efficiencyVtHomePerformanceEnergyStarProgram": {
@@ -963,7 +963,7 @@
   },
   "vt_efficiencyVTwithWECWeatherizationProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Weatherization Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -971,7 +971,7 @@
   },
   "vt_efficiencyVTwithWECWeatherizationIncomeBonusProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Weatherization Income Bonus Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -1019,7 +1019,7 @@
   },
   "vt_burlingtonElectricHeatPumpIncomeBonusRebateProgram": {
     "name": {
-      "en": "Burlington Electric Department - Rebate Program - Income Bonus"
+      "en": "Burlington Electric Department - Heat Pump Rebate Program - Income Bonus"
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf"
@@ -1035,7 +1035,7 @@
   },
   "vt_buttonUpWECAirToWaterHeatPumpProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Air to Water Heat Pump Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -1043,7 +1043,7 @@
   },
   "vt_buttonUpWECDuctedHeatPumpProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Ducted Heat Pump Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -1051,7 +1051,7 @@
   },
   "vt_buttonUpWECDuctlessHeatPumpProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Ductless Heat Pump Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -1059,7 +1059,7 @@
   },
   "vt_buttonUpWECGroundSourceHeatPumpProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Ground Source Heat Pump Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -1067,7 +1067,7 @@
   },
   "vt_buttonUpWECHeatPumpWaterHeaterProgram": {
     "name": {
-      "en": "Button Up WEC"
+      "en": "Button Up WEC - Heat Pump Water Heater Program"
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
@@ -1075,7 +1075,7 @@
   },
   "vt_greenMountainPowerDuctedHeatPumpRebateProgram": {
     "name": {
-      "en": "Green Mountain Power Rebate"
+      "en": "Green Mountain Power Ducted Heat Pump Rebate"
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/home-and-yard/heat-pump/"
@@ -1083,7 +1083,7 @@
   },
   "vt_greenMountainPowerDuctlessHeatPumpRebateProgram": {
     "name": {
-      "en": "Green Mountain Power Rebate"
+      "en": "Green Mountain Power Ductless Heat Pump Rebate"
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/home-and-yard/heat-pump/"
@@ -1115,7 +1115,7 @@
   },
   "vt_vermontElectricCoopThermalEfficiencyBillCreditDuctedHeatPumpBonusProgram": {
     "name": {
-      "en": "Thermal Efficiency Bill Credit Bonus"
+      "en": "Thermal Efficiency Bill Credit Bonus - Ducted Heat Pump"
     },
     "url": {
       "en": "https://eternityweb.formstack.com/forms/vermont_electric_coop_thermal_efficiency_bonus"
@@ -1123,7 +1123,7 @@
   },
   "vt_vermontElectricCoopThermalEfficiencyBillCreditDuctlessHeatPumpBonusProgram": {
     "name": {
-      "en": "Thermal Efficiency Bill Credit Bonus"
+      "en": "Thermal Efficiency Bill Credit Bonus - Ductless Heat Pump"
     },
     "url": {
       "en": "https://eternityweb.formstack.com/forms/vermont_electric_coop_thermal_efficiency_bonus"

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -526,7 +526,7 @@
       "start_date": 2023,
       "end_date": 2024,
       "ami_qualification": null,
-      "eligible": true,
+      "eligible": false,
       "short_description": "BED customers may receive a post purchase rebate up to $12,000 when you install an air-to-water heat pump."
     },
     {
@@ -718,33 +718,6 @@
       "end_date": 2024,
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Income-eligible Vermonters/BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified air-to-water heat pump."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "vt-burlington-electric-department",
-      "program": "Burlington Electric Department - Heat Pump Rebate Program - Income Bonus",
-      "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
-      },
-      "amount": {
-        "type": "dollar_amount",
-        "number": 400,
-        "maximum": 400
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": 2023,
-      "end_date": 2024,
-      "ami_qualification": null,
-      "eligible": true,
       "short_description": "Income-eligible Vermonters who are BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified ducted heat pump."
     },
     {
@@ -773,6 +746,33 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible BED customers qualify for a $400 enhanced rebate for a ductless HP."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "vt-burlington-electric-department",
+      "program": "Burlington Electric Department - Heat Pump Rebate Program - Income Bonus",
+      "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 400,
+        "maximum": 400
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "Income-eligible Vermonters/BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified air-to-water heat pump."
     },
     {
       "payment_methods": [

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -243,7 +243,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Program",
+      "program": "Efficiency Vermont Ducted Heat Pump Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -271,7 +271,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Program",
+      "program": "Efficiency Vermont Ductless Heat Pump Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -300,8 +300,8 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Program",
-      "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-heat-pump-water-heater-rebate-form.pdf",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -328,8 +328,8 @@
       ],
       "authority_type": "utility",
       "authority": "vt-burlington-electric-department",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Program",
-      "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-clothes-dryer-rebate-form.pdf",
+      "program": "Efficiency Vermont Clothes Dryer Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/clothes-dryers",
       "item": {
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer",
@@ -496,8 +496,8 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Program",
-      "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-ground-source-heat-pump-rebate-form.pdf",
+      "program": "Efficiency Vermont Ground Source Heat Pump Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/ground-source-heat-pumps",
       "item": {
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation",
@@ -583,7 +583,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Program",
+      "program": "Efficiency Vermont Air to Water Heat Pump Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -612,7 +612,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Income Bonus Program",
+      "program": "Efficiency Vermont Heat Pump Rebate Income Bonus Program",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -668,7 +668,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Income Bonus Program",
+      "program": "Efficiency Vermont Heat Pump Rebate Income Bonus Program",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "geothermal_heating_installation",
@@ -724,7 +724,7 @@
       ],
       "authority_type": "utility",
       "authority": "vt-burlington-electric-department",
-      "program": "Burlington Electric Department - Rebate Program - Income Bonus",
+      "program": "Burlington Electric Department - Heat Pump Rebate Program - Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -752,7 +752,7 @@
       ],
       "authority_type": "utility",
       "authority": "vt-burlington-electric-department",
-      "program": "Burlington Electric Department - Rebate Program - Income Bonus",
+      "program": "Burlington Electric Department - Heat Pump Rebate Program - Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -780,7 +780,7 @@
       ],
       "authority_type": "utility",
       "authority": "vt-burlington-electric-department",
-      "program": "Burlington Electric Department - Rebate Program - Income Bonus",
+      "program": "Burlington Electric Department - Heat Pump Rebate Program - Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -808,7 +808,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Income Bonus Program",
+      "program": "Efficiency Vermont Heat Pump Rebate Income Bonus Program",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -836,7 +836,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Income Bonus Program",
+      "program": "Efficiency Vermont Heat Pump Rebate Income Bonus Program",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -864,7 +864,7 @@
       ],
       "authority_type": "state",
       "authority": "vt-ev",
-      "program": "Efficiency Vermont Residential Energy Efficiency Rebate Income Bonus Program",
+      "program": "Efficiency Vermont Heat Pump Rebate Income Bonus Program",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_water_heater",
@@ -893,7 +893,7 @@
       "authority_type": "state",
       "authority": "vt-ev",
       "program": "Efficiency Vermont - Residential Energy Efficiency Rebate Program (DIY Weatherization)",
-      "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-residential-diy-weatherization-rebate-form.pdf",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/diy-weatherization",
       "item": {
         "type": "weatherization",
         "name": "Weatherization",


### PR DESCRIPTION
Some incentives are brought through a partnership of a state entity with a utility company. We are removing a couple of incentives here that are redundant.