### PR TITLE
Switch to configuring low-income explicitly by record.

### DIFF
--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1,7 +1,7 @@
 {
   "AZ": {
     "default": {
-      "records": [
+      "incentives": [
         "AZ-18",
         "AZ-21"
       ],
@@ -20,7 +20,7 @@
   },
   "CO": {
     "co-black-hills-energy": {
-      "records": [
+      "incentives": [
         "CO-24",
         "CO-25",
         "CO-26"
@@ -40,7 +40,7 @@
       }
     },
     "co-city-and-county-of-denver": {
-      "records": [
+      "incentives": [
         "CO-46",
         "CO-47"
       ],
@@ -57,7 +57,7 @@
       }
     },
     "co-energy-outreach-colorado": {
-      "records": [
+      "incentives": [
         "CO-103"
       ],
       "source_url": "https://socgov02.my.site.com/ceoweatherization/resource/Income_Guidelines",
@@ -75,7 +75,7 @@
       }
     },
     "co-colorado-energy-office": {
-      "records": [
+      "incentives": [
         "CO-318",
         "CO-319"
       ],
@@ -94,7 +94,7 @@
       }
     },
     "co-city-of-boulder": {
-      "records": [
+      "incentives": [
         "CO-335"
       ],
       "source_url": "https://assets-partners.bouldercounty.gov/wp-content/uploads/sites/2/2023/02/2023-COB-Rebate-Eligible-Upgrades.pdf",
@@ -110,7 +110,7 @@
       }
     },
     "co-glenwood-springs-electric": {
-      "records": [
+      "incentives": [
         "CO-376"
       ],
       "source_url": "https://garfieldcleanenergy.org/gwse-rebate-form/",
@@ -126,7 +126,7 @@
       }
     },
     "co-walking-mountains": {
-      "records": [
+      "incentives": [
         "CO-494",
         "CO-506",
         "CO-507",
@@ -155,7 +155,7 @@
   },
   "CT": {
     "default": {
-      "records": [
+      "incentives": [
         "CT-1",
         "CT-4"
       ],
@@ -172,7 +172,7 @@
       }
     },
     "ct-cheapr": {
-      "records": [
+      "incentives": [
         "CT-33",
         "CT-34"
       ],
@@ -191,7 +191,7 @@
   },
   "DC": {
     "dc-dc-sustainable-energy-utility": {
-      "records": [
+      "incentives": [
         "DC-12",
         "DC-13",
         "DC-14",
@@ -214,7 +214,7 @@
     },
     "dc-dc-department-of-energy-and-environment-60-ami": {
       "/": "DOEE's Weatherization Assistance Program's threshold is 60% AMI",
-      "records": [
+      "incentives": [
         "DC-21"
       ],
       "source_url": "https://doee.dc.gov/service/wap",
@@ -233,7 +233,7 @@
   "GA": {},
   "IL": {
     "default": {
-      "records": [
+      "incentives": [
         "IL-35"
       ],
       "source_url": "https://dceo.illinois.gov/communityservices/homeweatherization.html",
@@ -251,7 +251,7 @@
   },
   "MI": {
     "mi-dte": {
-      "records": [
+      "incentives": [
         "MI-39"
       ],
       "source_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/electric-vehicle-rebate.html#accordion-2c85f65c90-item-614638b806",
@@ -269,7 +269,7 @@
   },
   "NV": {
     "nv-nv-energy": {
-      "records": [
+      "incentives": [
         "NV-17",
         "NV-23",
         "NV-24",
@@ -290,7 +290,7 @@
   },
   "NY": {
     "default": {
-      "records": [
+      "incentives": [
         "NY-15"
       ],
       "source_url": "https://homeenergy.pseg.com/homeweatherization",
@@ -308,7 +308,7 @@
   },
   "RI": {
     "default": {
-      "records": [
+      "incentives": [
         "RI-11",
         "RI-12",
         "RI-13",
@@ -333,7 +333,7 @@
       }
     },
     "ri-dhs": {
-      "records": [
+      "incentives": [
         "RI-14"
       ],
       "source_url": "https://dhs.ri.gov/programs-and-services/energy-and-water-assistance-programs/ffy-2023-low-income-guidelines",
@@ -353,7 +353,7 @@
       }
     },
     "ri-rhode-island-energy": {
-      "records": [
+      "incentives": [
         "RI-27"
       ],
       "source_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services#qualify",
@@ -373,7 +373,7 @@
   },
   "VA": {
     "default": {
-      "records": [
+      "incentives": [
         "VA-18"
       ],
       "source_url": "https://www.dhcd.virginia.gov/sites/default/files/Docx/weatherization/income-limits.pdf",
@@ -395,7 +395,7 @@
   },
   "VT": {
     "default": {
-      "records": [
+      "incentives": [
         "VT-10",
         "VT-20",
         "VT-28",
@@ -414,7 +414,7 @@
       }
     },
     "default-moderate": {
-      "records": [
+      "incentives": [
         "VT-2",
         "VT-8",
         "VT-11",
@@ -437,7 +437,7 @@
       }
     },
     "vt-burlington-electric-department": {
-      "records": [
+      "incentives": [
         "VT-4",
         "VT-13",
         "VT-25"
@@ -455,7 +455,7 @@
       }
     },
     "vt-state-of-vermont": {
-      "records": [
+      "incentives": [
         "VT-30"
       ],
       "source_url": "https://www.driveelectricvt.com/Media/Default/docs/ryr/vermont-replace-your-ride-program-guidelines.pdf?refresh",
@@ -471,7 +471,7 @@
       }
     },
     "vt-vgs": {
-      "records": [
+      "incentives": [
         "VT-56"
       ],
       "source_url": "https://vgsvt.com/wp-content/uploads/2023/03/2023-Income-Verification-Form.pdf",
@@ -489,7 +489,7 @@
   },
   "WI": {
     "wi-focus-on-energy": {
-      "records": [
+      "incentives": [
         "WI-2",
         "WI-4",
         "WI-6"

--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1,6 +1,10 @@
 {
   "AZ": {
     "default": {
+      "records": [
+        "AZ-18",
+        "AZ-21"
+      ],
       "source_url": "https://www.tep.com/weatherization-assistance",
       "thresholds": {
         "1": 29160,
@@ -16,6 +20,11 @@
   },
   "CO": {
     "co-black-hills-energy": {
+      "records": [
+        "CO-24",
+        "CO-25",
+        "CO-26"
+      ],
       "source_url": "https://www.blackhillsenergy.com/sites/blackhillsenergy.com/files/2023%20COE%20Income%20Qualified%20EV%20Residential%20Rebate%20Form.pdf",
       "thresholds": {
         "1": 36983,
@@ -31,6 +40,10 @@
       }
     },
     "co-city-and-county-of-denver": {
+      "records": [
+        "CO-46",
+        "CO-47"
+      ],
       "source_url": "https://www.denvergov.org/files/assets/public/v/1/housing-stability/documents/2023-incomerent-limits/host-income-rent-limit-2023-mah.pdf",
       "thresholds": {
         "1": 69520,
@@ -44,6 +57,9 @@
       }
     },
     "co-energy-outreach-colorado": {
+      "records": [
+        "CO-103"
+      ],
       "source_url": "https://socgov02.my.site.com/ceoweatherization/resource/Income_Guidelines",
       "thresholds": {
         "1": 36983,
@@ -59,6 +75,10 @@
       }
     },
     "co-colorado-energy-office": {
+      "records": [
+        "CO-318",
+        "CO-319"
+      ],
       "source_url": "https://docs.google.com/spreadsheets/d/1I9wrt5zJ6khmLR3ZeFCKlz5EmNKUusaFYAK4oeKO4wY/edit#gid=0",
       "thresholds": {
         "1": 48720,
@@ -74,6 +94,9 @@
       }
     },
     "co-city-of-boulder": {
+      "records": [
+        "CO-335"
+      ],
       "source_url": "https://assets-partners.bouldercounty.gov/wp-content/uploads/sites/2/2023/02/2023-COB-Rebate-Eligible-Upgrades.pdf",
       "thresholds": {
         "1": 75980,
@@ -87,6 +110,9 @@
       }
     },
     "co-glenwood-springs-electric": {
+      "records": [
+        "CO-376"
+      ],
       "source_url": "https://garfieldcleanenergy.org/gwse-rebate-form/",
       "thresholds": {
         "1": 104250,
@@ -100,19 +126,20 @@
       }
     },
     "co-walking-mountains": {
-      "source_url": "https://www.walkingmountains.org/sustainability-hub/low-to-moderate-income-rebate-information/",
-      "thresholds": {
-        "1": 124350,
-        "2": 142050,
-        "3": 159750,
-        "4": 177450,
-        "5": 191700,
-        "6": 205950,
-        "7": 220050,
-        "8": 234300
-      }
-    },
-    "default": {
+      "records": [
+        "CO-494",
+        "CO-506",
+        "CO-507",
+        "CO-508",
+        "CO-509",
+        "CO-510",
+        "CO-511",
+        "CO-512",
+        "CO-513",
+        "CO-514",
+        "CO-515",
+        "CO-516"
+      ],
       "source_url": "https://www.walkingmountains.org/sustainability-hub/low-to-moderate-income-rebate-information/",
       "thresholds": {
         "1": 124350,
@@ -128,6 +155,10 @@
   },
   "CT": {
     "default": {
+      "records": [
+        "CT-1",
+        "CT-4"
+      ],
       "source_url": "https://energizect.com/energy-evaluations/income-eligible-options",
       "thresholds": {
         "1": 39761,
@@ -141,6 +172,10 @@
       }
     },
     "ct-cheapr": {
+      "records": [
+        "CT-33",
+        "CT-34"
+      ],
       "source_url": "https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines",
       "thresholds": {
         "1": 45180,
@@ -156,21 +191,16 @@
   },
   "DC": {
     "dc-dc-sustainable-energy-utility": {
+      "records": [
+        "DC-12",
+        "DC-13",
+        "DC-14",
+        "DC-15",
+        "DC-16",
+        "DC-19",
+        "DC-24"
+      ],
       "source_url": "https://www.dcseu.com/affordable-home-electrification",
-      "thresholds": {
-        "1": 85200,
-        "2": 97350,
-        "3": 109500,
-        "4": 121700,
-        "5": 133850,
-        "6": 146000,
-        "7": 158200,
-        "8": 170350
-      }
-    },
-    "dc-dc-department-of-energy-and-environment": {
-      "/": "DOEE's Solar for All's threshold is 80% AMI",
-      "source_url": "https://doee.dc.gov/solarforall",
       "thresholds": {
         "1": 85200,
         "2": 97350,
@@ -184,6 +214,9 @@
     },
     "dc-dc-department-of-energy-and-environment-60-ami": {
       "/": "DOEE's Weatherization Assistance Program's threshold is 60% AMI",
+      "records": [
+        "DC-21"
+      ],
       "source_url": "https://doee.dc.gov/service/wap",
       "thresholds": {
         "1": 49814,
@@ -195,38 +228,14 @@
         "7": 129325,
         "8": 132199
       }
-    },
-    "default": {
-      "source_url": "https://www.dcseu.com/affordable-home-electrification",
-      "thresholds": {
-        "1": 85200,
-        "2": 97350,
-        "3": 109500,
-        "4": 121700,
-        "5": 133850,
-        "6": 146000,
-        "7": 158200,
-        "8": 170350
-      }
     }
   },
-  "GA": {
-    "default": {
-      "source_url": "https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines",
-      "thresholds": {
-        "1": 15060,
-        "2": 20440,
-        "3": 25820,
-        "4": 31200,
-        "5": 36580,
-        "6": 41960,
-        "7": 47340,
-        "8": 52720
-      }
-    }
-  },
+  "GA": {},
   "IL": {
     "default": {
+      "records": [
+        "IL-35"
+      ],
       "source_url": "https://dceo.illinois.gov/communityservices/homeweatherization.html",
       "thresholds": {
         "1": 29160,
@@ -241,20 +250,10 @@
     }
   },
   "MI": {
-    "default": {
-      "source_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/electric-vehicle-rebate.html#accordion-2c85f65c90-item-614638b806",
-      "thresholds": {
-        "1": 60240,
-        "2": 81760,
-        "3": 103280,
-        "4": 124800,
-        "5": 146320,
-        "6": 167840,
-        "7": 189360,
-        "8": 210880
-      }
-    },
     "mi-dte": {
+      "records": [
+        "MI-39"
+      ],
       "source_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/electric-vehicle-rebate.html#accordion-2c85f65c90-item-614638b806",
       "thresholds": {
         "1": 60240,
@@ -269,20 +268,13 @@
     }
   },
   "NV": {
-    "default": {
-      "source_url": "https://www.nvenergy.com/save-with-powershift/qualified-appliance-replacement",
-      "thresholds": {
-        "1": 61400,
-        "2": 70200,
-        "3": 78950,
-        "4": 87700,
-        "5": 94750,
-        "6": 101750,
-        "7": 108750,
-        "8": 115800
-      }
-    },
     "nv-nv-energy": {
+      "records": [
+        "NV-17",
+        "NV-23",
+        "NV-24",
+        "NV-25"
+      ],
       "source_url": "https://www.nvenergy.com/save-with-powershift/qualified-appliance-replacement",
       "thresholds": {
         "1": 61400,
@@ -298,6 +290,9 @@
   },
   "NY": {
     "default": {
+      "records": [
+        "NY-15"
+      ],
       "source_url": "https://homeenergy.pseg.com/homeweatherization",
       "thresholds": {
         "1": 58320,
@@ -313,6 +308,14 @@
   },
   "RI": {
     "default": {
+      "records": [
+        "RI-11",
+        "RI-12",
+        "RI-13",
+        "RI-43",
+        "RI-34",
+        "RI-35"
+      ],
       "source_url": "https://dhs.ri.gov/programs-and-services/energy-and-water-assistance-programs/ffy-2023-low-income-guidelines",
       "thresholds": {
         "1": 34039,
@@ -330,6 +333,9 @@
       }
     },
     "ri-dhs": {
+      "records": [
+        "RI-14"
+      ],
       "source_url": "https://dhs.ri.gov/programs-and-services/energy-and-water-assistance-programs/ffy-2023-low-income-guidelines",
       "thresholds": {
         "1": 34039,
@@ -347,6 +353,9 @@
       }
     },
     "ri-rhode-island-energy": {
+      "records": [
+        "RI-27"
+      ],
       "source_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services#qualify",
       "thresholds": {
         "1": 32265,
@@ -364,6 +373,9 @@
   },
   "VA": {
     "default": {
+      "records": [
+        "VA-18"
+      ],
       "source_url": "https://www.dhcd.virginia.gov/sites/default/files/Docx/weatherization/income-limits.pdf",
       "thresholds": {
         "1": 37792,
@@ -383,6 +395,12 @@
   },
   "VT": {
     "default": {
+      "records": [
+        "VT-10",
+        "VT-20",
+        "VT-28",
+        "VT-52"
+      ],
       "source_url": "https://www.efficiencyvermont.com/services/income-based-assistance/energy-bill-reduction",
       "thresholds": {
         "1": 55050,
@@ -396,6 +414,16 @@
       }
     },
     "default-moderate": {
+      "records": [
+        "VT-2",
+        "VT-8",
+        "VT-11",
+        "VT-21",
+        "VT-38",
+        "VT-42",
+        "VT-51",
+        "VT-54"
+      ],
       "source_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
       "thresholds": {
         "1": 82400,
@@ -409,6 +437,11 @@
       }
     },
     "vt-burlington-electric-department": {
+      "records": [
+        "VT-4",
+        "VT-13",
+        "VT-25"
+      ],
       "source_url": "https://www.burlingtonelectric.com/rebate-form",
       "thresholds": {
         "1": 63600,
@@ -422,6 +455,9 @@
       }
     },
     "vt-state-of-vermont": {
+      "records": [
+        "VT-30"
+      ],
       "source_url": "https://www.driveelectricvt.com/Media/Default/docs/ryr/vermont-replace-your-ride-program-guidelines.pdf?refresh",
       "thresholds": {
         "1": 51968,
@@ -435,6 +471,9 @@
       }
     },
     "vt-vgs": {
+      "records": [
+        "VT-56"
+      ],
       "source_url": "https://vgsvt.com/wp-content/uploads/2023/03/2023-Income-Verification-Form.pdf",
       "thresholds": {
         "1": 78700,
@@ -449,20 +488,12 @@
     }
   },
   "WI": {
-    "default": {
-      "source_url": "https://focusonenergy.com/income-qualified",
-      "thresholds": {
-        "1": 66300,
-        "2": 75750,
-        "3": 85200,
-        "4": 94650,
-        "5": 102250,
-        "6": 109800,
-        "7": 117400,
-        "8": 124950
-      }
-    },
     "wi-focus-on-energy": {
+      "records": [
+        "WI-2",
+        "WI-4",
+        "WI-6"
+      ],
       "source_url": "https://focusonenergy.com/income-qualified",
       "thresholds": {
         "1": 66300,

--- a/src/data/low_income_thresholds.ts
+++ b/src/data/low_income_thresholds.ts
@@ -12,7 +12,7 @@ export type StateLowIncomeThresholds = {
 export type LowIncomeThresholdsAuthority = {
   source_url: string;
   thresholds: LowIncomeThresholds;
-  records: string[];
+  incentives: string[];
 };
 
 export type LowIncomeThresholds = {
@@ -52,14 +52,14 @@ export const AUTHORITY_INFO_SCHEMA: JSONSchemaType<LowIncomeThresholdsAuthority>
     properties: {
       source_url: { type: 'string' },
       thresholds: AUTHORITY_THRESHOLDS_SCHEMA,
-      records: {
+      incentives: {
         type: 'array',
         items: { type: 'string' },
         minItems: 1,
         uniqueItems: true,
       },
     },
-    required: ['source_url', 'thresholds', 'records'],
+    required: ['source_url', 'thresholds', 'incentives'],
   } as const;
 
 export const STATE_THRESHOLDS_SCHEMA: JSONSchemaType<StateLowIncomeThresholds> =

--- a/src/data/low_income_thresholds.ts
+++ b/src/data/low_income_thresholds.ts
@@ -12,6 +12,7 @@ export type StateLowIncomeThresholds = {
 export type LowIncomeThresholdsAuthority = {
   source_url: string;
   thresholds: LowIncomeThresholds;
+  records: string[];
 };
 
 export type LowIncomeThresholds = {
@@ -51,14 +52,20 @@ export const AUTHORITY_INFO_SCHEMA: JSONSchemaType<LowIncomeThresholdsAuthority>
     properties: {
       source_url: { type: 'string' },
       thresholds: AUTHORITY_THRESHOLDS_SCHEMA,
+      records: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1,
+        uniqueItems: true,
+      },
     },
-    required: ['source_url', 'thresholds'],
+    required: ['source_url', 'thresholds', 'records'],
   } as const;
 
 export const STATE_THRESHOLDS_SCHEMA: JSONSchemaType<StateLowIncomeThresholds> =
   {
     type: 'object',
-    required: ['default'],
+    required: [],
     dependentSchemas: {
       CO: {
         required: Object.values(COLowIncomeAuthority),

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -98,13 +98,13 @@ export function calculateStateIncentivesAndSavings(
     const thresholds_map = LOW_INCOME_THRESHOLDS_BY_AUTHORITY[stateId];
 
     if (typeof thresholds_map !== 'undefined') {
-      if (item.low_income) {
-        const authorities =
-          thresholds_map[item.low_income] ?? thresholds_map.default;
-        if (
-          request.household_income >
-          authorities.thresholds[request.household_size]
-        ) {
+      if (
+        item.low_income &&
+        thresholds_map[item.low_income] &&
+        request.household_income >
+          thresholds_map[item.low_income].thresholds[request.household_size]
+      ) {
+        {
           eligible = false;
         }
       }

--- a/test/data/low_income_thresholds.test.ts
+++ b/test/data/low_income_thresholds.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'tap';
+import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../../src/data/low_income_thresholds';
+import {
+  STATE_INCENTIVES_BY_STATE,
+  StateIncentive,
+} from '../../src/data/state_incentives';
+
+function computeIdToIncentiveMap(incentives: StateIncentive[]) {
+  const output: { [index: string]: StateIncentive } = {};
+  for (const incentive of incentives) {
+    output[incentive.id] = incentive;
+  }
+  return output;
+}
+
+test('low-income thresholds are equivalent in JSON config and incentives', async t => {
+  // All incentives have the threshold indicated in their config.
+  const map = computeIdToIncentiveMap(
+    Object.values(STATE_INCENTIVES_BY_STATE).flat(),
+  );
+  Object.entries(LOW_INCOME_THRESHOLDS_BY_AUTHORITY).forEach(
+    ([, stateThresholds]) => {
+      for (const [identifier, thresholds] of Object.entries(stateThresholds)) {
+        for (const incentiveId of thresholds.incentives) {
+          const incentive = map[incentiveId];
+          t.equal(incentive.low_income, identifier);
+        }
+      }
+    },
+  );
+  // Converse: all threshold configs accurately reflect the incentive IDs.
+  for (const [stateId, stateIncentives] of Object.entries(
+    STATE_INCENTIVES_BY_STATE,
+  )) {
+    for (const incentive of stateIncentives) {
+      if (incentive.low_income) {
+        const stateThresholds = LOW_INCOME_THRESHOLDS_BY_AUTHORITY[stateId];
+        t.hasProp(stateThresholds, incentive.low_income);
+        t.ok(
+          stateThresholds[incentive.low_income].incentives.includes(
+            incentive.id,
+          ),
+        );
+      }
+    }
+  }
+});

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -83,7 +83,7 @@ test('correct row to record transformation', tap => {
       'va-appalachian-power': {
         source_url: 'url',
         thresholds: {},
-        records: ['ID-1'],
+        incentives: ['VA-1'],
       },
     },
   };

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -83,6 +83,7 @@ test('correct row to record transformation', tap => {
       'va-appalachian-power': {
         source_url: 'url',
         thresholds: {},
+        records: ['ID-1'],
       },
     },
   };


### PR DESCRIPTION
This isn't fully complete, but I wanted to get initial feedback before writing tests.

After doing some investigation, I didn't want to go the geo_groups route for low_income configuration for a couple reasons:
1. low-income thresholds are of interest to external stakeholders, and I think it will complicate things for all parties if at some point in the spreadsheet-to-json process, we're replacing data that is standalone and human-readable with an enum key that only makes sense if referencing a separate dataset (this reasoning applies to geo groups too but is maybe less important there)
2. in the spreadsheets, data collectors tend to put notes in the income column that aren't shared across all records that have the same low-income thresholds. Some of these refer to the non-low-income counterpart incentive, if one exists (see CT and RI for examples). There may be other use cases too. I don't want to collapse these notes into the same JSON object like we did with geo_groups.

What I favor instead is keeping low-income in spreadsheet form as a free-text field, and then using config to tie the thresholds to records. I chose records instead of authorities or programs because I don't think it's that much extra config and it's more precise.

While it's redundant to express the records in the thresholds and also have low_income as an incentive field, I think it makes sense since creation of the incentives JSON is automated. In that sense we still have a single representation of low-income information and then the incentives JSON is downstream of that.

If this is okay, I'll add static tests to verify that the info in the thresholds and JSON reflect the same reality.

I'm also getting rid of the default requirement since we won't need that in the future.