### PR TITLE
Fix Fastify deprecation warning

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -50,7 +50,7 @@ export default async function (
   // Equivalent to Fastify's default request-end logging
   fastify.addHook('onResponse', (req, reply, done) => {
     req.log.info(
-      { res: reply, responseTime: reply.getResponseTime() },
+      { res: reply, responseTime: reply.elapsedTime },
       'request completed',
     );
     done();


### PR DESCRIPTION
## Description

This started when I upgraded fastify-cli. Switch to the new API that
the error message says.

## Test Plan

`yarn test` no longer shows the error. Run `yarn dev` and watch the
logs as you make a curl request; make sure the "request completed"
message includes a sensible responseTime (in milliseconds).