### PR TITLE
Add new update programs method now that programs.json is consolidated.

### DIFF
--- a/scripts/generate-misc-state-data.ts
+++ b/scripts/generate-misc-state-data.ts
@@ -13,9 +13,9 @@ async function generate(state: string, file: IncentiveFile) {
     from_line: file.headerRowNumber ?? 1,
   });
 
-  // For now this is always on since we need to ID this columns
-  // accurately to do the rest of the work.
-  const strict_mode = true;
+  // strict_mode can be false since it's more error-tolerant, and we'll fail
+  // if we don't have the right columns anyway.
+  const strict_mode = false;
   const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
     {},
@@ -28,8 +28,7 @@ async function generate(state: string, file: IncentiveFile) {
     authorityProgramManager.addRow(standardized);
   });
 
-  authorityProgramManager.updateProgramsTs();
-  authorityProgramManager.updateProgramJson();
+  authorityProgramManager.updatePrograms();
   authorityProgramManager.updateAuthoritiesJson();
 }
 


### PR DESCRIPTION
This is admittedly a bunch of string-hacking, but I don't see a better way to do it, aside from giving up on this step being automated – which is not out of the question since it's not run as often as the actual incentive-spreadsheet-to-json script. Still, I think we might as well give it a shot.

Testing: added a bunch of unit tests, and ran on CO and AZ to ensure that we saw no diffs.