### PR TITLE
Add "zip" and "address" top-level params

### DIFF
--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -46,7 +46,7 @@ export default async function (
   fastify: FastifyInstance & { sqlite: Database },
 ) {
   async function fetchAMIsForLocation(
-    location: APIRequestLocation,
+    location: Partial<APIRequestLocation>,
   ): Promise<IncomeInfo | null> {
     if (location.address) {
       // TODO: make sure bad addresses are handled here, and don't return anything
@@ -77,12 +77,16 @@ export default async function (
     { schema: API_CALCULATOR_SCHEMA },
     async (request, reply) => {
       const language = request.query.language ?? 'en';
-      const incomeInfo = await fetchAMIsForLocation(request.query.location);
+      const queryLocation = request.query.location ?? {
+        zip: request.query.zip,
+        address: request.query.address,
+      };
+      const incomeInfo = await fetchAMIsForLocation(queryLocation);
 
       if (!incomeInfo) {
         throw fastify.httpErrors.createError(
           404,
-          request.query.location.zip
+          queryLocation.zip
             ? t('errors', 'zip_code_doesnt_exist', language)
             : t('errors', 'cannot_locate_address', language),
           { field: 'location' },
@@ -125,13 +129,16 @@ export default async function (
     { schema: API_UTILITIES_SCHEMA },
     async (request, reply) => {
       const language = request.query.language ?? 'en';
-      const location = (await fetchAMIsForLocation(request.query.location))
-        ?.location;
+      const queryLocation = request.query.location ?? {
+        zip: request.query.zip,
+        address: request.query.address,
+      };
+      const location = (await fetchAMIsForLocation(queryLocation))?.location;
 
       if (!location) {
         throw fastify.httpErrors.createError(
           404,
-          request.query.location.zip
+          queryLocation.zip
             ? t('errors', 'zip_code_doesnt_exist', language)
             : t('errors', 'cannot_locate_address', language),
           {

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -14,7 +14,20 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
   title: 'APICalculatorRequest',
   type: 'object',
   properties: {
+    // TODO: remove location param once frontend is not using it
     location: API_REQUEST_LOCATION_SCHEMA,
+    zip: {
+      type: 'string',
+      description:
+        'Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.',
+      maxLength: 5,
+      minLength: 5,
+    },
+    address: {
+      type: 'string',
+      description:
+        "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
+    },
     authority_types: {
       type: 'array',
       description:
@@ -92,8 +105,12 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
     },
   },
   additionalProperties: false,
+  oneOf: [
+    { required: ['location'] },
+    { required: ['zip'] },
+    { required: ['address'] },
+  ],
   required: [
-    'location',
     'owner_status',
     'household_income',
     'tax_filing',

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -34,6 +34,7 @@ export const API_REQUEST_LOCATION_SCHEMA = {
   ],
   maxProperties: 1,
   minProperties: 1,
+  additionalProperties: false,
 } as const;
 
 /**

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -27,7 +27,20 @@ export const API_UTILITIES_SCHEMA = {
   querystring: {
     type: 'object',
     properties: {
+      // TODO remove location param once frontend is not using it
       location: API_REQUEST_LOCATION_SCHEMA,
+      zip: {
+        type: 'string',
+        description:
+          'Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.',
+        maxLength: 5,
+        minLength: 5,
+      },
+      address: {
+        type: 'string',
+        description:
+          "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
+      },
       language: {
         type: 'string',
         description: 'Optional choice of language for user-visible strings.',
@@ -44,7 +57,11 @@ export const API_UTILITIES_SCHEMA = {
         default: 'false',
       },
     },
-    required: ['location'],
+    oneOf: [
+      { required: ['location'] },
+      { required: ['zip'] },
+      { required: ['address'] },
+    ],
   },
   response: {
     200: {

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -66,6 +66,19 @@ test('response is valid and correct', async t => {
     },
     './test/fixtures/v1-80212-homeowner-80000-joint-4.json',
   );
+
+  // Same request but with location passed differently
+  await validateResponse(
+    t,
+    {
+      zip: '80212',
+      owner_status: 'homeowner',
+      household_income: 80000,
+      tax_filing: 'joint',
+      household_size: 4,
+    },
+    './test/fixtures/v1-80212-homeowner-80000-joint-4.json',
+  );
 });
 
 test('parent ZCTA is used', async t => {
@@ -252,13 +265,6 @@ test('VT low income response with state and utility filtering is valid and corre
 const BAD_QUERIES = [
   // bad location:
   {
-    owner_status: 'homeowner',
-    household_income: 80000,
-    tax_filing: 'joint',
-    household_size: 4,
-  },
-  {
-    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',


### PR DESCRIPTION
## Description

The `location` param being a key-value map makes it a little awkward
for some HTTP tooling. See https://rewiringameri-g3x1100.slack.com/archives/C04E4THEGMT/p1707244817589029

Instead, put the `zip` and `address` params at the top level. This PR
adds them and keeps `location` as-is, until we can switch over the
frontend, at which time we'll remove `location`. One of the three
params is required.

## Test Plan

`yarn test`. Tested the `address` param manually with:

`curl 'http://localhost:3000/api/v1/calculator?owner_status=homeowner&household_income=50000&tax_filing=single&household_size=1&address=82%20Smith%20St,Providence'`

and made sure RI-specific incentives show up.