### PR TITLE
Add smart thermostat incentives to RI

### DIFF
--- a/data/RI/incentive_relationships.json
+++ b/data/RI/incentive_relationships.json
@@ -2,6 +2,13 @@
   "exclusions": {
     "RI-43": [
       "RI-13"
+    ],
+    "RI-41": [
+      "RI-42"
     ]
+  },
+  "prerequesites": {
+    "RI-41": "RI-4",
+    "RI-42": "RI-4"
   }
 }

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -544,5 +544,51 @@
       "en": "Depending on your income, 100% of the cost to install a heat pump water heater, including up to $3,000 towards related electric service upgrades.",
       "es": "Según sus ingresos, el costo total de instalar un calentador de agua con bomba de calor. Incluye hasta $3,000 para mejoras eléctricas relacionadas."
     }
+  },
+  {
+    "id": "RI-41",
+    "authority_type": "utility",
+    "authority": "ri-pascoag-utility-district",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "smart_thermostat",
+    "program": "ri_residentialEnergyAuditWeatherization",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 100,
+      "maximum": 100
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$100 back on programmable wireless connection enabled thermostat.",
+      "es": "$100 dólares de devolución en termostato programable con conexión inalámbrica."
+    }
+  },
+  {
+    "id": "RI-42",
+    "authority_type": "utility",
+    "authority": "ri-pascoag-utility-district",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "smart_thermostat",
+    "program": "ri_residentialEnergyAuditWeatherization",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 25,
+      "maximum": 25
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$25 back on programmable non-wireless thermostat.",
+      "es": "$25 dólares de devolución en termostato programable no inalámbrico."
+    }
   }
 ]


### PR DESCRIPTION
# Changes

This PR adds the 2 new smart thermostat incentives available through PUD. I split this out from the original PR (which introduced new ebike incentives in RI) to reduce the risk releasing 2 beta items at once.

This shouldn't change any incentives available in the calculator since the calculator won't be requesting smart thermostat incentives.

All changes:
- 2 new smart thermostat incentives in `incentives.json`
- Based on the [program info](https://pud-ri.org/wp-content/uploads/2022/01/Residential-Energy-Audit-Weatherization-Incentives.pdf), added some incentive relationships:
    - exclusion between RI-41 and RI-42 (it specifies you can only get the $100 rebate OR the $25 one)
    - RI-4 is a prerequisite for both RI-41 and RI-42 because "Programmable thermostats will only qualify if recommended in the home energy audit" (RI-4 is the energy audit mentioned)

# Resources

- [PUD program rules](https://pud-ri.org/wp-content/uploads/2022/01/Residential-Energy-Audit-Weatherization-Incentives.pdf)
- [RI incentives spreadsheet](https://docs.google.com/spreadsheets/d/1Ik9iN2jDyD_ON2WdL24pmWUo6vps28zWiHKyFfZG334/edit#gid=533322917)
- [original ticket](https://app.asana.com/0/1206629812394927/1206378369410355/f)
- [new ticket](https://app.asana.com/0/1206629812394927/1206659708264490/f)
- [original PR](https://github.com/rewiringamerica/api.rewiringamerica.org/pull/300)