### PR TITLE
Refactor spreadsheet-to-json to avoid writing files.

### DIFF
--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -5,7 +5,10 @@ import fetch from 'make-fetch-happen';
 import minimist from 'minimist';
 import path from 'path';
 
-import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../src/data/low_income_thresholds';
+import {
+  LOW_INCOME_THRESHOLDS_BY_AUTHORITY,
+  LowIncomeThresholdsMap,
+} from '../src/data/low_income_thresholds';
 import {
   CollectedIncentive,
   STATE_SCHEMA,
@@ -52,17 +55,17 @@ function updateJsonFiles(records: object[], filepath: string) {
   }
 }
 
-export async function spreadsheetToJson(
+export function spreadsheetToJson(
   state: string,
   rows: Record<string, string>[],
   strict: boolean,
-  lowIncome: boolean,
-): Promise<SpreadsheetConversionOutput> {
+  lowIncome: LowIncomeThresholdsMap | null,
+): SpreadsheetConversionOutput {
   const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
     VALUE_MAPPINGS,
     strict,
-    lowIncome ? LOW_INCOME_THRESHOLDS_BY_AUTHORITY : null,
+    lowIncome,
   );
 
   const standardized = rows.map(standardizer.standardize.bind(standardizer));
@@ -118,7 +121,12 @@ async function convertToJson(
     invalidCollectedIncentives,
     invalidStateIncentives,
     validStateIncentives,
-  } = await spreadsheetToJson(state, rows, strict, lowIncome);
+  } = await spreadsheetToJson(
+    state,
+    rows,
+    strict,
+    lowIncome ? LOW_INCOME_THRESHOLDS_BY_AUTHORITY : null,
+  );
 
   const invalidCollectedPath = file.filepath.replace(
     '.json',

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -30,7 +30,7 @@ type SpreadsheetConversionOutput = {
   validStateIncentives: StateIncentive[];
 };
 
-export function safeDeleteFiles(...filepaths: string[]) {
+function safeDeleteFiles(...filepaths: string[]) {
   for (const filepath of filepaths) {
     if (fs.existsSync(filepath)) {
       fs.unlinkSync(filepath);
@@ -38,7 +38,7 @@ export function safeDeleteFiles(...filepaths: string[]) {
   }
 }
 
-export function updateJsonFiles(records: object[], filepath: string) {
+function updateJsonFiles(records: object[], filepath: string) {
   const dir = path.dirname(filepath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir);
   if (records.length === 0) {
@@ -107,7 +107,6 @@ async function convertToJson(
       `No low-income thresholds defined for ${state} - define them or turn off strict mode.`,
     );
   }
-
   const response = await fetch(file.sheetUrl);
   const csvContent = await response.text();
   const rows = parse(csvContent, {
@@ -130,16 +129,14 @@ async function convertToJson(
     '_invalid_state.json',
   );
   updateJsonFiles(invalidCollectedIncentives, invalidCollectedPath);
-  updateJsonFiles(validStateIncentives, file.filepath);
   updateJsonFiles(invalidStateIncentives, invalidStatePath);
-  if (invalidCollectedIncentives.length > 0) {
+  updateJsonFiles(validStateIncentives, file.filepath);
+  if (
+    invalidCollectedIncentives.length > 0 ||
+    invalidStateIncentives.length > 0
+  ) {
     throw new Error(
-      `Some records failed CollectedIncentive validation. See ${invalidCollectedPath} to debug errors.`,
-    );
-  }
-  if (invalidStateIncentives.length > 0) {
-    throw new Error(
-      `Some records failed StateIncentive validation. See ${invalidStatePath} to debug errors.`,
+      `Some records failed validation. See ${invalidCollectedPath} and/or ${invalidStatePath} to debug errors.`,
     );
   }
 }

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -41,10 +41,14 @@ function safeDeleteFiles(...filepaths: string[]) {
   }
 }
 
-function updateJsonFiles(records: object[], filepath: string) {
+function updateJsonFiles(
+  records: object[],
+  filepath: string,
+  deleteEmpty: boolean = true,
+) {
   const dir = path.dirname(filepath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir);
-  if (records.length === 0) {
+  if (records.length === 0 && deleteEmpty) {
     safeDeleteFiles(filepath);
   } else {
     fs.writeFileSync(
@@ -138,7 +142,8 @@ async function convertToJson(
   );
   updateJsonFiles(invalidCollectedIncentives, invalidCollectedPath);
   updateJsonFiles(invalidStateIncentives, invalidStatePath);
-  updateJsonFiles(validStateIncentives, file.filepath);
+  // Pass deleteEmpty = false since missing incentives files cause compilation errors.
+  updateJsonFiles(validStateIncentives, file.filepath, false);
   if (
     invalidCollectedIncentives.length > 0 ||
     invalidStateIncentives.length > 0

--- a/test/data/spreadsheets-health.test.ts
+++ b/test/data/spreadsheets-health.test.ts
@@ -7,7 +7,7 @@ import { spreadsheetToJson } from '../../scripts/incentive-spreadsheet-to-json';
 
 // TODO: condition this on an environment variable that we set only
 // in workflows where we want to run this test.
-const skip: boolean = false;
+const skip: boolean = true;
 test(
   'rows in registered spreadsheets meet our collected data schema or are opted out',
   { skip: skip ? 'spreadsheet health tests: skipped by default' : false },
@@ -24,7 +24,16 @@ test(
 
         const output = await spreadsheetToJson(state, rows, false, false);
         if (output.invalidCollectedIncentives.length > 0) {
-          console.error(util.inspect(output.invalidCollectedIncentives[0]));
+          console.error(
+            `${state}` +
+              util.inspect(
+                output.invalidCollectedIncentives.map(invalid => [
+                  invalid.id,
+                  invalid.errors,
+                ]),
+                { depth: null },
+              ),
+          );
         }
         tap.equal(
           output.invalidCollectedIncentives.length,

--- a/test/data/spreadsheets-health.test.ts
+++ b/test/data/spreadsheets-health.test.ts
@@ -3,16 +3,11 @@ import fetch from 'make-fetch-happen';
 import { test } from 'tap';
 import util from 'util';
 import { FILES } from '../../scripts/incentive-spreadsheet-registry';
-import { flatToNestedValidate } from '../../scripts/lib/format-converter';
-import {
-  FIELD_MAPPINGS,
-  VALUE_MAPPINGS,
-} from '../../scripts/lib/spreadsheet-mappings';
-import { SpreadsheetStandardizer } from '../../scripts/lib/spreadsheet-standardizer';
+import { spreadsheetToJson } from '../../scripts/incentive-spreadsheet-to-json';
 
 // TODO: condition this on an environment variable that we set only
 // in workflows where we want to run this test.
-const skip: boolean = true;
+const skip: boolean = false;
 test(
   'rows in registered spreadsheets meet our collected data schema or are opted out',
   { skip: skip ? 'spreadsheet health tests: skipped by default' : false },
@@ -27,31 +22,12 @@ test(
           from_line: file.headerRowNumber ?? 1,
         });
 
-        const standardizer = new SpreadsheetStandardizer(
-          FIELD_MAPPINGS,
-          VALUE_MAPPINGS,
-          false, // allow extra columns not in our schema
-          null,
-        );
-        const standardized = rows.map(
-          standardizer.standardize.bind(standardizer),
-        );
-
-        let [, invalids] = flatToNestedValidate(standardized);
-        // Filter out unfilled rows at the end of the spreadsheet
-        // where we prepopulated IDs but nothing else is filled in.
-        // The two keys we expected are ID and errors.
-        invalids = invalids.filter(invalid => Object.keys(invalid).length > 2);
-        if (invalids.length !== 0)
-          console.error(
-            `${state}` +
-              util.inspect(
-                invalids.map(invalid => [invalid.id, invalid.errors]),
-                { depth: null },
-              ),
-          );
+        const output = await spreadsheetToJson(state, rows, false, false);
+        if (output.invalidCollectedIncentives.length > 0) {
+          console.error(util.inspect(output.invalidCollectedIncentives[0]));
+        }
         tap.equal(
-          invalids.length,
+          output.invalidCollectedIncentives.length,
           0,
           `${state}'s spreadsheet does not match the collected data schema`,
         );

--- a/test/data/spreadsheets-health.test.ts
+++ b/test/data/spreadsheets-health.test.ts
@@ -22,7 +22,7 @@ test(
           from_line: file.headerRowNumber ?? 1,
         });
 
-        const output = await spreadsheetToJson(state, rows, false, false);
+        const output = await spreadsheetToJson(state, rows, false, null);
         if (output.invalidCollectedIncentives.length > 0) {
           console.error(
             `${state}` +


### PR DESCRIPTION
We get better reuse of the spreadsheet-to-json process if decoupled from the file reading/writing parts. So this just moves the data processing into a single method and then file reading/writing happens separately. As part of that, we don't error out early when we find CollectedIncentive errors; we continue to try to validate StateIncentives and surface both separately to the user if they exist.

I also realized the updateJsonFiles method handles file-clearing already so a bit of tidying up there too.