### PR TITLE
Document generate-utility-data script in README

### DIFF
--- a/scripts/generate-utility-data.ts
+++ b/scripts/generate-utility-data.ts
@@ -210,6 +210,9 @@ enum Col {
   const seen = new Set<string>();
   const names = new Map<string, string>();
 
+  // Print the last refresh date
+  console.log(sheet[0][0].v);
+
   for (const sheetRow of sheet.slice(3)) {
     const row: { [c in keyof typeof Col]: string } = Object.fromEntries(
       _.zip(


### PR DESCRIPTION
## Description

I realized I was going through a somewhat finicky process to clean up
the utility data for each state, and this is now has to be an integral
part of the spreadsheet-to-JSON process, so I'd better document it.

I'm not yet totally sure where this process should fit into the
overall process for each state, so interested in feedback on that.

Also I realized I have no plan for running this script on a regular
basis. I have no idea how often ENERGY STAR updates the data, so I
thought the script should at least print out the last-updated date (in
the first cell of the spreadsheet) so we can start to figure that out.

## Test Plan

Read it. Run the script.
