### PR TITLE
[RFC] Add "utilities" list field to incentives

### DIFF
--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -1808,8 +1808,14 @@
   },
   {
     "id": "CO-81",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1830,8 +1836,14 @@
   },
   {
     "id": "CO-82",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1852,8 +1864,14 @@
   },
   {
     "id": "CO-83",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1874,8 +1892,14 @@
   },
   {
     "id": "CO-84",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1896,8 +1920,14 @@
   },
   {
     "id": "CO-85",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1918,8 +1948,14 @@
   },
   {
     "id": "CO-86",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1940,8 +1976,14 @@
   },
   {
     "id": "CO-87",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],
@@ -1961,8 +2003,14 @@
   },
   {
     "id": "CO-88",
-    "authority_type": "utility",
+    "authority_type": "state",
     "authority": "co-platte-river-power-authority",
+    "utilities": [
+      "co-estes-park-power-and-communications",
+      "co-fort-collins-utilities",
+      "co-longmont-power-and-communications",
+      "co-loveland-water-and-power"
+    ],
     "payment_methods": [
       "rebate"
     ],

--- a/data/authorities.json
+++ b/data/authorities.json
@@ -39,9 +39,6 @@
       "co-loveland-water-and-power": {
         "name": "Loveland Water and Power"
       },
-      "co-platte-river-power-authority": {
-        "name": "Platte River Power Authority"
-      },
       "co-empire-electric-association": {
         "name": "Empire Electric Association"
       },
@@ -151,6 +148,9 @@
       }
     },
     "state": {
+      "co-platte-river-power-authority": {
+        "name": "Platte River Power Authority"
+      },
       "co-energy-outreach-colorado": {
         "name": "Energy Outreach Colorado"
       },

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -164,3 +164,31 @@ curl \
 &tax_filing=joint\
 &household_size=4" \
   | jq . > test/fixtures/v1-15289-homeowner-80000-joint-4.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=80517\
+&include_beta_states=true\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=single\
+&household_size=1\
+&authority_types=state\
+&authority_types=utility\
+&items=heat_pump_water_heater\
+&utility=co-xcel-energy" \
+  | jq . > test/fixtures/v1-80517-xcel.json
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=80517\
+&include_beta_states=true\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=single\
+&household_size=1\
+&authority_types=state\
+&authority_types=utility\
+&items=heat_pump_water_heater\
+&utility=co-estes-park-power-and-communications" \
+  | jq . > test/fixtures/v1-80517-estes-park.json
+

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -126,6 +126,7 @@ export type DerivedFields = {
   agi_max_limit?: number;
   agi_min_limit?: number;
   authority: string;
+  utilities?: string[];
   program: string;
   bonus_available?: boolean;
   start_date: number;
@@ -137,6 +138,7 @@ const derivedIncentivePropertySchema = {
   agi_max_limit: { type: 'integer', nullable: true },
   agi_min_limit: { type: 'integer', nullable: true },
   authority: { type: 'string' },
+  utilities: { type: 'array', items: { type: 'string' }, nullable: true },
   program: { type: 'string', enum: ALL_PROGRAMS },
   bonus_available: { type: 'boolean', nullable: true },
   start_date: { type: 'number' },
@@ -185,6 +187,7 @@ const fieldOrder: {
   agi_min_limit: undefined,
   authority_type: undefined,
   authority: undefined,
+  utilities: undefined,
   payment_methods: undefined,
   item: undefined,
   program: undefined,

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -249,6 +249,15 @@ function skipBasedOnRequestParams(
     return true;
   }
 
+  if (
+    item.utilities &&
+    (!request.utility || !item.utilities.includes(request.utility))
+  ) {
+    // If the incentive requires you to be a customer of some set of utilities,
+    // fail if no utility was passed or it's not in the set.
+    return true;
+  }
+
   // County and City incentives are approximate and prone to
   // false positives, since zip codes to not map 1:1 to counties
   // and cities.

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -187,6 +187,9 @@ test('state incentives JSON files match schemas', async tap => {
           `must define city attribute on corresponding authority ${incentive.authority} for incentives with city authority type`,
         );
       }
+      incentive.utilities?.forEach(utility =>
+        tap.hasProp(authorities.utility, utility),
+      );
 
       // Allow duplicate incentive IDs if we split one incentive into multiple due
       // to tax filing status

--- a/test/data/utilities.test.ts
+++ b/test/data/utilities.test.ts
@@ -12,7 +12,6 @@ import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
 // be a customer of. That is, separate the concepts of "who offers this
 // incentive" from "which utilities must someone be a customer of to get this".
 const EXCEPTIONS = new Set([
-  'co-platte-river-power-authority',
   'co-tri-state-g-t',
   'co-walking-mountains',
   'vt-vppsa',

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -1,0 +1,132 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "co-estes-park-power-and-communications": {
+      "name": "Estes Park Power and Communications"
+    },
+    "co-platte-river-power-authority": {
+      "name": "Platte River Power Authority"
+    }
+  },
+  "coverage": {
+    "state": "CO",
+    "utility": "co-estes-park-power-and-communications"
+  },
+  "location": {
+    "state": "CO",
+    "city": "Estes Park",
+    "county": "Larimer"
+  },
+  "incentives": [
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "co-estes-park-power-and-communications",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 500,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$500 off a heat pump water heater UEF 3.0. Max rebate: $1000 per home."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "co-platte-river-power-authority",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 500,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$500 off a heat pump water heater UEF 3.0. Max rebate: $1000 per home."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "co-estes-park-power-and-communications",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 300,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$300 off a heat pump water heater UEF 2.0. Max rebate: $1000 per home."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "co-platte-river-power-authority",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 300,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$300 off a heat pump water heater UEF 2.0. Max rebate: $1000 per home."
+    }
+  ]
+}

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -1,0 +1,16 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {},
+  "coverage": {
+    "state": "CO",
+    "utility": "co-xcel-energy"
+  },
+  "location": {
+    "state": "CO",
+    "city": "Estes Park",
+    "county": "Larimer"
+  },
+  "incentives": []
+}

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -154,6 +154,45 @@ test('AZ low income response with state and utility filtering for UniSource is v
     './test/fixtures/v1-az-85702-state-utility-lowincome.json',
   );
 });
+
+// CO utility consortium tests
+test('CO incentive for PRPA shows up as intended', async t => {
+  await validateResponse(
+    t,
+    {
+      location: { zip: '80517' },
+      owner_status: 'homeowner',
+      household_size: 1,
+      household_income: 80000,
+      tax_filing: 'single',
+      authority_types: ['state', 'utility'],
+      items: ['heat_pump_water_heater'],
+      // Not in PRPA; incentives should not show up
+      utility: 'co-xcel-energy',
+      // TODO: Remove when CO is fully launched.
+      include_beta_states: true,
+    },
+    './test/fixtures/v1-80517-xcel.json',
+  );
+  await validateResponse(
+    t,
+    {
+      location: { zip: '80517' },
+      owner_status: 'homeowner',
+      household_size: 1,
+      household_income: 80000,
+      tax_filing: 'joint',
+      authority_types: ['state', 'utility'],
+      items: ['heat_pump_water_heater'],
+      // Is in PRPA; incentives should show up
+      utility: 'co-estes-park-power-and-communications',
+      // TODO: Remove when CO is fully launched.
+      include_beta_states: true,
+    },
+    './test/fixtures/v1-80517-estes-park.json',
+  );
+});
+
 // CT low income test
 test('CT low income response with state and utility filtering is valid and correct', async t => {
   await validateResponse(


### PR DESCRIPTION
I've been messing around with this for days, and it's time to just get
something out there and see what people think. This just does the
modification to the PRPA incentives in Colorado, since it was the
simplest and I'm not fully convinced by this approach.

I find this awkward in a few ways:

- I can't picture how the mapping from spreadsheet to JSON would work
  here. For spreadsheet purposes it seems most straightforward just to
  have "PRPA", but where in the spreadsheet-to-JSON process would this
  new field be introduced?

- It's duplicative in data; every incentive from one of these
  consortiums will have the same list of utilities. Not a huge
  problem, but still.

- It's duplicative in functionality; there'd now be two ways to
  specify an incentive that's offered to customers of a single
  utility.

- It doesn't cleanly extend to groups of counties (a thing that exists
  in NV, for example). Sure you could add an analogous `counties`
  field, but what would it mean for an incentive to have both a
  `counties` and a `utilities` field?

### Alternatives?

Alternative approaches to this all fall into the category of "define
authority groups somehow". That solves the duplicative-data problem,
but introduces all sorts of awkwardness in deciding how to represent
the groups.

- Is a group of authorities itself a kind of authority, or a distinct
  concept?

- Could a group include different kinds of authority, like some
  utilities and some counties? What would that even mean -- "one of
  these utilities AND one of these counties", or "one of these
  utilities OR one of these counties"?

I'm starting to form a thought on this that what's making things
difficult is the overlap of namespaces: utilities, cities, and
counties are each a namespace of their own, and an authority is its
own identity (name, logo) that can consist of one or more of the
above. That's just an awkward thing to represent.