### PR TITLE
Support for data partners with logos

### DIFF
--- a/data/data_partners.json
+++ b/data/data_partners.json
@@ -1,0 +1,12 @@
+{
+  "NV": {
+    "nv-nevada-clean-energy-fund": {
+      "name": "Nevada Clean Energy Fund",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/nv-nevada-clean-energy-fund.png",
+        "width": 300,
+        "height": 200
+      }
+    }
+  }
+}

--- a/src/data/data_partners.ts
+++ b/src/data/data_partners.ts
@@ -8,7 +8,7 @@ import { STATES_PLUS_DC } from './types/states';
  * and review the state's incentive data, but they don't offer incentives
  * directly. We include them to give them credit for their work and to demonstrate
  * their endorsement of the incentives calculator.
- * 
+ *
  * Some organizations are both data partners who have helped gather incentives
  * and authorities that offer incentives. These organizations should
  * represented as authorities in the code.
@@ -23,7 +23,6 @@ export const API_DATA_PARTNER_SCHEMA = {
   required: ['name'],
   additionalProperties: false,
 } as const;
-
 
 const dataPartnerMapSchema = {
   type: 'object',

--- a/src/data/data_partners.ts
+++ b/src/data/data_partners.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import { FromSchema } from 'json-schema-to-ts';
+import { API_IMAGE_SCHEMA } from '../schemas/v1/image';
+import { STATES_PLUS_DC } from './types/states';
+
+/**
+ * A data partner is a partner organization that has helped gather
+ * and review the state's incentive data, but they don't offer incentives
+ * directly. We include them to give them credit for their work and to demonstrate
+ * their endorsement of the incentives calculator.
+ * 
+ * Some organizations are both data partners who have helped gather incentives
+ * and authorities that offer incentives. These organizations should
+ * represented as authorities in the code.
+ */
+
+export const API_DATA_PARTNER_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    logo: API_IMAGE_SCHEMA,
+  },
+  required: ['name'],
+  additionalProperties: false,
+} as const;
+
+
+const dataPartnerMapSchema = {
+  type: 'object',
+  additionalProperties: API_DATA_PARTNER_SCHEMA,
+  required: [],
+} as const;
+
+export type DataPartnersType = FromSchema<typeof dataPartnerMapSchema>;
+
+export const SCHEMA = {
+  type: 'object',
+  propertyNames: {
+    type: 'string',
+    enum: STATES_PLUS_DC,
+  },
+  additionalProperties: dataPartnerMapSchema,
+  required: [],
+} as const;
+
+export type DataPartnersByState = FromSchema<typeof SCHEMA>;
+
+export const DATA_PARTNERS_BY_STATE: DataPartnersByState = JSON.parse(
+  fs.readFileSync('./data/data_partners.json', 'utf-8'),
+);

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -4,6 +4,7 @@ import {
   AuthoritiesById,
   AuthorityType,
 } from '../data/authorities';
+import { DataPartnersType } from '../data/data_partners';
 import { IRAIncentive, IRA_INCENTIVES } from '../data/ira_incentives';
 import { SOLAR_PRICES } from '../data/solar_prices';
 import { StateIncentive } from '../data/state_incentives';
@@ -26,7 +27,6 @@ import {
   getStateIncentiveRelationships,
 } from './state-incentives-calculation';
 import estimateTaxAmount from './tax-brackets';
-import { DataPartnersType } from '../data/data_partners';
 
 const MAX_POS_SAVINGS = 14000;
 const OWNER_STATUSES = new Set(Object.values(OwnerStatus));
@@ -390,7 +390,10 @@ export default function calculateIncentives(
     });
   }
 
-  const data_partners: DataPartnersType = getStateDataPartners(state_id, request);
+  const data_partners: DataPartnersType = getStateDataPartners(
+    state_id,
+    request,
+  );
 
   return {
     is_under_80_ami: isUnder80Ami,

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -22,9 +22,11 @@ import { AMI, CompleteIncomeInfo, GeoInfo, MFI } from './income-info';
 import {
   calculateStateIncentivesAndSavings,
   getAllStateIncentives,
+  getStateDataPartners,
   getStateIncentiveRelationships,
 } from './state-incentives-calculation';
 import estimateTaxAmount from './tax-brackets';
+import { DataPartnersType } from '../data/data_partners';
 
 const MAX_POS_SAVINGS = 14000;
 const OWNER_STATUSES = new Set(Object.values(OwnerStatus));
@@ -388,12 +390,15 @@ export default function calculateIncentives(
     });
   }
 
+  const data_partners: DataPartnersType = getStateDataPartners(state_id, request);
+
   return {
     is_under_80_ami: isUnder80Ami,
     is_under_150_ami: isUnder150Ami,
     is_over_150_ami: isOver150Ami,
     authorities,
     coverage,
+    data_partners,
     location: {
       state: state_id,
       city: location.city,

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -10,6 +10,7 @@ import {
   STATE_INCENTIVES_BY_STATE,
   StateIncentive,
 } from '../data/state_incentives';
+import { DATA_PARTNERS_BY_STATE } from '../data/data_partners';
 import { AmountType } from '../data/types/amount';
 import { APICoverage } from '../data/types/coverage';
 import { OwnerStatus } from '../data/types/owner-status';
@@ -44,6 +45,14 @@ export function getAllStateIncentives(
 
 export function getStateIncentiveRelationships(stateId: string) {
   return INCENTIVE_RELATIONSHIPS_BY_STATE[stateId] ?? {};
+}
+
+export function getStateDataPartners(stateId: string, request: CalculateParams,) {
+  // Only process state data partners for launched states, or beta states if beta was requested.
+  if (!isStateIncluded(stateId, request.include_beta_states ?? false)) {
+    return {};
+  }
+  return DATA_PARTNERS_BY_STATE[stateId] || {};
 }
 
 export function calculateStateIncentivesAndSavings(

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -1,5 +1,6 @@
 import { min } from 'lodash';
 import { AuthoritiesByType, AuthorityType } from '../data/authorities';
+import { DATA_PARTNERS_BY_STATE } from '../data/data_partners';
 import { GEO_GROUPS_BY_STATE } from '../data/geo_groups';
 import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../data/low_income_thresholds';
 import {
@@ -10,7 +11,6 @@ import {
   STATE_INCENTIVES_BY_STATE,
   StateIncentive,
 } from '../data/state_incentives';
-import { DATA_PARTNERS_BY_STATE } from '../data/data_partners';
 import { AmountType } from '../data/types/amount';
 import { APICoverage } from '../data/types/coverage';
 import { OwnerStatus } from '../data/types/owner-status';
@@ -47,7 +47,10 @@ export function getStateIncentiveRelationships(stateId: string) {
   return INCENTIVE_RELATIONSHIPS_BY_STATE[stateId] ?? {};
 }
 
-export function getStateDataPartners(stateId: string, request: CalculateParams,) {
+export function getStateDataPartners(
+  stateId: string,
+  request: CalculateParams,
+) {
   // Only process state data partners for launched states, or beta states if beta was requested.
   if (!isStateIncluded(stateId, request.include_beta_states ?? false)) {
     return {};

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -1,5 +1,6 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { API_AUTHORITY_SCHEMA, AuthorityType } from '../../data/authorities';
+import { API_DATA_PARTNER_SCHEMA } from '../../data/data_partners';
 import { FilingStatus } from '../../data/tax_brackets';
 import { API_COVERAGE_SCHEMA } from '../../data/types/coverage';
 import { ALL_ITEMS } from '../../data/types/items';
@@ -146,6 +147,10 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
     },
     coverage: API_COVERAGE_SCHEMA,
     location: API_RESPONSE_LOCATION_SCHEMA,
+    data_partners: {
+      type: 'object',
+      additionalProperties: API_DATA_PARTNER_SCHEMA,
+    },
     incentives: {
       type: 'array',
       items: { $ref: 'APIIncentive' },

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -16,6 +16,7 @@
     "city": "Oak Park",
     "county": "Cook"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -21,6 +21,7 @@
     "city": "Block Island",
     "county": "Washington"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -35,6 +35,7 @@
     "city": "Providence",
     "county": "Providence"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -12,6 +12,7 @@
     "city": "Pittsburgh",
     "county": "Allegheny"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -12,6 +12,7 @@
     "city": "Denver",
     "county": "Denver"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -19,6 +19,7 @@
     "city": "Estes Park",
     "county": "Larimer"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -12,5 +12,6 @@
     "city": "Estes Park",
     "county": "Larimer"
   },
+  "data_partners": {},
   "incentives": []
 }

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -16,6 +16,7 @@
     "city": "Tucson",
     "county": "Pima"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -16,6 +16,7 @@
     "city": "Tucson",
     "county": "Pima"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -28,6 +28,7 @@
     "city": "Vail",
     "county": "Eagle"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -19,6 +19,7 @@
     "city": "Bloomfield",
     "county": "Hartford"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -3,13 +3,13 @@
   "is_under_150_ami": true,
   "is_over_150_ami": false,
   "authorities": {
-    "dc-dc-department-of-energy-and-environment": {
-      "name": "DC Department of Energy and Environment"
-    },
     "dc-dc-sustainable-energy-utility": {
       "name": "DC Sustainable Energy Utility",
       "city": "Washington",
       "county": "District of Columbia"
+    },
+    "dc-dc-department-of-energy-and-environment": {
+      "name": "DC Department of Energy and Environment"
     }
   },
   "coverage": {
@@ -21,6 +21,7 @@
     "city": "Washington",
     "county": "District of Columbia"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -16,6 +16,7 @@
     "city": "Decatur",
     "county": "DeKalb"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -16,6 +16,7 @@
     "city": "Ann Arbor",
     "county": "Washtenaw"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -16,6 +16,16 @@
     "city": "Las Vegas",
     "county": "Clark"
   },
+  "data_partners": {
+    "nv-nevada-clean-energy-fund": {
+      "name": "Nevada Clean Energy Fund",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/nv-nevada-clean-energy-fund.png",
+        "width": 300,
+        "height": 200
+      }
+    }
+  },
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -22,6 +22,7 @@
     "city": "Hewlett",
     "county": "Nassau"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -16,6 +16,7 @@
     "city": "Fairfax",
     "county": "Fairfax"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -22,6 +22,7 @@
     "city": "Burlington",
     "county": "Chittenden"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -16,6 +16,7 @@
     "city": "Madison",
     "county": "Dane"
   },
+  "data_partners": {},
   "incentives": [
     {
       "payment_methods": [


### PR DESCRIPTION
# Changes

1. Adds support for a new concept, data partners (see comment in src/data/data_partners.ts for description). Basically there are some orgs, like NCEF in Nevada, who help us with data collection and reviewing incentives, so we want to feature their logo in the calculator. However, they don't fit neatly into any existing data structures -- they're not really authorities since they don't offer incentives directly. This PR adds a concept of "data partners" to represent these organizations
2. Creates the first data partner, NCEF in NV
3. Adds `data_partners` to the API V1 response
4. Updates fixtures. Should be `data_partners: {}` for all states except NV

# Why

We need to be able to feature NCEF's logo in the calculator. See context here https://rewiringameri-g3x1100.slack.com/archives/C04E4THEGMT/p1709746224613009