### PR TITLE
Add omit_to_api to our schema to filter out unwanted records.

### DIFF
--- a/scripts/lib/format-converter.ts
+++ b/scripts/lib/format-converter.ts
@@ -10,12 +10,16 @@ const ajv = new Ajv({ allErrors: true, coerceTypes: 'array' });
 // TODO: consolidate with spreadsheet-standardizer.ts constant
 // and generate both directly from CollectedIncentive schema.
 const ARRAY_FIELDS = ['data_urls', 'payment_methods', 'owner_status'];
+const BOOL_FIELDS = ['omit_from_api'];
 
 const validate = ajv
   .addSchema(LOCALIZABLE_STRING_SCHEMA)
   .compile(COLLECTED_DATA_SCHEMA);
 
 type NestedKeyVal = { [index: string]: NestedKeyVal };
+export type CollectedIncentivesWithErrors = Partial<CollectedIncentive> & {
+  errors: object[];
+};
 
 /**
  * Call this function to perform validation on the collected records.
@@ -29,15 +33,17 @@ export function flatToNestedValidate(
   rows: any[],
   /* eslint-enable @typescript-eslint/no-explicit-any */
   arrayCols: string[] = ARRAY_FIELDS,
-): [CollectedIncentive[], Record<string, string | object>[]] {
+  boolCols: string[] = BOOL_FIELDS,
+): [CollectedIncentive[], CollectedIncentivesWithErrors[]] {
   const valids: CollectedIncentive[] = [];
-  const invalids: Record<string, string | object>[] = [];
-  for (const json of flatToNested(rows, arrayCols)) {
+  const invalids: CollectedIncentivesWithErrors[] = [];
+  for (const json of flatToNested(rows, arrayCols, boolCols)) {
     if (!validate(json)) {
+      const invalid = json as CollectedIncentivesWithErrors;
       if (validate.errors !== undefined && validate.errors !== null) {
-        json.errors = validate.errors;
+        invalid.errors = validate.errors;
       }
-      invalids.push(json);
+      invalids.push(invalid);
     } else {
       valids.push(json);
     }
@@ -67,7 +73,8 @@ export function flatToNested(
   rows: any[],
   /* eslint-enable @typescript-eslint/no-explicit-any */
   arrayCols: string[] = [],
-): Record<string, string | string[] | object>[] {
+  boolCols: string[] = [],
+): Partial<CollectedIncentive>[] {
   const objs: Record<string, string | string[] | object>[] = [];
   for (const row of rows) {
     const output: NestedKeyVal = {};
@@ -77,6 +84,10 @@ export function flatToNested(
       if (arrayCols.includes(columnName)) {
         // Assume comma-delimited array and split into components.
         val = val.split(',').map((s: string) => s.trim());
+      }
+      if (boolCols.includes(columnName)) {
+        // Minimal-effort conversion of booleans from string.
+        val = coerceToBoolean(val);
       }
 
       const chunks = columnName.split('.');
@@ -100,4 +111,10 @@ export function flatToNested(
     objs.push(output);
   }
   return objs;
+}
+
+function coerceToBoolean(input: string): boolean | string {
+  if (input.toLowerCase() === 'true') return true;
+  if (input.toLowerCase() === 'false') return false;
+  return input;
 }

--- a/scripts/lib/format-converter.ts
+++ b/scripts/lib/format-converter.ts
@@ -113,6 +113,10 @@ export function flatToNested(
   return objs;
 }
 
+// This function is only necessary because ajv cannot convert the string values
+// 'TRUE' or 'FALSE' to boolean, which is how Google Sheets/csv renders boolean
+// values. Any other value will (appropriately) cause the schema validation to
+// fail, so we don't deal with errors here.
 function coerceToBoolean(input: string): boolean | string {
   if (input.toLowerCase() === 'true') return true;
   if (input.toLowerCase() === 'false') return false;

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -43,6 +43,7 @@ export const FIELD_MAPPINGS: AliasMap = {
   // It may not appear in all spreadsheets.
   editorial_notes: ['Editorial Notes'],
   questions: ['Questions'],
+  omit_from_api: ['Omit from API?'],
 };
 
 export const VALUE_MAPPINGS: { [index: string]: AliasMap } = {

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -55,7 +55,7 @@ export type CollectedIncentive = {
   financing_details?: string;
   editorial_notes?: string;
   questions?: string;
-  serve_in_api?: boolean;
+  omit_from_api?: boolean;
 };
 
 const collectedIncentivePropertySchema = {
@@ -98,7 +98,7 @@ const collectedIncentivePropertySchema = {
   financing_details: { type: 'string', nullable: true },
   editorial_notes: { type: 'string', nullable: true },
   questions: { type: 'string', nullable: true },
-  serve_in_api: { type: 'boolean', nullable: true },
+  omit_from_api: { type: 'boolean', nullable: true },
 } as const;
 const requiredCollectedFields = [
   'id',

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -31,6 +31,19 @@ test('array fields are split up', tap => {
   tap.end();
 });
 
+test('eligible boolean fields are converted', tap => {
+  const objs = [
+    {
+      basicProperty: 'foo',
+      booleanProperty: 'TRUE',
+    },
+  ];
+  tap.matchOnly(flatToNested(objs, [], ['booleanProperty']), [
+    { basicProperty: 'foo', booleanProperty: true },
+  ]);
+  tap.end();
+});
+
 test('nested columns properly expanded', tap => {
   const objs = [
     {
@@ -53,7 +66,7 @@ test('nested columns properly expanded', tap => {
   tap.end();
 });
 
-test('validation work', tap => {
+test('validation works', tap => {
   const fullInput = {
     id: 'VA-1',
     data_urls: 'https://takechargeva.com/programs/for-your-home',


### PR DESCRIPTION
I figured we'd need this eventually, but it seems like now is the time since:
1. PEP folks requested this so that when there are records in the spreadsheet that shouldn't appear in the JSON, they don't have to keep deleting the generated output from the spreadsheet-to-json flow.
2. Upcoming test/script will verify equivalence of spreadsheet and JSON data, so we do need a way to mark that some records can be skipped.

Design choices:
- it's omit_from_api rather than serve_in_api because serving should be the default
- we drop these records entirely now, though as a follow-up, I'll probably have them returned as a separate category so they can be properly accounted for.