### PR TITLE
[RFC] Add concept of "geo groups"

### DIFF
--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -1808,8 +1808,9 @@
   },
   {
     "id": "CO-81",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1830,8 +1831,9 @@
   },
   {
     "id": "CO-82",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1852,8 +1854,9 @@
   },
   {
     "id": "CO-83",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1874,8 +1877,9 @@
   },
   {
     "id": "CO-84",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1896,8 +1900,9 @@
   },
   {
     "id": "CO-85",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1918,8 +1923,9 @@
   },
   {
     "id": "CO-86",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1940,8 +1946,9 @@
   },
   {
     "id": "CO-87",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1961,8 +1968,9 @@
   },
   {
     "id": "CO-88",
-    "authority_type": "utility",
+    "authority_type": "other",
     "authority": "co-platte-river-power-authority",
+    "geo_group": "co-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -1810,7 +1810,7 @@
     "id": "CO-81",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1833,7 +1833,7 @@
     "id": "CO-82",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1856,7 +1856,7 @@
     "id": "CO-83",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1879,7 +1879,7 @@
     "id": "CO-84",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1902,7 +1902,7 @@
     "id": "CO-85",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1925,7 +1925,7 @@
     "id": "CO-86",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1948,7 +1948,7 @@
     "id": "CO-87",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1970,7 +1970,7 @@
     "id": "CO-88",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_eligibility_group": "co-group-platte-river-power-authority",
+    "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -1810,7 +1810,7 @@
     "id": "CO-81",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1833,7 +1833,7 @@
     "id": "CO-82",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1856,7 +1856,7 @@
     "id": "CO-83",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1879,7 +1879,7 @@
     "id": "CO-84",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1902,7 +1902,7 @@
     "id": "CO-85",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1925,7 +1925,7 @@
     "id": "CO-86",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1948,7 +1948,7 @@
     "id": "CO-87",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],
@@ -1970,7 +1970,7 @@
     "id": "CO-88",
     "authority_type": "other",
     "authority": "co-platte-river-power-authority",
-    "geo_group": "co-platte-river-power-authority",
+    "geo_eligibility_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
     ],

--- a/data/authorities.json
+++ b/data/authorities.json
@@ -39,9 +39,6 @@
       "co-loveland-water-and-power": {
         "name": "Loveland Water and Power"
       },
-      "co-platte-river-power-authority": {
-        "name": "Platte River Power Authority"
-      },
       "co-empire-electric-association": {
         "name": "Empire Electric Association"
       },
@@ -159,6 +156,11 @@
       },
       "co-state-of-colorado": {
         "name": "State of Colorado"
+      }
+    },
+    "other": {
+      "co-platte-river-power-authority": {
+        "name": "Platte River Power Authority"
       }
     }
   },

--- a/data/geo_groups.json
+++ b/data/geo_groups.json
@@ -1,6 +1,6 @@
 {
   "CO": {
-    "co-platte-river-power-authority": {
+    "co-group-platte-river-power-authority": {
       "utilities": [
         "co-estes-park-power-and-communications",
         "co-fort-collins-utilities",

--- a/data/geo_groups.json
+++ b/data/geo_groups.json
@@ -1,0 +1,12 @@
+{
+  "CO": {
+    "co-platte-river-power-authority": {
+      "utilities": [
+        "co-estes-park-power-and-communications",
+        "co-fort-collins-utilities",
+        "co-longmont-power-and-communications",
+        "co-loveland-water-and-power"
+      ]
+    }
+  }
+}

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -9,6 +9,7 @@ export const FIELD_MAPPINGS: AliasMap = {
   data_urls: ['Data Source URL(s)'],
   authority_type: ['Authority Level *'],
   authority_name: ['Authority (Name) *'],
+  geo_eligibility: ['Geographic Eligibility'],
   program_title: ['Program Title *'],
   program_url: ['Program URL'],
   item: ['Technology *'],

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -206,6 +206,7 @@ curl \
 &items=heat_pump_water_heater\
 &utility=co-xcel-energy" \
   | jq . > test/fixtures/v1-80517-xcel.json
+
 curl \
   "http://localhost:3000/api/v1/calculator\
 ?location\[zip\]=80517\

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -178,6 +178,7 @@ curl \
 &household_size=4" \
   | jq . > test/fixtures/v1-15289-homeowner-80000-joint-4.json
 
+
 # TODO: Remove beta states argument when DC is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
@@ -190,3 +191,32 @@ curl \
 &authority_types=state\
 &authority_types=city" \
   | jq . > test/fixtures/v1-dc-20303-state-city-lowincome.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=80517\
+&include_beta_states=true\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=single\
+&household_size=1\
+&authority_types=state\
+&authority_types=utility\
+&authority_types=other\
+&items=heat_pump_water_heater\
+&utility=co-xcel-energy" \
+  | jq . > test/fixtures/v1-80517-xcel.json
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?location\[zip\]=80517\
+&include_beta_states=true\
+&owner_status=homeowner\
+&household_income=80000\
+&tax_filing=single\
+&household_size=1\
+&authority_types=state\
+&authority_types=utility\
+&authority_types=other\
+&items=heat_pump_water_heater\
+&utility=co-estes-park-power-and-communications" \
+  | jq . > test/fixtures/v1-80517-estes-park.json

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -23,6 +23,7 @@ export enum AuthorityType {
   County = 'county',
   State = 'state',
   Utility = 'utility',
+  Other = 'other',
 }
 
 export const API_AUTHORITY_SCHEMA = {
@@ -60,6 +61,7 @@ export const SCHEMA = {
       utility: authoritiesMapSchema,
       city: authoritiesMapSchema,
       county: authoritiesMapSchema,
+      other: authoritiesMapSchema,
     },
     required: ['state', 'utility'],
     additionalProperties: false,

--- a/src/data/geo_groups.ts
+++ b/src/data/geo_groups.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import { FromSchema } from 'json-schema-to-ts';
+import { STATES_PLUS_DC } from './types/states';
+
+const GEO_GROUP_SCHEMA = {
+  type: 'object',
+  properties: {
+    utilities: { type: 'array', items: { type: 'string' }, minItems: 1 },
+    cities: { type: 'array', items: { type: 'string' }, minItems: 1 },
+    counties: { type: 'array', items: { type: 'string' }, minItems: 1 },
+  },
+  additionalProperties: false,
+  anyOf: [
+    { required: ['utilities'] },
+    { required: ['cities'] },
+    { required: ['counties'] },
+  ],
+} as const;
+
+export type GeoGroup = FromSchema<typeof GEO_GROUP_SCHEMA>;
+
+export const GEO_GROUPS_SCHEMA = {
+  type: 'object',
+  propertyNames: {
+    type: 'string',
+    enum: STATES_PLUS_DC,
+  },
+  additionalProperties: {
+    type: 'object',
+    additionalProperties: GEO_GROUP_SCHEMA,
+    required: [],
+  },
+  required: [],
+} as const;
+
+export type GeoGroupsByState = FromSchema<typeof GEO_GROUPS_SCHEMA>;
+
+export const GEO_GROUPS_BY_STATE: GeoGroupsByState = JSON.parse(
+  fs.readFileSync('./data/geo_groups.json', 'utf-8'),
+);

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -63,6 +63,7 @@ const collectedIncentivePropertySchema = {
   data_urls: { type: 'array', items: { type: 'string' } },
   authority_type: { type: 'string', enum: Object.values(AuthorityType) },
   authority_name: { type: 'string' },
+  geo_eligibility: { type: 'string', nullable: true },
   program_title: { type: 'string' },
   program_url: { type: 'string' },
   item: { type: 'string', enum: ALL_ITEMS },
@@ -126,7 +127,7 @@ export type DerivedFields = {
   agi_max_limit?: number;
   agi_min_limit?: number;
   authority: string;
-  geo_group?: string;
+  geo_eligibility_group?: string;
   program: string;
   bonus_available?: boolean;
   start_date: number;
@@ -138,7 +139,7 @@ const derivedIncentivePropertySchema = {
   agi_max_limit: { type: 'integer', nullable: true },
   agi_min_limit: { type: 'integer', nullable: true },
   authority: { type: 'string' },
-  geo_group: { type: 'string', nullable: true },
+  geo_eligibility_group: { type: 'string', nullable: true },
   program: { type: 'string', enum: ALL_PROGRAMS },
   bonus_available: { type: 'boolean', nullable: true },
   start_date: { type: 'number' },
@@ -187,7 +188,7 @@ const fieldOrder: {
   agi_min_limit: undefined,
   authority_type: undefined,
   authority: undefined,
-  geo_group: undefined,
+  geo_eligibility_group: undefined,
   payment_methods: undefined,
   item: undefined,
   program: undefined,

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -126,6 +126,7 @@ export type DerivedFields = {
   agi_max_limit?: number;
   agi_min_limit?: number;
   authority: string;
+  geo_group?: string;
   program: string;
   bonus_available?: boolean;
   start_date: number;
@@ -137,6 +138,7 @@ const derivedIncentivePropertySchema = {
   agi_max_limit: { type: 'integer', nullable: true },
   agi_min_limit: { type: 'integer', nullable: true },
   authority: { type: 'string' },
+  geo_group: { type: 'string', nullable: true },
   program: { type: 'string', enum: ALL_PROGRAMS },
   bonus_available: { type: 'boolean', nullable: true },
   start_date: { type: 'number' },
@@ -185,6 +187,7 @@ const fieldOrder: {
   agi_min_limit: undefined,
   authority_type: undefined,
   authority: undefined,
+  geo_group: undefined,
   payment_methods: undefined,
   item: undefined,
   program: undefined,

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -127,7 +127,7 @@ export type DerivedFields = {
   agi_max_limit?: number;
   agi_min_limit?: number;
   authority: string;
-  geo_eligibility_group?: string;
+  eligible_geo_group?: string;
   program: string;
   bonus_available?: boolean;
   start_date: number;
@@ -139,7 +139,7 @@ const derivedIncentivePropertySchema = {
   agi_max_limit: { type: 'integer', nullable: true },
   agi_min_limit: { type: 'integer', nullable: true },
   authority: { type: 'string' },
-  geo_eligibility_group: { type: 'string', nullable: true },
+  eligible_geo_group: { type: 'string', nullable: true },
   program: { type: 'string', enum: ALL_PROGRAMS },
   bonus_available: { type: 'boolean', nullable: true },
   start_date: { type: 'number' },
@@ -188,7 +188,7 @@ const fieldOrder: {
   agi_min_limit: undefined,
   authority_type: undefined,
   authority: undefined,
-  geo_eligibility_group: undefined,
+  eligible_geo_group: undefined,
   payment_methods: undefined,
   item: undefined,
   program: undefined,

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -381,13 +381,9 @@ export default function calculateIncentives(
   const authorities: AuthoritiesById = {};
   if (stateAuthorities) {
     incentives.forEach(i => {
-      if (
-        'authority' in i &&
-        i.authority &&
-        (i.authority_type === 'state' || i.authority_type === 'utility')
-      ) {
+      if ('authority' in i && i.authority && i.authority_type !== 'federal') {
         authorities[i.authority] =
-          stateAuthorities[i.authority_type][i.authority];
+          stateAuthorities[i.authority_type]![i.authority];
       }
     });
   }

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -1,5 +1,6 @@
 import { min } from 'lodash';
 import { AuthoritiesByType, AuthorityType } from '../data/authorities';
+import { GEO_GROUPS_BY_STATE } from '../data/geo_groups';
 import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../data/low_income_thresholds';
 import {
   INCENTIVE_RELATIONSHIPS_BY_STATE,
@@ -284,5 +285,29 @@ function skipBasedOnRequestParams(
       return true;
     }
   }
+
+  if (item.geo_group) {
+    // A test ensures that geo groups are registered.
+    const group = GEO_GROUPS_BY_STATE[location.state_id]![item.geo_group];
+
+    // The request params must match ALL of the keys the geo group defines
+    if (
+      (group.utilities &&
+        (!request.utility || !group.utilities.includes(request.utility))) ||
+      (group.counties &&
+        (!location.county ||
+          !group.counties
+            .map(id => stateAuthorities.county[id].county)
+            .includes(location.county))) ||
+      (group.cities &&
+        (!location.city ||
+          !group.cities
+            .map(id => stateAuthorities.city[id].city)
+            .includes(location.city)))
+    ) {
+      return true;
+    }
+  }
+
   return false;
 }

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -286,10 +286,10 @@ function skipBasedOnRequestParams(
     }
   }
 
-  if (item.geo_eligibility_group) {
+  if (item.eligible_geo_group) {
     // A test ensures that geo groups are registered.
     const group =
-      GEO_GROUPS_BY_STATE[location.state_id]![item.geo_eligibility_group];
+      GEO_GROUPS_BY_STATE[location.state_id]![item.eligible_geo_group];
 
     // The request params must match ALL of the keys the geo group defines
     if (

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -286,9 +286,10 @@ function skipBasedOnRequestParams(
     }
   }
 
-  if (item.geo_group) {
+  if (item.geo_eligibility_group) {
     // A test ensures that geo groups are registered.
-    const group = GEO_GROUPS_BY_STATE[location.state_id]![item.geo_group];
+    const group =
+      GEO_GROUPS_BY_STATE[location.state_id]![item.geo_eligibility_group];
 
     // The request params must match ALL of the keys the geo group defines
     if (

--- a/test/data/geo_groups.test.ts
+++ b/test/data/geo_groups.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'tap';
+import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
+import { GEO_GROUPS_BY_STATE } from '../../src/data/geo_groups';
+
+test('geo groups refer to valid authorities', async t => {
+  Object.entries(GEO_GROUPS_BY_STATE).forEach(([state, groups]) => {
+    const authorities = AUTHORITIES_BY_STATE[state];
+
+    Object.values(groups).forEach(group => {
+      group.utilities?.forEach(utility =>
+        t.hasProp(authorities.utility, utility),
+      );
+      group.counties?.forEach(
+        county =>
+          t.ok(authorities.county) && t.hasProp(authorities.county!, county),
+      );
+      group.cities?.forEach(
+        city => t.ok(authorities.city) && t.hasProp(authorities.city!, city),
+      );
+    });
+  });
+});

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -144,6 +144,7 @@ test('state incentives JSON files match schemas', async tap => {
 
   STATE_INCENTIVE_TESTS.forEach(([stateId, schema, data]) => {
     const authorities = AUTHORITIES_BY_STATE[stateId as string];
+    const stateGeoGroups = GEO_GROUPS_BY_STATE[stateId];
 
     if (!tap.ok(ajv.validate(schema, data), `${stateId} incentives invalid`)) {
       console.error(ajv.errors);
@@ -198,19 +199,23 @@ test('state incentives JSON files match schemas', async tap => {
           `must define city attribute on corresponding authority ${incentive.authority} for incentives with city authority type`,
         );
       }
+
       if (incentive.authority_type === AuthorityType.Other) {
         tap.hasProp(
           incentive,
-          'geo_group',
+          'geo_eligibility_group',
           `authority_type 'other' must include a geo group (id ${incentive.id})`,
         );
 
-        const stateGroups = GEO_GROUPS_BY_STATE[stateId];
-        tap.equal(incentive.authority_type, AuthorityType.Other);
         tap.hasProp(
-          stateGroups,
-          incentive.geo_group!,
+          stateGeoGroups,
+          incentive.geo_eligibility_group!,
           `nonexistent geo_group (${stateId}, id ${incentive.id})`,
+        );
+      } else {
+        tap.notOk(
+          incentive.geo_eligibility_group,
+          `only authority_type 'other' can have a geo group (id ${incentive.id})`,
         );
       }
 

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -55,6 +55,10 @@ import { TAX_BRACKETS, SCHEMA as TB_SCHEMA } from '../../src/data/tax_brackets';
 import Ajv from 'ajv/dist/2020';
 import { SomeJSONSchema } from 'ajv/dist/types/json-schema';
 import {
+  GEO_GROUPS_BY_STATE,
+  GEO_GROUPS_SCHEMA,
+} from '../../src/data/geo_groups';
+import {
   ALL_PROGRAMS,
   PROGRAMS,
   PROGRAMS_SCHEMA,
@@ -82,6 +86,7 @@ const TESTS = [
     LOW_INCOME_THRESHOLDS_BY_AUTHORITY,
     'State low income',
   ],
+  [GEO_GROUPS_SCHEMA, GEO_GROUPS_BY_STATE, 'geo_groups'],
 ];
 
 test('static JSON files match schema', async tap => {
@@ -191,6 +196,21 @@ test('state incentives JSON files match schemas', async tap => {
           authorities[incentive.authority_type]![incentive.authority],
           'city',
           `must define city attribute on corresponding authority ${incentive.authority} for incentives with city authority type`,
+        );
+      }
+      if (incentive.authority_type === AuthorityType.Other) {
+        tap.hasProp(
+          incentive,
+          'geo_group',
+          `authority_type 'other' must include a geo group (id ${incentive.id})`,
+        );
+
+        const stateGroups = GEO_GROUPS_BY_STATE[stateId];
+        tap.equal(incentive.authority_type, AuthorityType.Other);
+        tap.hasProp(
+          stateGroups,
+          incentive.geo_group!,
+          `nonexistent geo_group (${stateId}, id ${incentive.id})`,
         );
       }
 

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -203,18 +203,18 @@ test('state incentives JSON files match schemas', async tap => {
       if (incentive.authority_type === AuthorityType.Other) {
         tap.hasProp(
           incentive,
-          'geo_eligibility_group',
+          'eligible_geo_group',
           `authority_type 'other' must include a geo group (id ${incentive.id})`,
         );
 
         tap.hasProp(
           stateGeoGroups,
-          incentive.geo_eligibility_group!,
+          incentive.eligible_geo_group!,
           `nonexistent geo_group (${stateId}, id ${incentive.id})`,
         );
       } else {
         tap.notOk(
-          incentive.geo_eligibility_group,
+          incentive.eligible_geo_group,
           `only authority_type 'other' can have a geo group (id ${incentive.id})`,
         );
       }

--- a/test/data/utilities.test.ts
+++ b/test/data/utilities.test.ts
@@ -12,7 +12,6 @@ import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
 // be a customer of. That is, separate the concepts of "who offers this
 // incentive" from "which utilities must someone be a customer of to get this".
 const EXCEPTIONS = new Set([
-  'co-platte-river-power-authority',
   'co-tri-state-g-and-t',
   'co-walking-mountains',
   'vt-vppsa',

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -1,0 +1,132 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "co-estes-park-power-and-communications": {
+      "name": "Estes Park Power and Communications"
+    },
+    "co-platte-river-power-authority": {
+      "name": "Platte River Power Authority"
+    }
+  },
+  "coverage": {
+    "state": "CO",
+    "utility": "co-estes-park-power-and-communications"
+  },
+  "location": {
+    "state": "CO",
+    "city": "Estes Park",
+    "county": "Larimer"
+  },
+  "incentives": [
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "co-estes-park-power-and-communications",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 500,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$500 off a heat pump water heater UEF 3.0. Max rebate: $1000 per home."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "other",
+      "authority": "co-platte-river-power-authority",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 500,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$500 off a heat pump water heater UEF 3.0. Max rebate: $1000 per home."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "co-estes-park-power-and-communications",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 300,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$300 off a heat pump water heater UEF 2.0. Max rebate: $1000 per home."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "other",
+      "authority": "co-platte-river-power-authority",
+      "program": "Efficiency Works",
+      "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
+      "item": {
+        "type": "heat_pump_water_heater",
+        "name": "Heat Pump Water Heater",
+        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 300,
+        "maximum": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": 2023,
+      "end_date": 2024,
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$300 off a heat pump water heater UEF 2.0. Max rebate: $1000 per home."
+    }
+  ]
+}

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -1,0 +1,16 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {},
+  "coverage": {
+    "state": "CO",
+    "utility": "co-xcel-energy"
+  },
+  "location": {
+    "state": "CO",
+    "city": "Estes Park",
+    "county": "Larimer"
+  },
+  "incentives": []
+}

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -5,6 +5,11 @@
   "authorities": {
     "dc-dc-department-of-energy-and-environment": {
       "name": "DC Department of Energy and Environment"
+    },
+    "dc-dc-sustainable-energy-utility": {
+      "name": "DC Sustainable Energy Utility",
+      "city": "Washington",
+      "county": "District of Columbia"
     }
   },
   "coverage": {

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -174,6 +174,44 @@ test('CO low income response with state and utility filtering is valid and corre
   );
 });
 
+// CO utility consortium tests
+test('CO incentive for PRPA shows up as intended', async t => {
+  await validateResponse(
+    t,
+    {
+      location: { zip: '80517' },
+      owner_status: 'homeowner',
+      household_size: 1,
+      household_income: 80000,
+      tax_filing: 'single',
+      authority_types: ['state', 'utility', 'other'],
+      items: ['heat_pump_water_heater'],
+      // Not in PRPA; incentives should not show up
+      utility: 'co-xcel-energy',
+      // TODO: Remove when CO is fully launched.
+      include_beta_states: true,
+    },
+    './test/fixtures/v1-80517-xcel.json',
+  );
+  await validateResponse(
+    t,
+    {
+      location: { zip: '80517' },
+      owner_status: 'homeowner',
+      household_size: 1,
+      household_income: 80000,
+      tax_filing: 'joint',
+      authority_types: ['state', 'utility', 'other'],
+      items: ['heat_pump_water_heater'],
+      // Is in PRPA; incentives should show up
+      utility: 'co-estes-park-power-and-communications',
+      // TODO: Remove when CO is fully launched.
+      include_beta_states: true,
+    },
+    './test/fixtures/v1-80517-estes-park.json',
+  );
+});
+
 // CT low income test
 test('CT low income response with state and utility filtering is valid and correct', async t => {
   await validateResponse(


### PR DESCRIPTION
This is where I got to following the comments on #322.

- There's a new concept that I'm calling "geo groups" (open to
  bikeshedding). Each one can contain a set of cities, a set of
  counties, and a set of utilities (in the form of their IDs from
  authorities.json).

  Geo groups are defined in a new file, `data/geo_groups.json`. I
  considered defining them in authorities.json, but I think it's
  better to clearly separate the concept of authority from geographic
  eligibility; that was part of the whole point of this, and I kind of
  lost sight of it before. A geo group is not an authority (although
  in practice there's probably very significant overlap); it's just a
  set of utilities/cities/counties.

  One potentially confusing thing is that geo group IDs are a totally
  separate namespace from all the authority namespaces. The fact that
  the authority ID and geo group ID are both `co-platte-river-power-authority`
  here is incidental. In fact, maybe they should be intentionally made
  different somehow, to emphasize that?

- There's a new authority type I'm calling `other`. It's meant for
  types of authority that don't have an inherent geographic
  restriction, which all the others do. Incentives with this authority
  type must have a `geo_group` key that references a geo group.

- When an incentive is of type `other`, its geo group is checked to
  make sure that the request params match each component. The
  request's `utility` must match one of the geo group's `utilities`
  items, etc.

  That means the combining semantic, for a geo group that defines more
  than one set of authorities, is "AND". If you need "OR" semantics
  (e.g. one of these utilities OR one of these counties), create two
  geo groups (one with only utilities and one with only counties),
  duplicate the incentive (one referring to each of the two geo
  groups), and add a mutual exclusion between the two copies of the
  incentive. (I have no idea if this will ever come up, but it's
  handled by this scheme.)

- The common cases (a utility offers an incentive to its customers, a
  city or county offers an incentive to its residents) are unchanged.

I think this will fit cleanly into the existing spreadsheet-to-JSON
process of defining authorities, though I'm not 100% sure. Certainly
it's more likely to do so than my first attempt was.