### PR TITLE
Update scripts to handle geo_groups

### DIFF
--- a/data/geo_groups.json
+++ b/data/geo_groups.json
@@ -8,11 +8,6 @@
         "co-loveland-water-and-power"
       ]
     },
-    "co-group-walking-mountains": {
-      "counties": [
-        "co-unincorporated-eagle-county"
-      ]
-    },
     "co-group-tri-state-g-and-t": {
       "utilities": [
         "co-empire-electric-association",
@@ -32,6 +27,11 @@
         "co-united-power",
         "co-white-river-electric-association",
         "co-y-w-electric-association"
+      ]
+    },
+    "co-group-walking-mountains": {
+      "counties": [
+        "co-unincorporated-eagle-county"
       ]
     }
   },

--- a/scripts/generate-misc-state-data.ts
+++ b/scripts/generate-misc-state-data.ts
@@ -2,7 +2,7 @@ import { parse } from 'csv-parse/sync';
 import minimist from 'minimist';
 import { FILES, IncentiveFile } from './incentive-spreadsheet-registry';
 import { AuthorityAndProgramUpdater } from './lib/authority-and-program-updater';
-import { FIELD_MAPPINGS } from './lib/spreadsheet-mappings';
+import { FIELD_MAPPINGS, VALUE_MAPPINGS } from './lib/spreadsheet-mappings';
 import { SpreadsheetStandardizer } from './lib/spreadsheet-standardizer';
 
 async function generate(state: string, file: IncentiveFile) {
@@ -18,7 +18,7 @@ async function generate(state: string, file: IncentiveFile) {
   const strict_mode = false;
   const standardizer = new SpreadsheetStandardizer(
     FIELD_MAPPINGS,
-    {},
+    VALUE_MAPPINGS,
     strict_mode,
   );
 

--- a/scripts/generate-misc-state-data.ts
+++ b/scripts/generate-misc-state-data.ts
@@ -30,6 +30,7 @@ async function generate(state: string, file: IncentiveFile) {
 
   authorityProgramManager.updatePrograms();
   authorityProgramManager.updateAuthoritiesJson();
+  authorityProgramManager.updateGeoGroupsJson();
 }
 
 (async function () {

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -144,6 +144,7 @@ export function updateGeoGroups(
         utilities: [],
         cities: [],
         counties: [],
+        notes: '',
       };
     }
   }

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -90,10 +90,13 @@ export function authorityNameToGroupName(authorityName: string): string {
 export function sortMapByKey<T>(json: Record<string, T>): Record<string, T> {
   const ordered = Object.keys(json)
     .sort()
-    .reduce((obj, key) => {
-      obj[key] = json[key];
-      return obj;
-    }, {} as Record<string, T>);
+    .reduce(
+      (obj, key) => {
+        obj[key] = json[key];
+        return obj;
+      },
+      {} as Record<string, T>,
+    );
   return ordered;
 }
 

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -54,6 +54,7 @@ export const VALUE_MAPPINGS: { [index: string]: AliasMap } = {
     utility: ['Utility'],
     county: ['County'],
     city: ['City'],
+    other: ['Other'],
   },
   payment_methods: {
     rebate: ['Rebate (Post Purchase)'],

--- a/src/data/geo_groups.ts
+++ b/src/data/geo_groups.ts
@@ -8,6 +8,7 @@ const GEO_GROUP_SCHEMA = {
     utilities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     cities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     counties: { type: 'array', items: { type: 'string' }, minItems: 1 },
+    notes: { type: 'string' },
   },
   additionalProperties: false,
   anyOf: [

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -32,6 +32,7 @@ export type CollectedIncentive = {
   data_urls: string[];
   authority_type: AuthorityType;
   authority_name: string;
+  geo_eligibility?: string;
   program_title: string;
   program_url: string;
   item: Item;

--- a/test/scripts/authority-and-program-updater.test.ts
+++ b/test/scripts/authority-and-program-updater.test.ts
@@ -479,6 +479,7 @@ test('add geo groups for new state', async tap => {
         utilities: [],
         cities: [],
         counties: [],
+        notes: '',
       },
     },
     CO: {
@@ -517,6 +518,7 @@ test('add geo groups to existing state', async tap => {
         utilities: [],
         cities: [],
         counties: [],
+        notes: '',
       },
       'co-group-something': {
         utilities: ['co-some-utility'],

--- a/test/scripts/authority-and-program-updater.test.ts
+++ b/test/scripts/authority-and-program-updater.test.ts
@@ -6,7 +6,7 @@ import {
   StateToAuthorityTypeMap,
   createProgramsContent,
   maybeUpdateProgramsTsFile,
-  sortJsonAlphabeticallyByStateKey,
+  sortMapByKey,
   updateAuthorities,
 } from '../../scripts/lib/authority-and-program-updater';
 
@@ -63,7 +63,7 @@ const baseSourceFile = `import SomeClass from './some_file';
 import CT_PROGRAMS from './programs/ct_programs';
 import NY_PROGRAMS from './programs/ny_programs';
 import OtherClass from './other_file';
-  
+
 const var = 'foo';
 
 const all_programs = {
@@ -122,10 +122,7 @@ test('correctly sort state authority information by state', tap => {
       },
     },
   };
-  tap.matchOnly(
-    ordered_json,
-    sortJsonAlphabeticallyByStateKey(unorderedFixture),
-  );
+  tap.matchOnly(ordered_json, sortMapByKey(unorderedFixture));
   tap.end();
 });
 
@@ -360,7 +357,7 @@ import AZ_PROGRAMS from './programs/az_programs';
 import CT_PROGRAMS from './programs/ct_programs';
 import NY_PROGRAMS from './programs/ny_programs';
 import OtherClass from './other_file';
-  
+
 const var = 'foo';
 
 const all_programs = {
@@ -396,7 +393,7 @@ import CT_PROGRAMS from './programs/ct_programs';
 import IL_PROGRAMS from './programs/il_programs';
 import NY_PROGRAMS from './programs/ny_programs';
 import OtherClass from './other_file';
-  
+
 const var = 'foo';
 
 const all_programs = {
@@ -432,7 +429,7 @@ import CT_PROGRAMS from './programs/ct_programs';
 import NY_PROGRAMS from './programs/ny_programs';
 import WA_PROGRAMS from './programs/wa_programs';
 import OtherClass from './other_file';
-  
+
 const var = 'foo';
 
 const all_programs = {


### PR DESCRIPTION
## Description

- Updates generate-misc-state-data to create entries in
  geo_groups.json for any authorities of type "other", with empty
  lists to be filled in by the engineer.

  A couple of wrinkles: the standardizer that gets created in this
  script has empty value mappings, which means the check for authority
  type has to look for the spreadsheet string `Other` rather than the
  standardized `other`. I don't know why the value mappings are empty
  in this case, but looking for the unstandardized value feels wrong.

  The standardizer is also created in strict mode, which means it
  errors out because there are extra columns in the CO and VT
  spreadsheets now ("description character count"/"description word
  count" and "questions / comments" respectively). I had to turn off
  strict mode to test the changes.

- Updates spreadsheet standardizer to add `eligible_geo_group` to any
  incentive with authority_type `other`.

The intended workflow, starting from initial state translation, is:

1. The "geographic eligibility" column in the sheet is filled with
   free text describing the criterion (or it's absent).

2. Run `generate-misc-state-data`, which will generate an entry in
   geo_groups.json for every authority with an "other"-type incentive.

3. Edit geo_groups.json manually, to define what those groups are,
   based on the free text in the sheet and/or manual research.

4. If customization is needed -- such as if one "other"-type authority
   doesn't have the same geo eligibility for all their incentives --
   define the necessary geo groups manually, and update the
   spreadsheet to put the appropriate geo group ID in the "Geographic
   Eligibility" column of each incentive where it's necessary.

5. Run `spreadsheet-to-json`. It will use the value of "Geographic
   Eligibility" as the `eligible_geo_group` if it looks like a geo
   group ID, or mechanically derive it from the authority name (the
   same way as in step 2) otherwise.

## Test Plan

Go through the above workflow with CO. (Although, as noted, I had to
turn off strict mode in step 2; I also had to comment out updating the
programs files since I'm doing this without #338.)