### PR TITLE
Stop specifying individual fields in spreadsheet registry.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,8 +32,6 @@ Filling out an entry for `incentive-spreadsheet-registry.ts` consists of creatin
 - Exporting and sharing a sheet URL in `sheetUrl`
   - To do this for a Google sheet, click File -> Share -> Publish to web and under `Link`, select the Incentives data tab and change the `Web page` default to `Comma separated values (.csv)`. The link that appears is what should be copied into the value.
 - Optionally declaring the header row number, if not the top row of the spreadsheet, in `headerRowNumber`
-- Declaring what the name of the ID column is in `idHeader`
-- Recording the english and spanish program description column names, in `enHeader` and `esHeader`
 
 [`generate-misc-state-data.ts`](generate-misc-state-data.ts) adds values to ancillary files to reflect the programs and authorities that will be needed for the JSON. This needs to happen first because our data schemas actually require an incentive's program/authority to be one of the listed members, and if that's not the case, the incentive will fail validation.
 

--- a/scripts/incentive-spreadsheet-registry.ts
+++ b/scripts/incentive-spreadsheet-registry.ts
@@ -1,9 +1,6 @@
 export type IncentiveFile = {
   filepath: string;
   sheetUrl: string;
-  idHeader: string;
-  enHeader: string;
-  esHeader?: string;
   headerRowNumber?: number;
   runSpreadsheetHealthCheck?: boolean;
 };
@@ -13,26 +10,18 @@ export const FILES: { [ident: string]: IncentiveFile } = {
     filepath: 'data/ira_incentives.json',
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vTt1X34nGvUZu8Z71S-P9voD_zL6zvNapDJcL-RbH8SohQYAKOMN7ZeAA4Ti130PFAjei4uHImyV6dg/pub?gid=0&single=true&output=csv',
-    idHeader: 'ID',
-    enHeader: 'Short Description (150 characters max)',
-    esHeader: 'Short Description-Spanish',
   },
   AZ: {
     filepath: 'data/AZ/incentives.json',
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vQEGP5ZcMknLdHAqBAeCUtdkNPtS0CiFzQzoM4bdbLWYqC_30j1lHLeJhMSKElFRuwRdrgcd46Gl54j/pub?gid=995688950&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (style guide)',
   },
   CO: {
     filepath: 'data/CO/incentives.json',
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/1nITjSNRWJjSusB0fWuSS63fqynm_4Co7KEeuo9Cm7fU/pub?gid=30198531&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (guideline)',
-    esHeader: 'Program Description (Spanish)',
     runSpreadsheetHealthCheck: true,
   },
   CT: {
@@ -40,35 +29,24 @@ export const FILES: { [ident: string]: IncentiveFile } = {
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vRGd0l3oNXGgLOkM2DUtWGURg640oaurqyHkJ0vQDVXRWd8TDfoGGAEgAIEkPWXLuMEPGiWSOeUTcOY/pub?gid=995688950&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (guideline)',
-    esHeader: 'Program Description (Spanish)',
   },
   IL: {
     filepath: 'data/IL/incentives.json',
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vS2FQ0bImM65Gk0KFmDIhXZXCExrh605eWGscPXLPY5Kz_rQWG8KtyNJo82vYZMngTlSCCHfkYLFsUt/pub?gid=995688950&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (guideline)',
-    esHeader: 'Program Description (Spanish)',
   },
   NV: {
     filepath: 'data/NV/incentives.json',
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vTmxGiQVAxehqTk76ej-y5BwoqmnLiE7Cq_1QGnaGokKG3-EYlZIFoZEa3KAv7HK3xdN2AxvGggFLAK/pub?gid=995688950&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (guildeline)',
   },
   RI: {
     filepath: 'data/RI/incentives.json',
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vSoBQdIvYNb9fRkFggllmLZmz9nwL6SYxM7cdsiTPDU90C0HXtFh2r1qlYKdfbTzzxiPZ0o4NpOva__/pub?gid=30198531&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (style guide)',
-    esHeader: 'Program Description (Spanish)',
     runSpreadsheetHealthCheck: true,
   },
   VA: {
@@ -76,8 +54,5 @@ export const FILES: { [ident: string]: IncentiveFile } = {
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vSR3gOc40GeRzaYJwSn7MwKs7LQ2otHExlDWQb6AvfXHLzal-mt5b6IPGelDc6roSPgF-41GaU-L5Ae/pub?gid=995688950&single=true&output=csv',
     headerRowNumber: 2,
-    idHeader: 'ID',
-    enHeader: 'Program Description (guideline)',
-    esHeader: 'Program Description (Spanish)',
   },
 };


### PR DESCRIPTION
After https://github.com/rewiringamerica/api.rewiringamerica.org/pull/319, these fields are basically not used, and we should be configuring any renaming in one place (spreadsheet-mappings).

I suspect this script is not long for this world anyway, since spreadsheet-to-json is a more comprehensive way to update spreadsheet files, but we can keep it for now in case someone wants to only run the Spanish translation updates.