### PR TITLE
Add testfilter yarn script for running a subset of tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "build": "./scripts/build.sh",
     "lint": "tsc --noEmit && prettier --check . --ignore-path=.prettierignore && eslint .",
     "test": "dotenv -- tap -- --ts \"test/**/*.test.ts\"",
+    "testfilter": "dotenv -- tap -- --ts",
     "update-descriptions": "ts-node scripts/update-descriptions"
   },
   "tap": {


### PR DESCRIPTION
Our test suite's grown a lot, and it would be nice to have an easy way to only run some tests while working on individual files. `yarn testfilter <path>` does this.

In yarn 2, there's a slicker way to do this that doesn't require a separate command, but I couldn't figure out an easy way to do this in yarn 1.