### PR TITLE
Turn start/end dates into strings

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -109,7 +109,7 @@
       "en": "Rebate of $500 for each minimum usable capacity battery unit of 5 kWh, installed on or after Jan 9, 2022.",
       "es": "Un reembolso de $500 dólares por cada unidad de batería de 5 kWh de capacidad mínima utilizable instalada a partir del 9 de enero del 2022."
     },
-    "start_date": 2022
+    "start_date": "2022"
   },
   {
     "id": "AZ-7",
@@ -280,8 +280,8 @@
       "en": "$400 rebate for TEP residential customers who purchase and install an Energy Star HPWH equipped with a wireless, programmable controller.",
       "es": "Un reembolso de $400 dólares para los clientes residenciales de TEP que compren e instalen un calentador de agua con bomba de calor Energy Star equipado con un temporizador/controlador inalámbrico y programable."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "AZ-21",

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -20,8 +20,8 @@
       "en": "$1700 rebate for ENERGY STAR Geothermal Heat Pump at least 14.1 EER.",
       "es": "Un reembolso de $1,700 dólares para una bomba de calor geotérmica ENERGY STAR de al menos 14.1 EER."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-2",
@@ -45,8 +45,8 @@
       "en": "Rebate of $0.50 per sq ft up to $500 for Attic Insulation. Minimum efficiency is R-38.",
       "es": "Un reembolso de $0.50 de dólar por pie cuadrado hasta $500 dólares para aislamiento del desván. La eficiencia mínima es R-38."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-3",
@@ -70,8 +70,8 @@
       "en": "Rebate of $1 per sq ft up to $750 for Wall Insulation. Minimum efficiency is R-13.",
       "es": "Un reembolso de $1 por pie cuadrado hasta $750 por aislamiento de paredes. La eficiencia mínima es R-13."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-4",
@@ -95,8 +95,8 @@
       "en": "Rebate of $0.50 per sq ft up to $250 for Floor Insulation Above Crawlspace. Minimum efficiency is R-25.",
       "es": "Un reembolso de $0.50 de dólar por pie cuadrado hasta $250 dólares para aislamiento de suelos sobre el entrepiso. La eficiencia mínima es R-25."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-5",
@@ -120,8 +120,8 @@
       "en": "Rebate of $0.50 per sq ft up to $250 for Basement Sidewall Insulation. Minimum efficiency is R-11.",
       "es": "Un reembolso de $0.50 de dólar por pie cuadrado hasta $250 dólares para aislamiento del muro lateral del sótano. La eficiencia mínima es R-11."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-6",
@@ -145,8 +145,8 @@
       "en": "Rebate of $0.50 per sq ft up to $250 for Rim/Band Joist Insulation. Minimum efficiency is R-13.",
       "es": "Un reembolso de $0.50 de dólar por pie cuadrado hasta $250 dólares para aislamiento de vigas de borde/banda. La eficiencia mínima es R-13."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-7",
@@ -169,8 +169,8 @@
       "en": "50% rebate up to $500 for Air Sealing. Minimum efficiency: 30% ACH Reduction. Blower door test required.",
       "es": "Un reembolso del 50% hasta $500 dólares por sellado hermético. Eficiencia mínima: 30% de reducción de ACH. Se requiere una prueba de soplado de compuerta."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-8",
@@ -193,8 +193,8 @@
       "en": "50% rebate up to $300 for Duct Sealing. Efficiency requirements apply. Duct blaster test required.",
       "es": "Un reembolso del 50% hasta $300 dólares para sellar ductos. Se deberán cumplir requisitos de eficiencia. Se requiere una prueba de soplado de conductos."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-9",
@@ -217,8 +217,8 @@
       "en": "$500 rebate for an Energy Star rated heat pump water heater.",
       "es": "Un reembolso de $500 dólares por un calentador de agua con bomba de calor con certificación Energy Star."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-10",
@@ -242,8 +242,8 @@
       "en": "Rebate up to $550 for Air Source Heat Pumps at least SEER 15, EER 12.5, HSPF 8.5. EPA Energy Star qualified installer: $550, otherwise $450.",
       "es": "Un reembolso de hasta $550 dólares para bombas de calor de fuente de aire de al menos SEER 15, EER 12.5, HSPF 8.5. Instalador con certificado Energy Star de la EPA: $550 dólares; en caso contrario, $450 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-11",
@@ -267,8 +267,8 @@
       "en": "Rebate up to $800 for Air Source Heat Pumps at least SEER 16, EER 12.5, HSPF 8.5. EPA Energy Star qualified installer: $800, otherwise $700.",
       "es": "Un reembolso de hasta $800 dólares para bombas de calor de fuente de aire de al menos SEER 16, EER 12.5, HSPF 8.5. Instalador con certificación Energy Star de la EPA: $800 dólares; de lo contrario, $700 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-12",
@@ -292,8 +292,8 @@
       "en": "Rebate up to $1050 for Air Source Heat Pumps at least SEER 17, EER 12.5, HSPF 8.6. EPA Energy Star qualified installer: $1050, otherwise $950.",
       "es": "Un reembolso de hasta $1,050 dólares para bombas de calor de fuente de aire de al menos 17 SEER, 12.5 EER, 8.6 HSPF. Instalador con certificación Energy Star de la EPA: $1,050 dólares; de lo contrario, $950 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-13",
@@ -317,8 +317,8 @@
       "en": "Up to $950 for early retirement of Air Source Heat Pump. At least SEER 15, EER 12.5, and HSPF 8.5, good working condition, and under 12 years old.",
       "es": "Hasta $950 dólares por la jubilación anticipada de una bomba de calor de fuente de aire. Al menos SEER 15, EER 12.5 y HSPF 8.5, en buenas condiciones de funcionamiento y menos de 12 años de antigüedad."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-14",
@@ -342,8 +342,8 @@
       "en": "Up to $1200 for early retirement of Air Source Heat Pump. At least SEER 16, EER 12.5, and HSPF 8.5, good working condition, and under 12 years old.",
       "es": "Hasta $1,200 dólares por el retiro anticipado de una bomba de calor de fuente de aire. Al menos SEER 16, EER 12.5 y HSPF 8.5, en buenas condiciones de trabajo y con menos de 12 años de antigüedad."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-15",
@@ -367,8 +367,8 @@
       "en": "Up to $1450 for early retirement of Air Source Heat Pump. At least SEER 17, EER 12.5, and HSPF 8.6, good working condition, and under 12 years old.",
       "es": "Hasta $1,450 dólares por el retiro anticipada de una bomba de calor de fuente de aire. Al menos SEER 17, EER 12.5 y HSPF 8.6, en buenas condiciones de funcionamiento y con menos de 12 años de antigüedad."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-16",
@@ -391,8 +391,8 @@
       "en": "$500 rebate for ductless mini split heat pumps at least 20 SEER and 9 HSPF.",
       "es": "Un reembolso de $500 dólares para bombas de calor mini split sin ductos de al menos 20 SEER y 9 HSPF."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-17",
@@ -416,8 +416,8 @@
       "en": "Rebate up to $1100 for Air Source Heat Pumps at least SEER 15, EER 12.5, HSPF 8.5. EPA Energy Star qualified installer: $1100, otherwise $1000.",
       "es": "Un reembolso de hasta $1,100 dólares para bombas de calor de fuente de aire de al menos SEER 15, EER 12.5, HSPF 8.5. Instalador con certificación Energy Star de la EPA: $1,100 dólares; en caso contrario, $1,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-18",
@@ -441,8 +441,8 @@
       "en": "Rebate up to $1600 for Air Source Heat Pumps at least SEER 16, EER 12.5, HSPF 8.5. EPA Energy Star qualified installer: $1600, otherwise $1500.",
       "es": "Un reembolso de hasta $1,600 dólares para bombas de calor de fuente de aire de al menos SEER 16, EER 12.5, HSPF 8.5. Instalador con certificación Energy Star de la EPA: $1,600 dólares; en caso contrario, $1,500 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-19",
@@ -466,8 +466,8 @@
       "en": "Rebate up to $2100 for Air Source Heat Pumps at least SEER 17, EER 12.5, HSPF 8.6. EPA Energy Star qualified installer: $2100, otherwise $2000.",
       "es": "Un reembolso de hasta $2,100 dólares para bombas de calor de fuente de aire de al menos 17 SEER, 12.5 EER, 8.6 HSPF. Instalador con certificación Energy Star de la EPA: $2,100 dólares; en caso contrario, $2,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-20",
@@ -490,8 +490,8 @@
       "en": "$900 rebate for a Ductless Mini Split Heat Pump that is at least 20 SEER and 9 HSPF.",
       "es": "Un reembolso de $900 dólares para una bomba de calor mini split sin ductos que tenga al menos 20 SEER y 9 HSPF."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-21",
@@ -514,8 +514,8 @@
       "en": "$5,200 rebate for an Energy Star Geothermal Heat Pump that is at least 14 EER.",
       "es": "Un reembolso de $5,200 dólares para una bomba de calor geotérmica Energy Star que tenga al menos 14 EER."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-22",
@@ -538,8 +538,8 @@
       "en": "$800 rebate for an Energy Star rated Heat Pump Water Heater.",
       "es": "Un reembolso de $800 dólares por un calentador de agua con bomba de calor de categoría Energy Star."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-23",
@@ -562,8 +562,8 @@
       "en": "Rebate up to $500 for for the purchase and installation of a Level 2 (240 volt) electric vehicle charger.",
       "es": "Un reembolso de hasta $500 dólares por la compra e instalación de un cargador de vehículos eléctricos de nivel 2 (240 voltios)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-24",
@@ -586,8 +586,8 @@
       "en": "Income qualified rebate up to $1300 for for the purchase and installation of a Level 2 (240 volt) electric vehicle charger.",
       "es": "Un reembolso basado en nivel de ingresos de hasta $1,300 dólares para la compra e instalación de un cargador de vehículos eléctricos de nivel 2 (240 voltios)."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "low_income": "co-black-hills-energy"
   },
   {
@@ -612,8 +612,8 @@
       "en": "Income qualified rebate up to $5,500 for a new EV with an MSRP up to $50,000.",
       "es": "Un reembolso basado en nivel de ingresos de hasta $5,500 para un VE nuevo con un precio de venta sugerido por el fabricante de hasta $50,000."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "low_income": "co-black-hills-energy"
   },
   {
@@ -638,8 +638,8 @@
       "en": "Income qualified rebate up to $3,000 for a used EV with a purchase price up to $50,000.",
       "es": "Un reembolso basado en nivel de ingresos de hasta $3,000 dólares para un VE usado con un precio de compra de hasta $50,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "low_income": "co-black-hills-energy"
   },
   {
@@ -663,8 +663,8 @@
       "en": "Rebate up to $200 for insulation and air sealing.",
       "es": "Un reembolso de hasta $200 dólares por aislamiento y sellado hermético."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-28",
@@ -687,8 +687,8 @@
       "en": "Rebate up to $500 for an Energy Star certified ducted or ductless air source heat pump.",
       "es": "Un reembolso de hasta $500 dólares por una bomba de calor con fuente de aire, con o sin ductos, con certificación Energy Star."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-29",
@@ -711,8 +711,8 @@
       "en": "Rebate up to $1000 for a qualifying cold climate air source heat pump.",
       "es": "Un reembolso de hasta $1,000 dólares por una bomba de calor con fuente de aire para climas fríos que cumpla los requisitos."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-30",
@@ -735,8 +735,8 @@
       "en": "Rebate up to $200 on an Energy Star certified heat pump water heater.",
       "es": "Un reembolso de hasta $200 dólares en un calentador de agua con bomba de calor con certificación Energy Star."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-31",
@@ -759,7 +759,7 @@
       "en": "Rebate up to 40% of the total cost of an air source heat pump and installation, up to $1,500. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 40% del costo total de una bomba de calor de fuente de aire y de la instalación, hasta $1,500 dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-32",
@@ -782,7 +782,7 @@
       "en": "Rebate up to 40% of the total cost of a cold climate air source heat pump and installation, up to $3,500. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 40% del costo total de una bomba de calor con fuente de aire para climas fríos y de la instalación, hasta $3,500 dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-33",
@@ -805,7 +805,7 @@
       "en": "Rebate up to 80% of the total cost of a ground source heat pump and installation, up to $3,500. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 80% del costo total de una bomba de calor geotérmica y su instalación, hasta $3,500 dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-34",
@@ -828,7 +828,7 @@
       "en": "Rebate up to 40% of the total cost of a mini-split heat pump and installation, up to $1,500. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 40% del costo total de una bomba de calor mini-split y de la instalación, hasta $1,500 dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-35",
@@ -851,7 +851,7 @@
       "en": "Rebate up to 40% of the total cost of a cold climate mini-split heat pump and installation, up to $3,500. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 40% del costo total de una bomba de calor mini-split para climas fríos y de la instalación, hasta $3,500  dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-36",
@@ -874,7 +874,7 @@
       "en": "Rebate up to 60% of the total cost of a high efficency heat pump water heater and installation, up to $1,000. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 60% del costo total de un calentador de agua con bomba de calor de alta eficiencia y de la instalación, hasta $1,000 dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-37",
@@ -897,7 +897,7 @@
       "en": "Rebate up to 60% of the total cost of a smart/connected heat pump water heater and installation, up to $1,750. Efficiency minimums apply.",
       "es": "Un reembolso de hasta el 60% del costo total de un calentador de agua con bomba de calor inteligente/conectado y de la instalación, hasta $1,750 dólares. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-38",
@@ -920,7 +920,7 @@
       "en": "Level 2 EV Charging Home Wiring rebate, up to 80% of the total cost and up to $1,000 for permitting, materials, installation, and electrical costs.",
       "es": "Un reembolso para el cableado doméstico para realizar recargas de VEs de nivel 2, de hasta el 80% del costo total y hasta $1,000 dólares para permisos, materiales, instalación y costos eléctricos."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-39",
@@ -943,7 +943,7 @@
       "en": "Vehicle to Building EV Charger rebate up to 80% of the cost and up to $2,000 for equipment, permitting, materials, installation, & electrical costs.",
       "es": "Reembolso por un cargador VE de vehículo a edificio de hasta un 80% del costo y hasta $2,000 dólares para equipamiento, permisos, materiales, instalación y costos eléctricos."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-40",
@@ -966,7 +966,7 @@
       "en": "$1.00 per watt ($1000/kW) rebate for rooftop solar up to $4,000. Rebates cannot exceed 80% of the total cost.",
       "es": "Un reembolso de 1 dólar por watt ($1,000 dólares/kW) para energía solar en techos de hasta $4,000 dólares. Un reembolso no puede superar el 80% del costo total."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-41",
@@ -989,7 +989,7 @@
       "en": "Rebate up to 80% of the cost of battery storage, up to $2,750. Home must have a heat pump space heater, heat pump water heater, OR V2B EV charger.",
       "es": "Un reembolso de hasta el 80% del costo de almacenamiento de la batería, hasta $2,750 dólares. La vivienda debe tener un calefactor con bomba de calor, un calentador de agua con bomba de calor O un cargador VE V2B."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-42",
@@ -1012,7 +1012,7 @@
       "en": "Rebate up to 80% of the cost of battery storage, up to $500 for homes without a heat pump space heater, heat pump water heater, OR V2B EV charger.",
       "es": "Un reembolso de hasta el 80% del costo de almacenamiento de la batería, hasta $500 dólares para hogares sin una bomba de calor calentador de espacio, calentador de agua con bomba de calor, O V2B cargador para VEs."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-43",
@@ -1035,7 +1035,7 @@
       "en": "Rebate for up to 80% of the total cost of electric service upgrades and up to $2,000.",
       "es": "Un reembolso de hasta el 80% del costo total de las actualizaciones del servicio eléctrico y de hasta $2,000 dólares."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-44",
@@ -1175,7 +1175,7 @@
       "en": "Up to $500 per customer off air source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares de descuento por cliente en bombas de calor de fuente de aire. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-50",
@@ -1198,7 +1198,7 @@
       "en": "Up to $500 per customer off ground source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares por cliente en descuentos en bombas de calor geotérmicas. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-51",
@@ -1358,7 +1358,7 @@
       "en": "Up to $500 per customer off air source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares de descuento por cliente en bombas de calor de fuente de aire. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-58",
@@ -1381,7 +1381,7 @@
       "en": "Up to $500 per customer off ground source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares por cliente en descuentos en bombas de calor geotérmicas. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-59",
@@ -1541,7 +1541,7 @@
       "en": "Up to $500 per customer off air source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares de descuento por cliente en bombas de calor de fuente de aire. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-66",
@@ -1564,7 +1564,7 @@
       "en": "Up to $500 per customer off ground source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares por cliente en descuentos en bombas de calor geotérmicas. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-67",
@@ -1724,7 +1724,7 @@
       "en": "Up to $500 per customer off air source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares de descuento por cliente en bombas de calor de fuente de aire. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-74",
@@ -1747,7 +1747,7 @@
       "en": "Up to $500 per customer off ground source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares por cliente en descuentos para bombas de calor geotérmicas. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-75",
@@ -1908,7 +1908,7 @@
       "en": "Up to $500 per customer off air source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares de descuento por cliente en bombas de calor de fuente de aire. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-82",
@@ -1932,7 +1932,7 @@
       "en": "Up to $500 per customer off ground source heat pumps. Efficiency minimums apply.",
       "es": "Hasta $500 dólares en descuentos por cliente en bombas de calor geotérmicas. Mínimos de eficiencia aplican."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-83",
@@ -3499,8 +3499,8 @@
       "en": "Up to $750/ton for qualifying Cold Climate Air Source Heat Pumps (maximum 50% of material cost). Rebate amount dependent upon equipment capacity.",
       "es": "Hasta $750 dólares/tonelada para bombas de calor de fuente de aire de clima frío que cumplan los requisitos (máximo 50% del costo del material). El monto del reembolso depende de la capacidad del equipo."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "CO-153",
@@ -3522,8 +3522,8 @@
       "en": "Up to $350/ton for qualifying base tier Air Source Heat Pumps (maximum 50% of material cost). Rebate amount dependent upon equipment capacity.",
       "es": "Hasta $350 dólares/tonelada para bombas de calor de fuente de aire certificadas de nivel básico (máximo 50% del costo del material). El monto del reembolso depende de la capacidad del equipo."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "CO-154",
@@ -3589,8 +3589,8 @@
       "en": "Up to $750/ton for qualifying Air-to-Water Heat Pumps (maximum 50% of material cost). Rebate amount dependent upon equipment capacity.",
       "es": "Hasta $750 dólares/tonelada para bombas de calor de aire a agua certificadas (con un máximo 50% del costo del material). El monto del reembolso depende de la capacidad del equipo."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "CO-157",
@@ -4230,7 +4230,7 @@
       "en": "Up to $350 per unit for induction cooktops measuring 30\" or larger. New appliances only.",
       "es": "Hasta $350 dólares por unidad para parrillas de inducción de 30 pulgadas o más. Sólo electrodomésticos nuevos."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-186",
@@ -4252,7 +4252,7 @@
       "en": "$25 per WiFi-enabled smart thermostat.",
       "es": "$25 dólares por termostato inteligente con WiFi."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-187",
@@ -4276,7 +4276,7 @@
       "en": "Up to $90 for ENERGY STAR clothes dryers.",
       "es": "Hasta $90 dólares para secadoras de ropa ENERGY STAR."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-188",
@@ -4298,7 +4298,7 @@
       "en": "Up to $350 for ENERGY STAR® rated heat pump (air source) water heaters with 30 gallon minimum.",
       "es": "Hasta $350 dólares para calentadores de agua con bomba de calor (fuente de aire) con clasificación ENERGY STAR® y capacidad mínima de 30 galones."
     },
-    "end_date": 2023,
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -4322,7 +4322,7 @@
       "en": "Up to $500 per ton for ground source heat pumps ($250/ton for replacements), with additional $120 for hot water (desuperheater).",
       "es": "Hasta $500 dólares por tonelada para bombas de calor geotérmicas ($250 dólares/tonelada para sustituciones), con $120 dólares adicionales para agua caliente (regulador del vapor sobrecalentado)."
     },
-    "end_date": 2023,
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -4346,7 +4346,7 @@
       "en": "$16 per kilowatt (kW) for Electric Thermal Storage controlled by timer or master control system. Energy audit recommended.",
       "es": "$16 dólares por kilowatt (kW) para almacenamiento térmico eléctrico controlado por temporizador o sistema de control maestro."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-191",
@@ -4369,7 +4369,7 @@
       "en": "Up to $1,800 for qualifying Tier 1 (standard climate) Air Source Heat Pumps, capped at 50% of equipment cost.",
       "es": "Hasta $1,800 dólares para bombas de calor de fuente de aire de nivel 1 (clima estándar) certificadas, con un tope del 50% del costo del equipo."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-192",
@@ -4392,7 +4392,7 @@
       "en": "Up to $2,400 for qualifying Tier 2 Cold Climate Air Source Heat Pumps, capped at 50% of equipment cost.",
       "es": "Hasta $2,400 dólares para bombas de calor de fuente de aire de clima frío de nivel 2 certificadas, con un tope del 50% del costo del equipo."
     },
-    "end_date": 2023,
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -4416,7 +4416,7 @@
       "en": "$450 per ton rebate for air-to-water heat pump units.",
       "es": "Un reembolso de $450 dólares por tonelada para unidades de bomba de calor de aire a agua."
     },
-    "end_date": 2023,
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -4439,7 +4439,7 @@
       "en": "$100 rebate for whole house fans for replacement or new installations. Rebates not issued for powered attic ventilators.",
       "es": "Un reembolso de $100 dólares de ventiladores para toda la casa para reemplazos o nuevas instalaciones. El reembolso no aplica a ventiladores de desván motorizados."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-195",
@@ -4461,7 +4461,7 @@
       "en": "$200 rebate per unit for minimum 2,500 CFM evaporative coolers. Replacements or new installations qualify. No window or portable units.",
       "es": "Un reembolso de $200 dólares por unidad para enfriadores por evaporación de un mínimo de 2,500 CFM. Reemplazos o nuevas instalaciones califican. No se aceptan unidades de ventana o portátiles."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-196",
@@ -4485,7 +4485,7 @@
       "en": "25% of cost up to $1,000 for electric riding mower.",
       "es": "25% del costo para podadora de césped eléctrica con asiento, hasta $1,000 dólares."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-197",
@@ -4509,7 +4509,7 @@
       "en": "25% of the cost up to $150 for electric mower (walk-behind) or electric bicycle.",
       "es": "Un 25% del costo de podadora de césped eléctrica (de operador a pie) o bicicleta eléctrica, hasta $150 dólares."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-198",
@@ -4533,7 +4533,7 @@
       "en": "25% of the cost up to $150 for a single-stage snow blower and up to $250 for a 2-stage snow blower.",
       "es": "25% del costo de un soplador de nieve de una etapa y hasta $250 por uno de dos etapas, hasta $150 dólares."
     },
-    "end_date": 2023,
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -4558,7 +4558,7 @@
       "en": "25% of cost up to $100 for electric chainsaws.",
       "es": "Un 25% del costo de motosierras eléctricas, hasta $100 dólares."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-200",
@@ -4582,7 +4582,7 @@
       "en": "25% of cost up to $50 for an electric blower, power-washer, pruner, and trimmer.",
       "es": "25% del costo para comprar un soplador eléctrico, una hidrolimpiadora, una podadora y una recortadora, hasta $50 dólares."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-201",
@@ -4606,7 +4606,7 @@
       "en": "Additional Battery Rebate: 50% of the cost up to $25.",
       "es": "Reembolso por batería adicional: 50% del costo, hasta $25 dólares."
     },
-    "end_date": 2023,
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -4630,7 +4630,7 @@
       "en": "50% of total equipment and installation costs up to $500 for non-managed Level 2 Electric Vehicle chargers. Limit 2 chargers per member account.",
       "es": "Un 50% de los costos totales de equipamiento e instalación para cargadores de vehículos eléctricos de nivel 2 sin sistema de control, hasta $500 dólares. Límite de 2 cargadores por cuenta de socio."
     },
-    "end_date": 2023
+    "end_date": "2023"
   },
   {
     "id": "CO-203",
@@ -5251,8 +5251,8 @@
       "en": "$80 off for Energy Star rated clothes dryer.",
       "es": "Descuento de $80 dólares para secadora de ropa con clasificación ENERGY STAR."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-230",
@@ -5274,8 +5274,8 @@
       "en": "$90 off for Energy Star rated hybrid heat pump clothes dryer.",
       "es": "Descuento de $90 dólares en secadora de ropa híbrida con bomba de calor de clasificación ENERGY STAR."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-231",
@@ -5297,8 +5297,8 @@
       "en": "$350 off for heat pump water heater (30 gallon minimum).",
       "es": "$350 de descuento por calentador de agua con bomba de calor (30 galones mínimo)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-232",
@@ -5322,8 +5322,8 @@
       "en": "25% off up to $150 for Energy Star rated snow blower and walk-behind mower.",
       "es": "Un 25% de descuento en sopladoras de nieve y podadoras de césped manuales con clasificación ENERGY STAR, hasta $150 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-233",
@@ -5347,8 +5347,8 @@
       "en": "25% off up to $50 for Energy Star rated electric trimmers, pruners, blowers, and power-washers.",
       "es": "Un descuento del 25% hasta $50 dólares en recortadoras, podadoras, sopladoras y lavadoras eléctricas con clasificación ENERGY STAR."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-234",
@@ -5372,8 +5372,8 @@
       "en": "25% off up to $150 for Energy Star rated electric bicycles.",
       "es": "Un 25% de descuento en bicicletas eléctricas con clasificación ENERGY STAR, hasta $150 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-235",
@@ -5397,8 +5397,8 @@
       "en": "25% off up to $1,000 for Energy Star rated electric riding lawnmower.",
       "es": "25% de descuento en podadoras de céspedes eléctricas con clasificación ENERGY STAR, hasta $1,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-236",
@@ -5422,8 +5422,8 @@
       "en": "50% off up to $25 for additional battery purchase.",
       "es": "Un descuento del 50% por la compra de baterías adicionales, hasta $25 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-237",
@@ -5447,8 +5447,8 @@
       "en": "25% off up to $100 for Energy Star rated electric chainsaws.",
       "es": "Un 25% de descuento en motosierras eléctricas con clasificación ENERGY STAR, hasta $100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-238",
@@ -5472,8 +5472,8 @@
       "en": "Up to $50 off for Wifi enabled smart thermostat.",
       "es": "Hasta $50 dólares de descuento en termostato inteligente con Wifi."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-239",
@@ -5495,8 +5495,8 @@
       "en": "$200 off for evaporative cooler with a minimum of 2,500 CFM.",
       "es": "Un descuento de $200 dólares para un enfriador por evaporación con un mínimo de 2,500 CFM."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-240",
@@ -5518,8 +5518,8 @@
       "en": "$100 off for whole house fan.",
       "es": "Un descuento de $100 dólares para un ventilador de casa completa."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-241",
@@ -5542,8 +5542,8 @@
       "en": "$40/KW off for Electric Thermal Storage (ETS) unit.",
       "es": "Un descuento de $40 dólares/KW para una unidad de almacenamiento térmico eléctrico (o ETS)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-242",
@@ -5566,8 +5566,8 @@
       "en": "$12/KW off for Electric Thermal Storage (ETS) thermal slab.",
       "es": "Un descuento de $12 dólares/KW para una losa de calor de Almacenamiento Térmico Eléctrico (o ETS, por sus siglas en inglés)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-243",
@@ -5590,8 +5590,8 @@
       "en": "60% off up to $450 for roof insulation upgrade.",
       "es": "Un 60% de descuento para actualizar el aislamiento de techo, hasta $450 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-244",
@@ -5614,8 +5614,8 @@
       "en": "60% off up to $350 for wall insulation upgrade.",
       "es": "Un 60% de descuento para actualizar el aislamiento de muros, hasta $350 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-245",
@@ -5638,8 +5638,8 @@
       "en": "60% off up to $350 for floor insulation upgrade.",
       "es": "Un 60% de descuento para actualizar el aislamiento térmico de pisos, hasta $350 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-246",
@@ -5662,8 +5662,8 @@
       "en": "50% off up to $2,300 for Tier 1 standard air-source heat pump (HSPF>= 9 SEER >=15).",
       "es": "Un 50% de descuento para una bomba de calor de aire estándar de nivel 1 (HSPF>= 9 SEER >=15), hasta $2,300 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-247",
@@ -5686,8 +5686,8 @@
       "en": "50% off up to $2,900 for Tier 2 cold climate air-source heat pump (HSPF>= 10 SEER >=16).",
       "es": "Un 50% de descuento para una bomba de calor con fuente de aire de nivel 2 para climas fríos (HSPF>= 10 SEER >=16), hasta $2,900 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-248",
@@ -5710,8 +5710,8 @@
       "en": "$500 off for qualifying plug-in electric vehicle.",
       "es": "Un descuento de $500 dólares por vehículo eléctrico enchufable que cumpla los requisitos."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-249",
@@ -5734,8 +5734,8 @@
       "en": "$500 off for qualifying plug-in electric vehicle.",
       "es": "Un descuento de $500 dólares por vehículo eléctrico enchufable que cumpla los requisitos."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-250",
@@ -5758,8 +5758,8 @@
       "en": "50% off up to $500 for equipment and electric service installation for Level 2 chargers (non-managed rate program).",
       "es": "Un 50% de descuento de hasta $500 en equipos e instalación de servicios eléctricos para cargadores de Nivel 2 (programa de tarifas para sistemas sin control)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-251",
@@ -5782,8 +5782,8 @@
       "en": "50% off up to $1,000 for equipment and electric service installation for Level 2 chargers (managed TOU rate program).",
       "es": "Un 50% de descuento hasta $1,000 dólares en equipos e instalación de servicios eléctricos para cargadores de nivel 2 (programa de tarifas TOU con control)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-252",
@@ -5806,8 +5806,8 @@
       "en": "50% off up to $3,000 for equipment and installation for Direct Current Fast Charger (DCFC) with 50KW peak output.",
       "es": "Un descuento del 50% para equipo e instalación de un cargador rápido de corriente directa (DCFC) con potencia máxima de 50 kW, hasta $3,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-253",
@@ -5830,8 +5830,8 @@
       "en": "50% off up to $5,000 for equipment and installation for Direct Current Fast Charger (DCFC) with 100KW+ peak output.",
       "es": "Un 50% de descuento en equipos e instalación para cargador rápido de corriente directa (DCFC) con salida pico de 100KW+, hasta $5,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-254",
@@ -5854,8 +5854,8 @@
       "en": "Up to $750/ton not to exceed 50% of equipment cost for ground-source heat pumps.",
       "es": "Hasta $750 dólares/tonelada sin superar el 50% del costo del equipo para bombas de calor geotérmicas."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -6050,8 +6050,8 @@
       "en": "$100 rebate for Residential Energy Audit.",
       "es": "Reembolso de $100 dólares para una auditoría de consumo de energía doméstica."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-264",
@@ -7238,7 +7238,7 @@
       "en": "State tax credit of $5,000 for the purchase or lease of a new EV (max MSRP: $80,000).",
       "es": "Crédito fiscal estatal de $5,000 dólares por la compra o el alquiler de un VE nuevo (MSRP máximo: $80,000 dólares)."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-317",
@@ -7261,8 +7261,8 @@
       "en": "Additional state tax credit of $2,500 for Coloradans purchasing or leasing an EV with a max MSRP of $35,000.",
       "es": "Crédito fiscal estatal adicional de $2,500 dólares para los habitantes de Colorado que compren o alquilen un VE con un precio máximo de $35,000 dólares."
     },
-    "start_date": 2024,
-    "end_date": 2029
+    "start_date": "2024",
+    "end_date": "2029"
   },
   {
     "id": "CO-318",
@@ -7331,7 +7331,7 @@
       "en": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption.",
       "es": "Un descuento del 12.9% sobre el precio del equipamiento de bombas de calor y calentadores de agua con bomba de calor, gracias a una condonación fiscal del estado de Colorado y una bonificación del impuesto sobre las ventas."
     },
-    "start_date": 2023,
+    "start_date": "2023",
     "bonus_available": true
   },
   {
@@ -7355,7 +7355,7 @@
       "en": "12.9% discount on battery storage systems through Colorado State tax credit and sales tax exemption.",
       "es": "Un descuento del 12.9% en sistemas de almacenamiento en batería gracias a una condonación fiscal por parte del estado de Colorado y una bonificación del impuesto sobre las ventas."
     },
-    "start_date": 2023
+    "start_date": "2023"
   },
   {
     "id": "CO-322",
@@ -7378,8 +7378,8 @@
       "en": "50% of costs, up to $650 for ENERGY STAR Ground Source Heat Pumps with desuperheater.",
       "es": "El 50% de los costos de bombas de calor geotérmicas ENERGY STAR con regulador de vapor sobrecalentado, hasta $650 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-323",
@@ -7402,8 +7402,8 @@
       "en": "50% of costs, up to $400 for 'Cold Climate' Rated Ducted Air Source Heat Pump (ASHP) (incl. Mini-Splits Cooling & Heating units).",
       "es": "50% de los costos para bomba de calor de fuente de aire con ductos (ASHP) con calificación de \"clima frío\" (incl. unidades mini-splits de refrigeración y calefacción), hasta $400 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-324",
@@ -7426,8 +7426,8 @@
       "en": "50% of costs, up to $400 for 'Cold Climate' Rated Ductless Air Source Heat Pump (ASHP) (incl. Mini-Splits Cooling & Heating units).",
       "es": "50% de los costos para bombas de calor sin ductos (ASHP) con clasificación de \"clima frío\" (incl. unidades mini-splits de refrigeración y calefacción) , hasta $400 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-325",
@@ -7450,8 +7450,8 @@
       "en": "50% of costs, up to $400 for ENERGY STAR Ground Source Heat Pump (no desuperheater).",
       "es": "50% de los costos, hasta $400 dólares para bomba de calor geotérmica ENERGY STAR (sin regulador de vapor sobrecalentado)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-326",
@@ -7474,8 +7474,8 @@
       "en": "50% of costs, up to $250 for 'Non-Cold' Climate Ducted Air Source Heat Pump (ASHP) (incl. Mini-Split Cooling & Heating units) with HSPF 8.5/SEER 15",
       "es": "50% de los costos para bombas de calor de fuente de aire (ASHP) con ductos (incluyendo unidades mini-splits de refrigeración y calefacción) con HSPF 8.5/SEER 15, hasta $250 dólares"
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-327",
@@ -7498,8 +7498,8 @@
       "en": "50% of costs, up to $250 for 'Non-Cold' Climate Ductless Air Source Heat Pump (ASHP) with HSPF 8.5/SEER 15",
       "es": "50% de los costos para clima \"no frío\" de bomba de calor de fuente de aire sin ductos (ASHP) con HSPF 8.5/SEER 15, hasta $250 dólares"
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-328",
@@ -7522,8 +7522,8 @@
       "en": "50% of costs, up to $250 for ENERGY STAR Electric Heat Pump Water Heater (minimum 2.00 Energy Factor)",
       "es": "50% de los costos de calentador eléctrico de agua con bomba de calor ENERGY STAR (factor energético mínimo de 2.00), hasta $250 dólares"
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-329",
@@ -7546,8 +7546,8 @@
       "en": "50% of costs, up to $250 for Attic Insulation & Air Sealing.",
       "es": "50% de los costos para aislamiento térmico y sellado hermético del desván, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-330",
@@ -7570,8 +7570,8 @@
       "en": "50% of costs, up to $250 for Wall Insulation.",
       "es": "50% de los costos para el aislamiento térmico de muros, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-331",
@@ -7594,8 +7594,8 @@
       "en": "50% of costs, up to $250 for Foundation (Crawl Space or Basement) Insulation & Air Sealing.",
       "es": "50% de los costos para aislamiento térmico de muros, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-332",
@@ -7618,8 +7618,8 @@
       "en": "50% of costs, up to $250 for Sub-Floor or Frame Floor Insulation & Air Sealing.",
       "es": "50% de los costos para aislamiento térmico y sellado hermético del subsuelo o del piso de la estructura, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-333",
@@ -7642,8 +7642,8 @@
       "en": "50% of costs, up to $250 for Professionally Applied Air Sealing, and Duct Insulation. Do-it-yourself not eligible.",
       "es": "50% de los costos para sellado hermético y aislamiento de ductos realizados por un profesional. Los trabajos hechos por usted mismo no son elegibles, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-334",
@@ -7666,8 +7666,8 @@
       "en": "50% of costs, up to $250 for Duct Insulation.",
       "es": "50% de los costos para aislamiento de ductos, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-335",
@@ -7712,8 +7712,8 @@
       "en": "$500 rebate for removing a natural gas furnace or boiler and installing an air or ground source heat pump.",
       "es": "Un reembolso de $500 dólares por retirar un horno o una caldera de gas natural e instalar una bomba de calor de fuente de aire o de tierra."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7736,8 +7736,8 @@
       "en": "$500 rebate for modifying a natural gas furnace with a heat pump add-on.",
       "es": "Un reembolso de $500 dólares por modificar un horno de gas natural con un aditamento de bomba de calor."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7760,8 +7760,8 @@
       "en": "$500 rebate for removing a natural gas water heater and replacing it with an electric water heater.",
       "es": "Un reembolso de $500 dólares por retirar un calentador de agua de gas natural y sustituirlo por uno eléctrico."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7784,8 +7784,8 @@
       "en": "$200 rebate for removing a natural gas stove/cooktop and replacing it with an electric cooktop or stove.",
       "es": "Un reembolso de $200 dólares por retirar una estufa o parrilla de gas natural y sustituirla por una estufa o parrilla eléctrica."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-340",
@@ -7829,8 +7829,8 @@
       "en": "Rebate for 25% of project costs up to $300 for a “Cold Climate” Ducted Air Source\nHeat Pump.",
       "es": "Un reembolso del 25% de los costos del proyecto de hasta $300 dólares para una bomba de calor con ductos de fuente de aire para \"clima frío\"."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7854,8 +7854,8 @@
       "en": "Rebate for 25% of project costs up to $300 for a “Cold Climate” Ductless (Mini-Split) Air Source Heat Pump.",
       "es": "Un reembolso del 25% de los costos del proyecto de hasta $300 dólares para una bomba de calor sin ductos (mini-splits) de fuente de aire para \"clima frío\"."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7879,8 +7879,8 @@
       "en": "Rebate for 25% of project costs up to $300 for a Ground Source Heat Pump.",
       "es": "Un reembolso del 25% de los costos del proyecto para una bomba de calor geotérmica, hasta $300 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7904,8 +7904,8 @@
       "en": "Rebate for 25% of project costs up to $200 for Solar PV in conjunction with air or ground source heat pump installation or owning an EV.",
       "es": "Un reembolso del 25% de los costos del proyecto para energía solar fotovoltaica junto con la instalación de una bomba de calor de fuente de aire o de tierra o por poseer un VE, hasta $200 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-345",
@@ -7928,8 +7928,8 @@
       "en": "Rebate for 25% of project costs up to $100 for a “Non-Cold Climate” Ducted Air Source\nHeat Pump.",
       "es": "Un reembolso del 25% de los costos del proyecto para una bomba de calor de fuente de aire para \"clima no frío\" con ductos, hasta $100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7953,8 +7953,8 @@
       "en": "Rebate for 25% of project costs up to $100 for a “Non-Cold Climate” Ductless (Mini-Split) Air Source Heat Pump.",
       "es": "Un reembolso del 25% de los costos del proyecto de hasta $100 dólares para una bomba de calor de fuente de aire sin ductos (mini-splits) para \"climas no fríos\"."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -7978,8 +7978,8 @@
       "en": "Rebate for 25% of project costs up to $100 for Attic Insulation with Air Sealing.",
       "es": "Un reembolso del 25% de los costos del proyecto para aislamiento térmico y sellado hermético del desván, hasta $100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8003,8 +8003,8 @@
       "en": "Rebate for 25% of project costs up to $100 for Wall Insulation.",
       "es": "Un reembolso del 25% de los costos del proyecto hasta $100 dólares para aislamiento térmico de muros."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8028,8 +8028,8 @@
       "en": "Rebate for 25% of project costs up to $100 for Foundation (Basement or Crawl\nSpace) Insulation and Air Sealing.",
       "es": "Un reembolso del 25% de los costos del proyecto para el aislamiento y sellado hermético de cimientos (sótanos o espacios reducidos), hasta $100 dólares"
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8053,8 +8053,8 @@
       "en": "Rebate for 25% of project costs up to $100 for ENERGY STAR Electric Heat Pump\nWater Heater.",
       "es": "Un reembolso del 25% de los costos del proyecto para un calentador de agua eléctrico con bomba de calor ENERGY STAR, hasta 100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8078,8 +8078,8 @@
       "en": "$100 rebate for an electric stove if you remove a gas stove.",
       "es": "Un reembolso de $100 dólares por una estufa eléctrica si retira una estufa de gas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-352",
@@ -8102,8 +8102,8 @@
       "en": "Receive 25% of project cost up to $400 for 'Cold Climate' Ducted Air Source Heat Pump.",
       "es": "Reciba un 25% del costo del proyecto, hasta $400 dólares, por una bomba de calor de fuente de aire con ductos para \"Clima frío\"."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8127,8 +8127,8 @@
       "en": "Receive 25% of project cost up to $400 for 'Cold Climate' Ductless (Mini-Split) Air Source Heat Pump.",
       "es": "Reciba un 25% del costo del proyecto, hasta $400 dólares, por una bomba de calor de fuente de aire sin ductos (mini-splits) para \"clima frío\"."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8152,8 +8152,8 @@
       "en": "Receive 25% of project cost up to $300 for Electric Panel Upgrade.",
       "es": "Reciba el 25% del costo del proyecto hasta un máximo de $300 dólares para actualizar el centro de carga."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-355",
@@ -8176,8 +8176,8 @@
       "en": "Receive 25% of project cost up to $250 for 'Non-Cold' Climate Ducted Air Source Heat Pump.",
       "es": "Reciba un 25% del costo del proyecto por una bomba de calor de fuente de aire con ductos para climas \"no fríos\", hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8201,8 +8201,8 @@
       "en": "Receive 25% of project cost up to $250 for 'Non-Cold' Climate Ductless Air Source Heat Pump.",
       "es": "Reciba un 25% del costo del proyecto por una bomba de calor de fuente de aire sin ductos para climas \"no fríos\", hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8226,8 +8226,8 @@
       "en": "Receive 25% of project cost up to $250 for Ceiling/Attic Insulation.",
       "es": "Reciba el 25% del costo de un proyecto de aislamiento térmico del techo/desván, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-358",
@@ -8250,8 +8250,8 @@
       "en": "Receive 25% of project cost up to $250 for Wall Insulation.",
       "es": "Reciba el 25% del costo de un proyecto de aislamiento térmico de muros, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-359",
@@ -8274,8 +8274,8 @@
       "en": "Receive 25% of project cost up to $250 for Underbelly and Behind Exterior Skirting 'Burrito' Insulation.",
       "es": "Reciba un 25% del costo de proyecto, hasta un máximo de $250 dólares, para aislamiento térmico del \"burrito\" bajo el revestimiento y detrás del faldón exterior."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-360",
@@ -8298,8 +8298,8 @@
       "en": "Receive 25% of project cost up to $250 for ENERGY STAR Electric Heat Pump Water Heaters or Electric Water Heater.",
       "es": "Reciba el 25% del costo del proyecto hasta $250 para calentadores de agua eléctricos con bomba de calor o calentadores de agua eléctricos ENERGY STAR."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8323,8 +8323,8 @@
       "en": "Receive 25% of project cost up to $250 for All-Electric Cooktop.",
       "es": "Reciba el 25% del costo del proyecto para una parrilla completamente eléctrica, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8349,8 +8349,8 @@
       "en": "Receive 25% of project cost up to $250 for Rooftop and wall mounted permanent units.",
       "es": "Reciba el 25% del costo del proyecto hasta $250 para las unidades permanentes instaladas en el techo y en la pared."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-363",
@@ -8373,8 +8373,8 @@
       "en": "Receive 25% of project cost up to $250 for Storm Windows.",
       "es": "Reciba un 25% del costo del proyecto para ventanas a prueba de tormentas, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-364",
@@ -8397,8 +8397,8 @@
       "en": "Receive 25% of project cost up to $250 for Heat Pump Clothes Dryer.",
       "es": "Reciba un 25% del costo del proyecto por una secadora de ropa con bomba de calor, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -8422,8 +8422,8 @@
       "en": "Receive 25% of project cost up to $50 for Insulated/Cellular Shades.",
       "es": "Reciba un 25% del costo del proyecto hasta un máximo de $50 dólares por persianas aislantes/de panal."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-366",
@@ -8446,8 +8446,8 @@
       "en": "Receive 25% of project cost up to $50 for Portable Heat Pump.",
       "es": "Reciba un 25% del costo del proyecto hasta $50 dólares por una bomba de calor portátil."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-367",
@@ -8470,8 +8470,8 @@
       "en": "Receive 25% of project cost up to $50 for Smart Thermostat.",
       "es": "Reciba el 25% del costo del proyecto por un termostato inteligente, hasta $50 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-368",
@@ -8811,8 +8811,8 @@
       "en": "Rebate for 25% of the cost up to $150 for walk-behind mower or bicycles.",
       "es": "Un reembolso del 25% del costo de hasta $150 dólares para podadoras  de césped de operador a pie o bicicletas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-383",
@@ -8836,8 +8836,8 @@
       "en": "Rebate for 25% of the cost up to $250 for electric snow blowers.",
       "es": "Un reembolso del 25% del costo de sopladoras de nieve eléctricas, hasta $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-384",
@@ -8861,8 +8861,8 @@
       "en": "Rebate for 25% of the cost up to $50 for electric leaf blower, pruner, trimmer and power washer.",
       "es": "Reembolso del 25% del costo de una sopladora eléctrica de hojas, podadora, recortadora y lavadora eléctrica, hasta $50 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-385",
@@ -8886,8 +8886,8 @@
       "en": "Rebate for 25% of the cost up to $100 for electric chainsaws.",
       "es": "Reembolso del 25% del costo, de motosierras eléctricas, hasta $100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-386",
@@ -8911,8 +8911,8 @@
       "en": "Rebate for 25% of the cost up to $1,000 for electric riding mowers.",
       "es": "Reembolso del 25% del costo de una podadora de césped eléctrica con asiento, hasta $1,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-387",
@@ -8936,8 +8936,8 @@
       "en": "Rebate for 25% of the cost up to $25 for additional batteries purchased with or for qualifying equipment.",
       "es": "Reembolso del 25% del costo de baterías adicionales compradas con o para equipos certificados, hasta $25 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-388",
@@ -8961,8 +8961,8 @@
       "en": "Up to $350 rebate for induction cooktops/ranges (measuring 30\" or larger), depending on previous fuel source.",
       "es": "Reembolso de hasta $350 dólares para estufas/parrillas de inducción (que midan 30 pulgadas o más), dependiendo de la fuente de combustible anterior."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-389",
@@ -8984,8 +8984,8 @@
       "en": "$180 rebate per heat pump clothes dryer.",
       "es": "Reembolso de $180 dólares para una secadora de ropa con bomba de calor."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-390",
@@ -9008,8 +9008,8 @@
       "en": "$850 rebate per ton for new installations of ground source heat pumps.",
       "es": "Un reembolso de $850 dólares por tonelada para nuevas instalaciones de bombas de calor geotérmicas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-391",
@@ -9032,8 +9032,8 @@
       "en": "$425 rebate per ton for existing unit replacements of ground source heat pumps.",
       "es": "Reembolso de $425 dólares por tonelada para la sustitución de unidades existentes de bombas de calor geotérmicas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-392",
@@ -9055,8 +9055,8 @@
       "en": "$100 rebate per unit for ground source heat pump powered water heaters.",
       "es": "Reembolso de $100 dólares por unidad para calentadores de agua alimentados por bomba de calor geotérmica."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-393",
@@ -9080,8 +9080,8 @@
       "en": "$675 rebate for non-Cold-Climate Air Source Heat Pumps less than or equal to 2 tons, $1800 for greater than 2 tons.",
       "es": "Reembolso de $675 dólares para bombas de calor de fuente de aire para clima no frío de menos o igual a 2 toneladas, $1,800 dólares para las de más de 2 toneladas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-394",
@@ -9105,8 +9105,8 @@
       "en": "$1000 rebate for Cold-Climate Air Source Heat Pumps less than or equal to 2 tons, $2400 for greater than 2 tons (Tier 2).",
       "es": "Reembolso de $1,000 dólares para bombas de calor de fuente de aire para clima frío de menos o igual a 2 toneladas, $2,400 dólares para las de más de 2 toneladas (Nivel 2)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-395",
@@ -9130,8 +9130,8 @@
       "en": "$50 rebate per smart thermostat (limit 2).",
       "es": "Reembolso de $50 dólares para termostatos inteligentes (límite 2)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-396",
@@ -9153,8 +9153,8 @@
       "en": "$375 rebate per unit for ENERGY STAR heat pump water heaters.",
       "es": "Reembolso de $375 dólares por unidad para calentadores de agua con bomba de calor con certificación ENERGY STAR."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-397",
@@ -9177,8 +9177,8 @@
       "en": "50% rebate up to $500 non-managed or $1,000 for member system managed Level 2 EC Chargers.",
       "es": "Reembolso del 50% , hasta $500 para los que no tengan sistema de control o $1,000 dólares para cargadores EC de Nivel 2 con sistema de control administrado por afiliados."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-398",
@@ -9201,8 +9201,8 @@
       "en": "50% rebate up to $7,500 for DC Fast Chargers.",
       "es": "Reembolso del 50%  para cargadores rápidos de corriente directa, hasta $7,500 dólares"
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CO-399",

--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -44,8 +44,8 @@
       "en": "$1,500 per ton after-purchase rebate for qualifying ground source heat pumps, up to $15,000.",
       "es": "Un reembolso de $1,500 dólares por tonelada después de la compra para bombas de calor geotérmicas que se ajusten a los requisitos, hasta un máximo de $15,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-3",
@@ -67,8 +67,8 @@
       "en": "$650 off eligible Energy Star certified Heat Pump Water Heaters.",
       "es": "Un de descuento de $650 dólares en calentadores de agua con bomba de calor con certificación Energy Star."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-4",
@@ -116,8 +116,8 @@
       "en": "Attic insulation rebate up to $5,000 for homes with electric heating and A/C. Must have a home energy inspection and work with a licensed contractor.",
       "es": "Un reembolso de hasta $5,000 dólares para aislamiento del ático para hogares equipados con calefacción y aire acondicionado eléctricos. Debe someterse a una inspección de consumo energético de la vivienda y trabajar con un contratista autorizado."
     },
-    "start_date": 2022,
-    "end_date": 2023
+    "start_date": "2022",
+    "end_date": "2023"
   },
   {
     "id": "CT-6",
@@ -139,8 +139,8 @@
       "en": "Rebate for the full cost up to $2,500 for a qualifying heat pump water heater. Apply within 30 days of installation and use a licensed contractor.",
       "es": "Un reembolso del costo total o hasta $2,500 dólares para un calentador de agua con bomba de calor que cumpla los requisitos. Solicítelo en los 30 días siguientes a la instalación y utilice un contratista autorizado."
     },
-    "start_date": 2022,
-    "end_date": 2023
+    "start_date": "2022",
+    "end_date": "2023"
   },
   {
     "id": "CT-7",
@@ -183,8 +183,8 @@
       "en": "Rebate for the full cost up to $500 off an eligible high-efficiency heat pump clothes dryer.",
       "es": "Un reembolso por el costo total de hasta $500 dólares para una secadora de ropa con bomba de calor de alta eficiencia que cumpla los requisitos."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-9",
@@ -208,8 +208,8 @@
       "en": "Rebate of $1 per square foot for wall insulation, up to $8,000 total lifetime rebate. Must be installed by a licensed contractor.",
       "es": "Un reembolso de $1 dólar por pie cuadrado para material aislante de paredes, hasta un total de $8,000 dólares de reembolso vitalicio. Debe instalarlo un contratista autorizado."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-10",
@@ -233,8 +233,8 @@
       "en": "Rebate of $1.50 per square foot for attic insulation, up to $8,000 total lifetime rebate. Must be installed by a licensed contractor.",
       "es": "Un reembolso de $1.50 de dólar por pie cuadrado para aislamiento del ático, hasta un total de $8,000 dólares de reembolso vitalicio. Debe instalarlo un contratista autorizado."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-11",
@@ -258,8 +258,8 @@
       "en": "Rebate off a qualifying heat pump system, dependent on size. Typical heat pump installations will receive approximately $900.",
       "es": "Un reembolso por un sistema de bomba de calor autorizado, en función del tamaño. Las instalaciones típicas de bombas de calor recibirán aproximadamente $900 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-12",
@@ -283,8 +283,8 @@
       "en": "Size dependent rebate off installation of an air source heat pump replacing oil or gas, up to $20,000. Obtain pre-approval from NPU beforehand.",
       "es": "Un reembolso por instalación de una bomba de calor de fuente de aire que sustituya al gasóleo o al gas, de hasta $20,000 dólares según el tamaño. Debe obtener previamente la aprobación del NPU."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-13",
@@ -306,8 +306,8 @@
       "en": "Rebate of $1,100 toward a qualifying heat pump water heater if installed during heat pump HVAC installation.",
       "es": "Un reembolso de $1,100 dólares para un calentador de agua con bomba de calor apto y si se coloca durante la instalación del sistema de calefacción, ventilación y aire acondicionado con bomba de calor."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-15",
@@ -331,8 +331,8 @@
       "en": "$750 per ton after-purchase rebate for qualifying air source heat pumps.",
       "es": "Un reembolso de $750 dólares por tonelada después de la compra de bombas de calor con fuente de aire que cumplan los requisitos."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-16",
@@ -356,8 +356,8 @@
       "en": "$1,500 per ton after-purchase rebate for qualifying ground source heat pumps, up to $15,000.",
       "es": "Un reembolso de $1,500 dólares por tonelada después de la compra para bombas de calor geotérmicas que cumplan los requisitos, con un pago máximo de $15,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-17",
@@ -379,8 +379,8 @@
       "en": "$650 off eligible Energy Star certified Heat Pump Water Heaters.",
       "es": "Un descuento de $650 dólares en calentadores de agua con bomba de calor que tengan certificación Energy Star."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-20",
@@ -404,8 +404,8 @@
       "en": "$750 per ton after-purchase rebate for qualifying air source heat pumps.",
       "es": "Un reembolso después de la compra de $750 dólares por tonelada para bombas de calor con fuente de aire que sean aptas."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-24",
@@ -429,8 +429,8 @@
       "en": "Size dependent rebate off qualifying ground source heat pumps, up to $20,000.",
       "es": "Un reembolso de hasta $20,000 dólares en bombas de calor geotérmicas que cumplan los requisitos, y según su tamaño."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "CT-25",
@@ -452,8 +452,8 @@
       "en": "Bonus $500 off ground source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months.",
       "es": "Una bonificación de $500 dólares para la instalación de una bomba de calor geotérmica si se ha aplicado aislamiento térmico por medio de Energize CT Home Energy Solutions en los 12 meses anteriores."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-26",
@@ -475,8 +475,8 @@
       "en": "Bonus $500 off air source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months.",
       "es": "Una bonificación de $500 dólares para la instalación de una bomba de calor de fuente de aire si en los 12 meses previos se instaló aislamiento térmico por medio de Energize CT Home Energy Solutions."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-27",
@@ -498,8 +498,8 @@
       "en": "Bonus $500 off air source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months.",
       "es": "Una bonificación de $500 dólares para la instalación de una bomba de calor de fuente de aire si en los 12 meses previos se instaló aislamiento térmico por medio de Energize CT Home Energy Solutions."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-28",
@@ -521,8 +521,8 @@
       "en": "Bonus $500 off ground source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months.",
       "es": "Una bonificación de $500 dólares en la instalación de una bomba de calor geotérmica si se instaló aislamiento térmico mediante Energize CT Home Energy Solutions en el período de los 12 meses previos."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "CT-29",
@@ -545,8 +545,8 @@
       "en": "Rebate up to $1,500 for purchasing a new EV (model year 2020 or newer). Can be combined with federal, state, or manufacturer incentives.",
       "es": "Un reembolso de hasta $1,500 dólares por comprar un VE nuevo (modelo del año 2020 o más reciente). Puede combinarse con incentivos federales, estatales o del fabricante."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "CT-30",
@@ -569,8 +569,8 @@
       "en": "Rebate up to $1,000 for purchasing a used EV (model year 2019 or newer). Can be combined with federal, state, or manufacturer incentives.",
       "es": "Un reembolso de hasta $1,000 dólares por comprar un VE usado (modelo del año 2019 o más reciente). Puede combinarse con incentivos federales, estatales o del fabricante."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "CT-31",
@@ -592,8 +592,8 @@
       "en": "$1,000 rebate for purchasing a residential use Level 2 EVSE. Must apply within 60 days of installation.",
       "es": "Un reembolso de $1,000 dólares por la compra de un EVSE de Nivel 2 para uso residencial. Debe solicitarse en los 60 días siguientes a la instalación."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "CT-32",

--- a/data/DC/incentives.json
+++ b/data/DC/incentives.json
@@ -20,8 +20,8 @@
     "short_description": {
       "en": "$75-$200 rebate for ENERGY STAR® or ENERGY STAR® Most Efficient qualified clothes dryers."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "DC-4",
@@ -43,8 +43,8 @@
     "short_description": {
       "en": "$75 rebate for electric push lawn mowers."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "DC-5",
@@ -66,8 +66,8 @@
     "short_description": {
       "en": "$500 rebate for electric riding lawn mowers."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "DC-7",
@@ -89,8 +89,8 @@
     "short_description": {
       "en": "$50 rebate for ENERGY STAR® qualified smart thermostats."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "DC-9",
@@ -113,8 +113,8 @@
     "short_description": {
       "en": "$375-$700 rebate for qualified ducted air source heat pump systems."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "DC-10",
@@ -137,8 +137,8 @@
     "short_description": {
       "en": "$375-$700 rebate for qualified variable speed (ductless) mini-split heat pumps systems."
     },
-    "start_date": 2023,
-    "end_date": 2024
+    "start_date": "2023",
+    "end_date": "2024"
   },
   {
     "id": "DC-12",
@@ -160,8 +160,8 @@
     "short_description": {
       "en": "100% of costs covered for switching to ducted heating systems. Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   },
   {
@@ -184,8 +184,8 @@
     "short_description": {
       "en": "100% of costs covered for switching to ductless heating systems. Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   },
   {
@@ -208,8 +208,8 @@
     "short_description": {
       "en": "100% of costs covered for switching to electric resistance stoves. Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   },
   {
@@ -232,8 +232,8 @@
     "short_description": {
       "en": "100% of costs covered for switching to induction cooktops. Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   },
   {
@@ -256,8 +256,8 @@
     "short_description": {
       "en": "100% of costs covered for switching to heat pump water heaters. Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   },
   {
@@ -280,8 +280,8 @@
     "short_description": {
       "en": "100% of costs covered for upgrading electrical panels. Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   },
   {
@@ -304,8 +304,8 @@
     "short_description": {
       "en": "100% of costs covered for home weatherization (insulation and air sealing). Income-qualified residents only."
     },
-    "start_date": 2023,
-    "end_date": 2024,
+    "start_date": "2023",
+    "end_date": "2024",
     "bonus_available": true,
     "low_income": "dc-dc-department-of-energy-and-environment-60-ami"
   },
@@ -329,8 +329,8 @@
     "short_description": {
       "en": "100% of costs covered for income-qualified homeowners to have solar photovoltaic (PV) systems installed by local contractors."
     },
-    "start_date": 2024,
-    "end_date": 2024,
+    "start_date": "2024",
+    "end_date": "2024",
     "low_income": "dc-dc-sustainable-energy-utility"
   }
 ]

--- a/data/GA/incentives.json
+++ b/data/GA/incentives.json
@@ -19,8 +19,8 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $250 for attic insulation. Addition of R-38 or greater required."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   },
   {
     "id": "GA-2",
@@ -42,8 +42,8 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $300 for air sealing. Must be completed by a participating program contractor."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   },
   {
     "id": "GA-3",
@@ -65,8 +65,8 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $300 for duct sealing."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   },
   {
     "id": "GA-4",
@@ -88,8 +88,8 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $75 for smart thermostats."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   },
   {
     "id": "GA-5",
@@ -111,8 +111,8 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $1,000 for ENERGY STAR certified mini-split and ground source heat pumps."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   },
   {
     "id": "GA-6",
@@ -134,8 +134,8 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $500 for ENERGY STAR certified heat pump water heaters."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   },
   {
     "id": "GA-7",
@@ -157,7 +157,7 @@
     "short_description": {
       "en": "Rebate for 50% of cost up to $50 for ENERGY STAR certified electric vehicle chargers. Must be 208/240 volt level 2 charger with dedicated circuit."
     },
-    "start_date": 2023,
-    "end_date": 2025
+    "start_date": "2023",
+    "end_date": "2025"
   }
 ]

--- a/data/IL/incentives.json
+++ b/data/IL/incentives.json
@@ -331,8 +331,8 @@
       "en": "$250 rebate for robotic or battery-powered riding mowers, $1,000 min purchase.",
       "es": "Un reembolso de $250 dólares para podadoras motorizadas robóticas o de batería, compra mínima de $1,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-16",
@@ -355,8 +355,8 @@
       "en": "$75 rebate for battery-powered push mowers, $250 minimum purchase.",
       "es": "Un reembolso de $75 dólares para podadoras de empuje de batería, compra mínima de $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-17",
@@ -379,8 +379,8 @@
       "en": "$25 rebate for battery-powered lawn equipment, $100 minimum purchase.",
       "es": "Un reembolso de $25 dólares para equipos de césped de baterías, compra mínima de $100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-18",
@@ -403,8 +403,8 @@
       "en": "$250 rebate for Self-Propel Snow Blowers with $2,000 minimum purchase.",
       "es": "Un reembolso de $250 dólares para sopladoras de nieves de autopropulsión con una compra mínima de $2,000 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-19",
@@ -427,8 +427,8 @@
       "en": "$75 rebate for Battery-Powered Single-Stage Snow Blowers with $250 minimum purchase.",
       "es": "Un reembolso de $75 dólares para sopladoras de nieve monofásicas de batería con una compra mínima de $250 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-20",
@@ -451,8 +451,8 @@
       "en": "$25 rebate for Battery-Powered Snow Shovels with $100 minimum purchase.",
       "es": "Un reembolso de $25 dólares para palas de nieve de batería con una compra mínima de $100 dólares."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-21",
@@ -476,8 +476,8 @@
       "en": "Up to $500 for Compressed Air Audit performed by Professional Engineer, Certified Energy Manager, or a cooperative pre-approved partner.",
       "es": "Hasta $500 dólares por una auditoría de aire comprimido realizada por un ingeniero profesional, un administrador de energía certificado o un colaborador pre-aprobado por la cooperativa."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-22",
@@ -501,8 +501,8 @@
       "en": "Up to $300 rebate for High Efficiency Electric Water Heater depending on size.",
       "es": "Un reembolso de hasta $300 dólares para un calentador de agua eléctrico de alta eficiencia dependiendo del tamaño."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-23",
@@ -526,8 +526,8 @@
       "en": "Up to $300 rebate for Solar Storage Water Heater with Electric Back-up depending on size.",
       "es": "Un reembolso de hasta $300 dólares por calentador de agua de depósito solar con respaldo eléctrico según el tamaño."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-24",
@@ -550,8 +550,8 @@
       "en": "$500 incentive for new construction homes meeting Illinois Energy Conservation Code (requires blower door test).",
       "es": "Incentivo de $500 dólares para viviendas de nueva construcción que cumplan el reglamento de conservación de energía de Illinois (requiere una prueba de soplado de compuerta)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-25",
@@ -574,8 +574,8 @@
       "en": "$250/ton rebate for qualifying Air Source Heat Pumps.",
       "es": "Un reembolso de $250 dólares/tonelada para bombas de calor de fuente de aire certificadas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-26",
@@ -598,8 +598,8 @@
       "en": "$250/ton rebate for qualifying Mini Split Heat Pumps.",
       "es": "Un reembolso de $250 dólares/tonelada para bombas de calor mini split certificadas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-27",
@@ -622,8 +622,8 @@
       "en": "$500/ton for upgrading existing Ground Source Heat Pump indoor equipment.",
       "es": "$500 dólares/tonelada para actualizar equipo interior existente de una bomba de calor geotérmica."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-28",
@@ -646,8 +646,8 @@
       "en": "$700/ton rebate for new installations of Ground Source Heat Pumps.",
       "es": "Un reembolso de $700 dólares/tonelada para instalaciones de bombas de calor geotérmicas nuevas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-29",
@@ -670,8 +670,8 @@
       "en": "Up to $500 for insulation/air-sealing after free home energy audit.",
       "es": "Hasta $500 dólares para aislamiento/sellado del aire una vez realizada una auditoría energética gratuita del hogar."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-30",
@@ -693,8 +693,8 @@
       "en": "$25 bill credit for any inductive range purchased and installed.",
       "es": "El proyecto de ley concede un crédito de $25 dólares en su cuenta de luz para cualquier parrilla de inducción comprada e instalada."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-31",
@@ -717,8 +717,8 @@
       "en": "$25 bill credit for ENERGY STAR clothes dryer.",
       "es": "Crédito de $25 dólares en su cuenta por una secadora de ropa ENERGY STAR."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-32",
@@ -741,8 +741,8 @@
       "en": "Up to $600 rebate for eligible air-source heat pumps, depending on unit efficiency, capped at 50% installed cost.",
       "es": "Un reembolso de hasta $600 dólares para bombas de calor alimentadas por aire que cumplan los requisitos, en función de la eficiencia de la unidad, con un tope del 50% del costo instalado."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-33",
@@ -765,8 +765,8 @@
       "en": "Up to $600 rebate for eligible ductless mini-split heat pumps, depending on unit efficiency, capped at 50% installed cost.",
       "es": "Un reembolso de hasta $600 dólares para bombas de calor  mini-split sin ductos elegibles, dependiendo de la eficiencia de la unidad, con un tope del 50% del costo instalado."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-34",
@@ -790,8 +790,8 @@
       "en": "Up to $75 rebate for ENERGY STAR® Smart Thermostats, not to exceed 50% of purchase price.",
       "es": "Un reembolso de hasta $75 dólares para termostatos inteligentes ENERGY STAR®, sin superar el 50% del precio de compra."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "IL-35",
@@ -861,8 +861,8 @@
       "en": "$500 incentive for new construction homes meeting Illinois Energy Conservation Code (requires blower door test).",
       "es": "Un incentivo de $500 dólares para viviendas de nueva construcción que cumplan el reglamento de conservación de energía de Illinois (requiere una prueba de soplado de compuerta)."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-38",
@@ -885,8 +885,8 @@
       "en": "$250/ton rebate for qualifying Air Source Heat Pumps. Minimum efficiency of at least 14.3 SEER2 & 7.5 HSPF2.",
       "es": "Un reembolso de $250 dólares/tonelada para bombas de calor de fuente de aire certificadas. Eficiencia mínima de al menos 14.3 SEER2 y 7.5 HSPF2."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-39",
@@ -909,8 +909,8 @@
       "en": "$250/ton rebate for qualifying Mini Split Heat Pumps. Minimum efficiency of at least 14.3 SEER2 & 7.5 HSPF2.",
       "es": "Un reembolso de $250 dólares/tonelada para bombas de calor mini split certificadas. Eficiencia mínima de al menos 14.3 SEER2 y 7.5 HSPF2."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-40",
@@ -934,8 +934,8 @@
       "en": "Up to $500 back on home insulation and air sealing, as well as up to $300 for an energy audit.",
       "es": "Hasta $500 dólares de devolución para aislamiento y sellado del aire de su hogar, así como hasta $300 dólares para una auditoría de consumo de energía."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-41",
@@ -958,8 +958,8 @@
       "en": "$25 bill credit for any inductive range purchased and installed.",
       "es": "El proyecto de ley concede un crédito de $25 dólares en la cuenta de luz por cualquier parrilla de inducción comprada e instalada."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-42",
@@ -983,8 +983,8 @@
       "en": "Up to $500 for Compressed Air Audit performed by Professional Engineer, Certified Energy Manager, or a cooperative pre-approved partner.",
       "es": "Hasta $500 dólares para una auditoría de aire comprimido realizada por un ingeniero profesional, un administrador de energía certificado o un colaborador pre-aprobado por la cooperativa."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-43",
@@ -1008,8 +1008,8 @@
       "en": "Up to $300 rebate for High Efficiency Electric Water Heater depending on size. Minimum capacity 75 gal.",
       "es": "Un reembolso de hasta $300 dólares por calentador de agua eléctrico de alta eficiencia según el tamaño. Capacidad mínima 75 gal."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-44",
@@ -1032,8 +1032,8 @@
       "en": "$25 bill credit for ENERGY STAR clothes dryer.",
       "es": "Crédito de $25 dólares en la cuenta de luz por una secadora de ropa ENERGY STAR."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-45",
@@ -1056,8 +1056,8 @@
       "en": "Up to $375 point-of-sale rebate for eligible air source heat pumps, depending on efficiency. Minimum 15.2 SEER2 and 8.1 HSPF2.",
       "es": "Un reembolso de hasta $375 dólares en el punto de venta para bombas de calor con fuente de aire que cumplan los requisitos, en función de su eficiencia. Mínimo 15.2 SEER2 y 8.1 HSPF2."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-46",
@@ -1080,8 +1080,8 @@
       "en": "Up to $300 point-of-sale rebate for eligible ductless mini-split heat pumps. Minimum 17 SEER2 and 10 HSPF2.",
       "es": "Un reembolso de hasta $300 dólares en el punto de venta para bombas de calor sin ductos mini-split elegibles. Mínimo 17 SEER2 y 10 HSPF2."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-47",
@@ -1105,8 +1105,8 @@
       "en": "Up to $100 rebate for ENERGY STAR® Smart Thermostats, up to 70% of equipment cost.",
       "es": "Un reembolso de hasta $100 dólares para termostatos inteligentes ENERGY STAR®, hasta el 70% del costo del equipo."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-48",
@@ -1129,8 +1129,8 @@
       "en": "Up to $1200 rebate for eligible geothermal heat pumps, depending on efficiency. Minimum 17 EERFL and 4.1 COPFL.",
       "es": "Un reembolso de hasta $1,200 dólares para bombas de calor geotérmicas que cumplan los requisitos, en función de su eficiencia. Mínimo 17 EERFL y 4.1 COPFL."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-49",
@@ -1153,8 +1153,8 @@
       "en": "Up to $225 per unit. Eligible HPWH will have a maximum capacity of 120 gal and at least 2.2 UEF.",
       "es": "Hasta $225 dólares por unidad. Los HPWH elegibles deberán tener una capacidad máxima de 120 gal y al menos 2.2 UEF."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "IL-50",
@@ -1178,7 +1178,7 @@
       "en": "Up to $300 for an energy audit by a Jo-Carroll Energy representative once subsequent insulation or air-sealing project is completed.",
       "es": "Hasta $300 dólares para una auditoría de consumo de energía realizada por un representante de Jo-Carroll Energy una vez que haya concluido el proyecto posterior de aislamiento o sellado hermético."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   }
 ]

--- a/data/MI/incentives.json
+++ b/data/MI/incentives.json
@@ -18,8 +18,8 @@
     "short_description": {
       "en": "$150 rebate for 15.0-15.99 SEER/14.3 SEER2 air source heat pump."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-2",
@@ -40,8 +40,8 @@
     "short_description": {
       "en": "$250 rebate for 16.0 SEER/15.2 SEER2 or higher air source heat pump."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-3",
@@ -62,8 +62,8 @@
     "short_description": {
       "en": "$250 rebate for 17.0-18.99 SEER/ 16-17 SEER2 ground source heat pump."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-4",
@@ -84,8 +84,8 @@
     "short_description": {
       "en": "$300 rebate for 19.0+ SEER/18 SEER2 or higher ground source heat pump."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-5",
@@ -106,8 +106,8 @@
     "short_description": {
       "en": "$250 rebate for 18-20.99 SEER/17-20 SEER2 ductless mini-split heat pump."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-6",
@@ -128,8 +128,8 @@
     "short_description": {
       "en": "$350 rebate for 21.0 SEER/20 SEER2 or higher ductless mini-split heat pump."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-7",
@@ -150,8 +150,8 @@
     "short_description": {
       "en": "$10 rebate for programmable thermostat. Must replace an existing nonprogrammable thermostat."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-8",
@@ -172,8 +172,8 @@
     "short_description": {
       "en": "$50 rebate for Wi-Fi enabled thermostat. Must replace existing non-programmable thermostat."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-9",
@@ -194,8 +194,8 @@
     "short_description": {
       "en": "$100 rebate for Wi-Fi enabled thermostat. Must replace an existing non-programmable thermostat."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-10",
@@ -218,8 +218,8 @@
     "short_description": {
       "en": "Up to $125 rebate for roof (attic) with insulation R-48 or less. Must insulate a minimum of 500 square feet of attic area."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-11",
@@ -242,8 +242,8 @@
     "short_description": {
       "en": "Up to $175 rebate for roof (attic) insulation with R-49 to R-59 . Must insulate a minimum of 500 square feet of attic area."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-12",
@@ -266,8 +266,8 @@
     "short_description": {
       "en": "Up to $200 rebate for roof (attic) R-60 or higher. Must insulate a minimum of 500 square feet of attic area."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-13",
@@ -290,8 +290,8 @@
     "short_description": {
       "en": "Up to $125 rebate for above grade wall insulation. Must insulate a minimum of 500 square feet of wall area."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-14",
@@ -312,8 +312,8 @@
     "short_description": {
       "en": "$50 rebate for basement wall insulation. Must insulate a minimum of 500 square feet of wall area."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-15",
@@ -336,8 +336,8 @@
     "short_description": {
       "en": "Up to $50 rebate for crawlspace insulation.  Must insulate a minimum of 200 square feet of wall area."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-16",
@@ -360,8 +360,8 @@
     "short_description": {
       "en": "Up to $50 rebate for rim joist insulation. Must insulate all accessible rim joist areas."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-17",
@@ -384,8 +384,8 @@
     "short_description": {
       "en": "$15 per window rebate for window replacement. No limit on number of windows."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-18",
@@ -408,8 +408,8 @@
     "short_description": {
       "en": "$40 per patio door rebate for patio door replacement. No limit on number of doors."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "MI-19",
@@ -430,8 +430,8 @@
     "short_description": {
       "en": "$75 rebate for heat pump clothes dryer (electric customers only)."
     },
-    "start_date": 2022,
-    "end_date": 2023
+    "start_date": "2022",
+    "end_date": "2023"
   },
   {
     "id": "MI-20",
@@ -795,7 +795,7 @@
     "short_description": {
       "en": "Up to $250 for a qualifying ENERGY STAR heat pump clothes dryer."
     },
-    "start_date": 2024
+    "start_date": "2024"
   },
   {
     "id": "MI-38",
@@ -838,7 +838,7 @@
     "short_description": {
       "en": "$1,500 rebate on a purchased or leased new electric vehicle."
     },
-    "start_date": 2022,
+    "start_date": "2022",
     "low_income": "mi-dte"
   },
   {
@@ -860,8 +860,8 @@
     "short_description": {
       "en": "$400 rebate for ENERGY STAR qualified electric heat pump clothes dryer."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-42",
@@ -882,8 +882,8 @@
     "short_description": {
       "en": "$50 rebate for Induction replacing gas or electric resistance. 3 element minimum. Portable units do not qualify."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-43",
@@ -904,8 +904,8 @@
     "short_description": {
       "en": "$75 rebate for Wi-Fi enabled smart thermostat."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-44",
@@ -927,8 +927,8 @@
     "short_description": {
       "en": "$50 rebate for Electric push or self-propelled walk-behind lawnmower."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-45",
@@ -950,8 +950,8 @@
     "short_description": {
       "en": "$300 rebate for battery-electric riding lawnmower."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-46",
@@ -973,8 +973,8 @@
     "short_description": {
       "en": "$40 rebate for battery-electric cordless or corded string trimmer."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-47",
@@ -996,8 +996,8 @@
     "short_description": {
       "en": "$40 rebate for battery-electric cordless or corded electric leaf blower."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-48",
@@ -1019,8 +1019,8 @@
     "short_description": {
       "en": "$40 rebate for electric chainsaw."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-49",
@@ -1041,8 +1041,8 @@
     "short_description": {
       "en": "$1000 rebate for central air source heat pump. AHRI Rated 15.0 SEER and 8.5 HSPF."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-50",
@@ -1063,8 +1063,8 @@
     "short_description": {
       "en": "$1500 rebate for ASHP – Central Air-Source Heat Pump (Must be listed on ashp.neep.org)."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-51",
@@ -1086,8 +1086,8 @@
     "short_description": {
       "en": "$900 rebate per outdoor unit for mini/multi split air-source heat pumps. Limit 2 units."
     },
-    "start_date": 2024,
-    "end_date": 2024,
+    "start_date": "2024",
+    "end_date": "2024",
     "bonus_available": true
   },
   {
@@ -1109,8 +1109,8 @@
     "short_description": {
       "en": "$100 rebate per indoor unit for mini/multi split air-source heat pumps. No limit on number of units."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-53",
@@ -1131,8 +1131,8 @@
     "short_description": {
       "en": "$2000 rebate for an air-to-water heat pump."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-54",
@@ -1153,8 +1153,8 @@
     "short_description": {
       "en": "$2000 rebate for a ground source heat pump. Includes Well-Connect or a replacement or new ground source heat pump."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-55",
@@ -1175,8 +1175,8 @@
     "short_description": {
       "en": "$2500 rebate for a new or replacement ground loop installed with eligible ground source heat pump."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-56",
@@ -1197,8 +1197,8 @@
     "short_description": {
       "en": "$500 rebate for a desuperheater connected to a ground source heat pump for domestic hot water generation."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-57",
@@ -1219,8 +1219,8 @@
     "short_description": {
       "en": "$1200 rebate for a heat pump water heater. Minimum 2.0 UEF."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-58",
@@ -1241,8 +1241,8 @@
     "short_description": {
       "en": "$500 rebate for up-sizing service panel capacity, adding a sub-panel, or increasing service capacity."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-59",
@@ -1264,8 +1264,8 @@
     "short_description": {
       "en": "Rebate up to $800 for a Level 2 Smart Charger."
     },
-    "start_date": 2024,
-    "end_date": 2024
+    "start_date": "2024",
+    "end_date": "2024"
   },
   {
     "id": "MI-60",

--- a/data/NY/incentives.json
+++ b/data/NY/incentives.json
@@ -19,8 +19,8 @@
     "short_description": {
       "en": "Instant or mail-in rebate for $1,000 off an Energy Star certified heat pump water heater."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "NY-2",
@@ -127,8 +127,8 @@
     "short_description": {
       "en": "Instant rebate for $1,000 off an eligible Energy Star certified heat pump water heater when purchased at a participating retailer."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "NY-7",

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -302,8 +302,8 @@
     ],
     "item": "heat_pump_water_heater",
     "program": "ri_residentialHeatPumpWaterHeater",
-    "start_date": 2024,
-    "end_date": 2024,
+    "start_date": "2024",
+    "end_date": "2024",
     "amount": {
       "type": "dollar_amount",
       "number": 600,
@@ -351,8 +351,8 @@
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "ri_electricHeatingAndCoolingRebates",
-    "start_date": 2024,
-    "end_date": 2024,
+    "start_date": "2024",
+    "end_date": "2024",
     "amount": {
       "type": "dollars_per_unit",
       "unit": "ton",

--- a/data/VA/incentives.json
+++ b/data/VA/incentives.json
@@ -19,8 +19,8 @@
       "en": "Receive up to $50 rebate for an Energy Start certified electric ventless or vented clothes dryer from an approved retailer.",
       "es": "Reciba un reembolso de hasta $50 dólares por una secadora eléctrica de ropa con o sin ventilación con certificación Energy Start de un proveedor autorizado."
     },
-    "start_date": 2022,
-    "end_date": 2026
+    "start_date": "2022",
+    "end_date": "2026"
   },
   {
     "id": "VA-2",
@@ -65,8 +65,8 @@
       "en": "Receive up to $100 rebate for a level 2 ENERGY STAR certified electric vehicle charger from an approved retailer.",
       "es": "Reciba un reembolso de hasta $100 dólares por un cargador para vehículos eléctricos con certificación ENERGY STAR de Nivel 2 de un distribuidor autorizado."
     },
-    "start_date": 2022,
-    "end_date": 2026
+    "start_date": "2022",
+    "end_date": "2026"
   },
   {
     "id": "VA-4",
@@ -132,8 +132,8 @@
       "en": "Receive up to $300 rebate for a ductless mini-split heat pump displacement or replacement from an approved retailer.",
       "es": "Reciba un reembolso de hasta $300 por el cambio o sustitución de una bomba de calor mini-split sin conductos de un distribuidor autorizado."
     },
-    "start_date": 2022,
-    "end_date": 2026
+    "start_date": "2022",
+    "end_date": "2026"
   },
   {
     "id": "VA-7",
@@ -176,8 +176,8 @@
       "en": "Receive up to $400 rebate for an ENERGY STAR certified heat pump water heater (HPWH) from an approved retailer.",
       "es": "Reciba un reembolso de hasta $400 dólares por un calentador de agua con bomba de calor (HPWH) con certificación ENERGY STAR de un distribuidor autorizado."
     },
-    "start_date": 2022,
-    "end_date": 2026
+    "start_date": "2022",
+    "end_date": "2026"
   },
   {
     "id": "VA-10",
@@ -266,7 +266,7 @@
       "en": "Dominion Energy customers can receive a $100 rebate on a new electric clothes dryer.",
       "es": "Los clientes de Dominion Energy pueden recibir un reembolso de $100 dólares en una nueva secadora eléctrica de ropa ."
     },
-    "start_date": 2019
+    "start_date": "2019"
   },
   {
     "id": "VA-16",
@@ -289,7 +289,7 @@
       "en": "Receive up to a $400 rebate for installing a heat pump water heater above 40 gallons in capacity.",
       "es": "Reciba un reembolso de hasta $400 dólares por la instalación de un calentador de agua con bomba de calor de más de 40 galones de capacidad."
     },
-    "start_date": 2022
+    "start_date": "2022"
   },
   {
     "id": "VA-17",

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -21,7 +21,7 @@
       "en": "Work with an Efficiency Excellence Network contractor to install your air-to-water heat pump and get up to $6,000 back.",
       "es": "Trabaje con un contratista de la red Efficiency Excellence Network para instalar su bomba de calor de aire a agua y reciba una devolución de hasta $6,000, además de una bonificación de $500 para los residentes de Vermont que cumplan con el nivel de ingresos."
     },
-    "start_date": 2020
+    "start_date": "2020"
   },
   {
     "id": "VT-2",
@@ -68,8 +68,8 @@
       "en": "BED customers may receive a post purchase rebate up to $12,000 when you install an air-to-water heat pump.",
       "es": "Los clientes de BED pueden recibir un reembolso posterior a la compra de hasta $12,000 dólares al instalar una bomba de calor de aire a agua."
     },
-    "start_date": 2021,
-    "end_date": 2023
+    "start_date": "2021",
+    "end_date": "2023"
   },
   {
     "id": "VT-4",
@@ -93,8 +93,8 @@
       "es": "Los residentes de Vermont que reúnan los requisitos de ingresos y sean clientes de BED pueden optar a un reembolso adicional ampliado de $400 dólares al instalar una bomba de calor aire a agua certificada."
     },
     "low_income": "vt-burlington-electric-department",
-    "start_date": 2021,
-    "end_date": 2023
+    "start_date": "2021",
+    "end_date": "2023"
   },
   {
     "id": "VT-5",
@@ -117,8 +117,8 @@
       "en": "WEC members receive a flat $500 bonus rebate for an air-to-water heat pump.",
       "es": "Los miembros de Washington Electric Co-op reciben un reembolso fijo de $500 dólares por una bomba de calor aire a agua."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "VT-6",
@@ -141,7 +141,7 @@
       "en": "Receive up to $400 cash back on qualifying ENERGY STAR® electric clothes dryer models.",
       "es": "Reciba hasta $400 dólares de devolución en efectivo en  modelos de secadoras eléctricas de ropa ENERGY STAR® que cumplan los requisitos."
     },
-    "start_date": 2019
+    "start_date": "2019"
   },
   {
     "id": "VT-7",
@@ -164,7 +164,7 @@
       "en": "Work with a contractor to install your ducted heat pump and get a $1,000-$2,000 instant discount.",
       "es": "Trabaje con un contratista para instalar su bomba de calor con ductos y obtenga un descuento instantáneo de entre $1,000 y $2,000 dólares, además de una bonificación para los residentes de Vermont que cumplan con el nivel de ingresos."
     },
-    "start_date": 2021
+    "start_date": "2021"
   },
   {
     "id": "VT-8",
@@ -257,8 +257,8 @@
       "en": "Up to $8,750 on heat pump installation.",
       "es": "Hasta 8,750 dólares en instalación de bomba de calor."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "VT-13",
@@ -282,8 +282,8 @@
       "en": "Income-eligible Vermonters who are BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified ducted heat pump.",
       "es": "Los residentes de Vermont que cumplan con el nivel de ingresos y sean clientes de BED pueden optar por un reembolso adicional ampliado de $400 dólares al instalar una bomba de calor con ductos certificada."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "VT-16",
@@ -306,7 +306,7 @@
       "en": "Receive a one-time $150 bill credit per unit installed for a qualifying ducted heat pump.",
       "es": "Reciba en su cuenta un crédito único de $150 dólares por unidad instalada para una bomba de calor con ductos que cumpla los requisitos."
     },
-    "start_date": 2021
+    "start_date": "2021"
   },
   {
     "id": "VT-17",
@@ -351,7 +351,7 @@
       "en": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor.",
       "es": "Contrate a un técnico y obtenga un descuento instantáneo de entre $350 y $450 dólares en modelos aprobados de bombas de calor sin ductos de un distribuidor participante."
     },
-    "start_date": 2021
+    "start_date": "2021"
   },
   {
     "id": "VT-20",
@@ -375,7 +375,7 @@
       "en": "Customers who are low or moderate income can save more with GMP's low to moderate income rebate for ductless heat pumps.",
       "es": "Los clientes con ingresos bajos o moderados pueden ahorrar más con el reembolso por ingresos bajos o moderados de GMP para bombas de calor sin ductos."
     },
-    "start_date": 2021
+    "start_date": "2021"
   },
   {
     "id": "VT-21",
@@ -439,8 +439,8 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2022,
-    "end_date": 2023,
+    "start_date": "2022",
+    "end_date": "2023",
     "short_description": {
       "en": "BED customers may receive a rebate up to $2,500 on qualifying HPs, plus an additional $500 for a second HP.",
       "es": "Los clientes de BED pueden recibir un reembolso de hasta $2,500 dólares en las bombas de calor que cumplan los requisitos, más $500 dólares adicionales por una segunda bomba de calor."
@@ -463,8 +463,8 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2022,
-    "end_date": 2023,
+    "start_date": "2022",
+    "end_date": "2023",
     "short_description": {
       "en": "BED customers may receive a rebate up to $2,500 on qualifying HPs, plus an additional $500 for a second HP.",
       "es": "Los clientes de BED pueden recibir un reembolso de hasta $2,500 dólares en las bombas de calor que cumplan los requisitos, más $500 dólares adicionales por una segunda bomba de calor."
@@ -487,8 +487,8 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2022,
-    "end_date": 2023,
+    "start_date": "2022",
+    "end_date": "2023",
     "low_income": "vt-burlington-electric-department",
     "short_description": {
       "en": "Income-eligible BED customers qualify for a $400 enhanced rebate for a ductless HP.",
@@ -824,7 +824,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "single",
     "agi_max_limit": 60001,
     "short_description": {
@@ -850,7 +850,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "single",
     "agi_min_limit": 60001,
     "agi_max_limit": 100001,
@@ -877,7 +877,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "hoh",
     "agi_max_limit": 75001,
     "short_description": {
@@ -903,7 +903,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "hoh",
     "agi_min_limit": 75001,
     "agi_max_limit": 125001,
@@ -930,7 +930,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "qualifying_widower_with_dependent_child",
     "agi_max_limit": 90001,
     "short_description": {
@@ -956,7 +956,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "qualifying_widower_with_dependent_child",
     "agi_min_limit": 90001,
     "agi_max_limit": 150001,
@@ -983,7 +983,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "joint",
     "agi_max_limit": 90001,
     "short_description": {
@@ -1009,7 +1009,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "joint",
     "agi_min_limit": 90001,
     "agi_max_limit": 150001,
@@ -1036,7 +1036,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "married_filing_separately",
     "agi_max_limit": 60001,
     "short_description": {
@@ -1062,7 +1062,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "filing_status": "married_filing_separately",
     "agi_min_limit": 60001,
     "agi_max_limit": 100001,
@@ -1090,7 +1090,7 @@
       "homeowner",
       "renter"
     ],
-    "start_date": 2022,
+    "start_date": "2022",
     "short_description": {
       "en": "The incentive amount for scrapping an eligible Internal Combustion Engine (ICE) vehicle is $5,000 based on income eligibility.",
       "es": "El Estado de Vermont ofrece un programa de incentivos por tiempo limitado a los consumidores para que puedan mandar a la chatarra su viejo vehículo con motor de combustión interna (o ICE, por sus siglas en inglés)."
@@ -1113,7 +1113,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "end_date": 2023,
+    "end_date": "2023",
     "short_description": {
       "en": "Up to $900 back on qualifying level 2 charger purchased within 60 days of vehicle purchase or lease.",
       "es": "Devolución de hasta $900 dólares por la compra de un cargador de nivel 2 válido en los 60 días siguientes a la compra o arrendamiento del vehículo. Con un cargador autorizado, puede registrarse para obtener una tarifa de carga de VE con descuento de 8 centavos/kWH cuando realice la recarga entre las 10 de la noche y el mediodía."
@@ -1155,7 +1155,7 @@
       "number": 250,
       "maximum": 250
     },
-    "start_date": 2018,
+    "start_date": "2018",
     "owner_status": [
       "homeowner"
     ],
@@ -1177,7 +1177,7 @@
       "type": "percent",
       "number": 1
     },
-    "start_date": 2018,
+    "start_date": "2018",
     "owner_status": [
       "homeowner",
       "renter"
@@ -1200,7 +1200,7 @@
       "type": "percent",
       "number": 1
     },
-    "start_date": 2018,
+    "start_date": "2018",
     "owner_status": [
       "homeowner",
       "renter"
@@ -1224,7 +1224,7 @@
       "type": "percent",
       "number": 1
     },
-    "start_date": 2018,
+    "start_date": "2018",
     "owner_status": [
       "homeowner",
       "renter"
@@ -1249,7 +1249,7 @@
       "number": 2100,
       "maximum": 50000
     },
-    "start_date": 2021,
+    "start_date": "2021",
     "owner_status": [
       "homeowner"
     ],
@@ -1272,7 +1272,7 @@
       "number": 500,
       "maximum": 500
     },
-    "start_date": 2021,
+    "start_date": "2021",
     "owner_status": [
       "homeowner"
     ],
@@ -1296,8 +1296,8 @@
       "number": 500,
       "maximum": 2000
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "owner_status": [
       "homeowner"
     ],
@@ -1347,7 +1347,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2020,
+    "start_date": "2020",
     "short_description": {
       "en": "Hire a contractor and get a $300-$600 discount from your utility or Efficiency Vermont.",
       "es": "Contrate a un técnico especialista y obtenga un descuento de entre $300 y $600 dólares de su compañía de suministro de luz o de Efficiency Vermont, además de una bonificación de $200 dólares para residentes de Vermont que cumplan con el nivel de ingresos."
@@ -1371,7 +1371,7 @@
       "homeowner"
     ],
     "low_income": "default-moderate",
-    "start_date": 2020,
+    "start_date": "2020",
     "short_description": {
       "en": "Income-eligible Vermonters may qualify for a $200 bonus rebate on HPWH.",
       "es": "Los residentes de Vermont que cumplan el nivel de ingresos pueden optar por un reembolso adicional de $200 en calentadores de agua con bomba de calor."
@@ -1394,8 +1394,8 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2022,
-    "end_date": 2023,
+    "start_date": "2022",
+    "end_date": "2023",
     "short_description": {
       "en": "BED customers may receive up to $800 rebate for a HPWH.",
       "es": "Los clientes de BED pueden recibir un reembolso de hasta $800 dólares por un calentador de agua con bomba de calor."
@@ -1418,8 +1418,8 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "short_description": {
       "en": "WEC members may receive $100 for replacing a fossil-fired hot water system.",
       "es": "Los miembros de la cooperativa WEC pueden recibir $100 dólares para reemplazar su sistema de agua caliente que funciona con combustibles fósiles"
@@ -1442,7 +1442,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2019,
+    "start_date": "2019",
     "short_description": {
       "en": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing.",
       "es": "Reciba dinero en efectivo en materiales para tres proyectos de auto-instalación elegibiles, incluyendo la colocación de sellos, aislamiento y sellado para juntas herméticas."
@@ -1465,7 +1465,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2023,
+    "start_date": "2023",
     "short_description": {
       "en": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project cost up to $4,000.",
       "es": "Trabaje con un técnico especialista de la red Efficiency Excellence Network para mejorar el aislamiento y los sellos herméticos de su vivienda, garantizando el confort, la salud y la seguridad de los ocupantes, y obtenga un 75% de descuento en el costo del proyecto, hasta un máximo de $4,000 dólares."
@@ -1488,7 +1488,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "start_date": 2023,
+    "start_date": "2023",
     "low_income": "default-moderate",
     "short_description": {
       "en": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project costs up to $9,500.",
@@ -1577,7 +1577,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "end_date": 2023,
+    "end_date": "2023",
     "short_description": {
       "en": "VGS offers qualifying single-family homeowners an incentive to cover 75% of comprehensive weatherization project costs up to $3,500.",
       "es": "VGS ofrece a los propietarios de viviendas unifamiliares que cumplan los requisitos un incentivo para cubrir el 75% de los costos del proyecto de climatización integral hasta un máximo de $3,500 dólares."

--- a/data/WI/incentives.json
+++ b/data/WI/incentives.json
@@ -19,8 +19,8 @@
     "short_description": {
       "en": "$675 for ENERGY STAR Qualified Air Sealing. Must be completed with Trade Ally contractor installed attic or wall insulation improvements."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-2",
@@ -42,8 +42,8 @@
     "short_description": {
       "en": "$1,125 for ENERGY STAR Qualified Air Sealing for income-qualified customers. Must be completed with Trade Ally contractor installed insulation."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "low_income": "wi-focus-on-energy"
   },
   {
@@ -66,8 +66,8 @@
     "short_description": {
       "en": "$525 for Attic Insulation."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-4",
@@ -89,8 +89,8 @@
     "short_description": {
       "en": "$675 for Attic Insulation for income-qualified customers."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "low_income": "wi-focus-on-energy"
   },
   {
@@ -113,8 +113,8 @@
     "short_description": {
       "en": "$150 for Foundation Insulation. Must be completed along with Trade Ally contractor installed attic or wall insulation improvements."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-6",
@@ -136,8 +136,8 @@
     "short_description": {
       "en": "$225 for Foundation Insulation for income-qualified customers. Must be completed along with Trade Ally contractor installed insulation."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "low_income": "wi-focus-on-energy"
   },
   {
@@ -160,8 +160,8 @@
     "short_description": {
       "en": "$450 for Wall Insulation."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-8",
@@ -183,8 +183,8 @@
     "short_description": {
       "en": "$75 for Duct Sealing & Insulation. Must be completed along with Trade Ally contractor installed attic or wall insulation improvements."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-9",
@@ -206,8 +206,8 @@
     "short_description": {
       "en": "$200 cash back for self-installed attic insulation and air sealing."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-10",
@@ -230,8 +230,8 @@
     "short_description": {
       "en": "$50 for Smart Thermostats. Available as instant discounts in the online marketplace or as rebates."
     },
-    "start_date": 2023,
-    "end_date": 2023,
+    "start_date": "2023",
+    "end_date": "2023",
     "bonus_available": true
   },
   {
@@ -275,8 +275,8 @@
     "short_description": {
       "en": "$500 for qualifying solar electric systems. Available to rural residential customers."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-13",
@@ -298,8 +298,8 @@
     "short_description": {
       "en": "$200 cash back for qualified self-installed attic insulation and air sealing."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-14",
@@ -321,8 +321,8 @@
     "short_description": {
       "en": "$1,000 for Air Source Heat Pump replacing natural gas or electric primary heating source."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-15",
@@ -344,8 +344,8 @@
     "short_description": {
       "en": "$400 for Air Source Heat Pump replacing propane, oil, existing heat pump etc."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-16",
@@ -367,8 +367,8 @@
     "short_description": {
       "en": "$1,000 for Certified Geothermal Heat Pump (with natural gas service)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   },
   {
     "id": "WI-17",
@@ -390,7 +390,7 @@
     "short_description": {
       "en": "$750 for Certified Geothermal Heat Pump (with no natural gas service)."
     },
-    "start_date": 2023,
-    "end_date": 2023
+    "start_date": "2023",
+    "end_date": "2023"
   }
 ]

--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -17,8 +17,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average.",
       "es": "Crédito fiscal del 30% (sin límite) por los sistemas de almacenamiento de batería, con un valor promedio de $4,800."
@@ -42,8 +42,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2022,
-    "end_date": 2032,
+    "start_date": "2022",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average.",
       "es": "Crédito fiscal del 30% (sin límite) por la instalación geotérmica, con un valor promedio de $7,200."
@@ -66,8 +66,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $600) por actualización del tablero en junto con otra mejora cubierto por 25C o 25D. Reinicio anual."
@@ -90,8 +90,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%.",
       "es": "Reembolsos hasta $4,000 por los costos del tablero eléctrico. Los hogares de bajos ingresos: reembolso del 100%. Los de ingresos medios reciben el 50%."
@@ -114,8 +114,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%.",
       "es": "Reembolsos hasta $4,000 por los costos del tablero eléctrico. Los hogares de bajos ingresos: reembolso del 100%. Los de ingresos medios reciben el 50%."
@@ -139,8 +139,8 @@
       "renter"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840.",
       "es": "Reembolsos hasta $840 por las estufas eléctricas y de inducción. Los hogares de bajos ingresos reciben un reembolso del 100% (ingresos medios: 50%)."
@@ -164,8 +164,8 @@
       "renter"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840.",
       "es": "Reembolsos hasta $840 por las estufas eléctricas y de inducción. Los hogares de bajos ingresos reciben un reembolso del 100% (ingresos medios: 50%)."
@@ -188,8 +188,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500.",
       "es": "Reembolsos hasta $2,500 por el cableado. Los hogares de bajos ingresos reciben un reembolso del 100% y los de ingresos medios reciben el 50%."
@@ -212,8 +212,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500.",
       "es": "Reembolsos hasta $2,500 por el cableado. Los hogares de bajos ingresos reciben un reembolso del 100% y los de ingresos medios reciben el 50%."
@@ -237,8 +237,8 @@
       "renter"
     ],
     "ami_qualification": null,
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities.",
       "es": "Crédito fiscal hasta $1,000 por los cargadores de vehículos eléctricos. Disponible en zonas rurales o comunidades de bajos ingresos."
@@ -264,8 +264,8 @@
     "ami_qualification": null,
     "agi_max_limit": 150000,
     "filing_status": "single",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
@@ -291,8 +291,8 @@
     "ami_qualification": null,
     "agi_max_limit": 150000,
     "filing_status": "married_filing_separately",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
@@ -318,8 +318,8 @@
     "ami_qualification": null,
     "agi_max_limit": 225000,
     "filing_status": "hoh",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
@@ -345,8 +345,8 @@
     "ami_qualification": null,
     "agi_max_limit": 300000,
     "filing_status": "joint",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
@@ -372,8 +372,8 @@
     "ami_qualification": null,
     "agi_max_limit": 75000,
     "filing_status": "single",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -399,8 +399,8 @@
     "ami_qualification": null,
     "agi_max_limit": 75000,
     "filing_status": "married_filing_separately",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -426,8 +426,8 @@
     "ami_qualification": null,
     "agi_max_limit": 150000,
     "filing_status": "joint",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -453,8 +453,8 @@
     "ami_qualification": null,
     "agi_max_limit": 112500,
     "filing_status": "hoh",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -477,8 +477,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor. Reinicio anual."
@@ -501,8 +501,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor. Reinicio anual."
@@ -525,8 +525,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households.",
       "es": "Reembolsos por los calentadores de agua con bomba de calor hasta $1,750. Los hogares de bajos ingresos reciben un reembolso del 100% (ingresos medios: 50%)."
@@ -550,8 +550,8 @@
       "renter"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000.",
       "es": "Reembolsos hasta $8,000 por las bombas de calor. Los hogares de bajos ingresos reciben un reembolso del 100% y los de ingresos medios reciben el 50%."
@@ -575,8 +575,8 @@
       "renter"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate.",
       "es": "Reembolsos hasta $840 por las secadoras con bomba de calor. Los hogares de bajos ingresos reciben un reembolso del 100% y los de ingresos medios reciben el 50%."
@@ -599,8 +599,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households.",
       "es": "Reembolsos por los calentadores de agua con bomba de calor hasta $1,750. Los hogares de bajos ingresos reciben un reembolso del 100% (ingresos medios: 50%)."
@@ -624,8 +624,8 @@
       "renter"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000.",
       "es": "Reembolsos hasta $8,000 por las bombas de calor. Los hogares de bajos ingresos reciben un reembolso del 100% y los de ingresos medios reciben el 50%."
@@ -649,8 +649,8 @@
       "renter"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate.",
       "es": "Reembolsos hasta $840 por las secadoras con bomba de calor. Los hogares de bajos ingresos reciben un reembolso del 100% y los de ingresos medios reciben el 50%."
@@ -673,8 +673,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2022,
-    "end_date": 2032,
+    "start_date": "2022",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas.",
       "es": "Crédito fiscal del 30% (sin límite) por la instalación del tejado solar y en conjunto, un crédito fiscal por la actualización del tablero."
@@ -697,8 +697,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600.",
       "es": "Reembolsos por los proyectos de impermeabilización hasta $16,000. Los hogares de bajos ingresos reciben un reembolso del 100% (los de ingresos medios: 50%)."
@@ -721,8 +721,8 @@
       "homeowner"
     ],
     "ami_qualification": null,
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows, and energy audits. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $1,200) por los proyectos de impermeabilización. Reinicio anual."
@@ -745,8 +745,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_150_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600.",
       "es": "Reembolsos por los proyectos de impermeabilización hasta $16,000. Los hogares de bajos ingresos reciben un reembolso del 100% (los de ingresos medios: 50%)."
@@ -769,8 +769,8 @@
       "homeowner"
     ],
     "ami_qualification": "less_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits.",
       "es": "Reembolsos hasta $8,000 para los hogares de bajos ingresos o de ingresos medios y hasta $4,000 para los otros por renovaciones de eficiencia energética"
@@ -793,8 +793,8 @@
       "homeowner"
     ],
     "ami_qualification": "more_than_80_ami",
-    "start_date": 2023,
-    "end_date": 2032,
+    "start_date": "2023",
+    "end_date": "2032",
     "short_description": {
       "en": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits.",
       "es": "Reembolsos hasta $8,000 para los hogares de bajos ingresos o de ingresos medios y hasta $4,000 para los otros por renovaciones de eficiencia energética"

--- a/scripts/lib/data-refiner.ts
+++ b/scripts/lib/data-refiner.ts
@@ -52,10 +52,10 @@ export class DataRefiner {
       output.short_description.es = record.short_description.es;
     }
     if (record.program_start_raw && record.program_start_raw !== '') {
-      output.start_date = +parseDateToYear(record.program_start_raw);
+      output.start_date = parseDateToYear(record.program_start_raw);
     }
     if (record.program_end_raw && record.program_end_raw !== '') {
-      output.end_date = +parseDateToYear(record.program_end_raw);
+      output.end_date = parseDateToYear(record.program_end_raw);
     }
     if (record.bonus_description && record.bonus_description !== '') {
       output.bonus_available = true;

--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -1,5 +1,6 @@
 import { JSONSchemaType } from 'ajv';
 import fs from 'fs';
+import { START_END_DATE_REGEX } from '../lib/dates';
 import { AuthorityType } from './authorities';
 import { PROGRAMS } from './programs';
 import { FilingStatus } from './tax_brackets';
@@ -21,12 +22,12 @@ export interface IRAIncentive {
   ami_qualification: AmiQualification | null;
   amount: Amount;
   authority_type: AuthorityType.Federal;
-  end_date: number;
+  end_date: string;
   filing_status?: FilingStatus;
   item: Item;
   owner_status: OwnerStatus[];
   program: string;
-  start_date: number;
+  start_date: string;
   type:
     | PaymentMethod.PosRebate
     | PaymentMethod.TaxCredit
@@ -80,8 +81,14 @@ export const SCHEMA: JSONSchemaType<IRAIncentive[]> = {
         enum: Object.values(FilingStatus),
         nullable: true,
       },
-      start_date: { type: 'number' },
-      end_date: { type: 'number' },
+      start_date: {
+        type: 'string',
+        pattern: START_END_DATE_REGEX.source,
+      },
+      end_date: {
+        type: 'string',
+        pattern: START_END_DATE_REGEX.source,
+      },
       short_description: {
         $ref: 'LocalizableString',
       },

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -132,8 +132,8 @@ export type DerivedFields = {
   eligible_geo_group?: string;
   program: string;
   bonus_available?: boolean;
-  start_date?: string;
-  end_date?: string;
+  start_date: string;
+  end_date: string;
   low_income?: LowIncomeAuthority;
 };
 
@@ -147,12 +147,10 @@ const derivedIncentivePropertySchema = {
   start_date: {
     type: 'string',
     pattern: START_END_DATE_REGEX.source,
-    nullable: true,
   },
   end_date: {
     type: 'string',
     pattern: START_END_DATE_REGEX.source,
-    nullable: true,
   },
   low_income: { type: 'string', nullable: true },
 } as const;

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -11,6 +11,7 @@ import { PROGRAMS } from './programs';
 import { FilingStatus } from './tax_brackets';
 import { AMOUNT_SCHEMA } from './types/amount';
 
+import { START_END_DATE_REGEX } from '../lib/dates';
 import { Amount } from './types/amount';
 import { PaymentMethod } from './types/incentive-types';
 import { ALL_ITEMS, Item } from './types/items';
@@ -131,8 +132,8 @@ export type DerivedFields = {
   eligible_geo_group?: string;
   program: string;
   bonus_available?: boolean;
-  start_date: number;
-  end_date: number;
+  start_date?: string;
+  end_date?: string;
   low_income?: LowIncomeAuthority;
 };
 
@@ -143,8 +144,16 @@ const derivedIncentivePropertySchema = {
   eligible_geo_group: { type: 'string', nullable: true },
   program: { type: 'string', enum: Object.keys(PROGRAMS) },
   bonus_available: { type: 'boolean', nullable: true },
-  start_date: { type: 'number' },
-  end_date: { type: 'number' },
+  start_date: {
+    type: 'string',
+    pattern: START_END_DATE_REGEX.source,
+    nullable: true,
+  },
+  end_date: {
+    type: 'string',
+    pattern: START_END_DATE_REGEX.source,
+    nullable: true,
+  },
   low_income: { type: 'string', nullable: true },
 } as const;
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,16 @@
+/**
+ * This allows representing the start or end date of an incentive at the
+ * granularity of:
+ *
+ * - A whole year
+ * - The first or second half of a year
+ * - One of the quarters of a year
+ * - A month
+ * - A specific day
+ *
+ * It enforces that months are between 01 and 12, and days are between 01 and
+ * 31, but not that the month/day combos are possible (e.g. it will pass
+ * 2024-09-31).
+ */
+export const START_END_DATE_REGEX =
+  /^\d{4}(H[12]|Q[1-4]|-(0[1-9]|1[0-2])(-(0[1-9]|1[0-9]|2[0-9]|3[01]))?)?$/;

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -225,8 +225,8 @@ function transformItems(
 
       // TODO: unclear whether state/utility incentives always have defined
       // end dates.
-      start_date: 2023,
-      end_date: 2024,
+      start_date: '2023',
+      end_date: '2024',
     };
     transformed.push(transformedItem);
   }

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -27,6 +27,8 @@ IRA_INCENTIVES.forEach(incentive => Object.freeze(incentive));
 function translateIncentives(incentives: IRAIncentive[]): WebsiteIncentive[] {
   return incentives.map(incentive => ({
     ...incentive,
+    start_date: parseInt(incentive.start_date),
+    end_date: parseInt(incentive.end_date),
     item_es: t('items', incentive.item, 'es'),
     item: t('items', incentive.item, 'en'),
     program_es: tr(PROGRAMS[incentive.program as keyof Programs].name, 'es'),

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -89,10 +89,10 @@ export const API_INCENTIVE_SCHEMA = {
       minItems: 1,
     },
     start_date: {
-      type: 'number',
+      type: 'string',
     },
     end_date: {
-      type: 'number',
+      type: 'string',
     },
     special_note: {
       type: 'string',

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -40,8 +40,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Up to $15,000 for weatherization projects, excluding windows, siding, roofing and plumbing. Income qualified. Limited yearly funding available."

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -42,8 +42,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
@@ -68,8 +68,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades."
@@ -96,8 +96,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
@@ -123,8 +123,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
@@ -150,8 +150,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers."
@@ -175,8 +175,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "agi_max_limit": 300000,
       "filing_status": "joint",
@@ -201,8 +201,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -58,8 +58,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Weatherization Assistance Program reduces energy costs for households that meet LIHEAP criteria. If you qualify, there's no cost to you."
@@ -84,8 +84,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Income-Eligible Energy Savings Program makes your home healthier, more comfortable and more affordable. If you qualify, there's no cost to you."
@@ -110,8 +110,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades."
@@ -137,8 +137,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Depending on your income, 100% of the cost to install a heat pump water heater, including up to $3,000 towards related electric service upgrades."
@@ -164,8 +164,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "75% up to $750 back on the final purchase of an e-bike or e-cargo bike for income qualified residents."
@@ -191,8 +191,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "30% up to $350 back on the final purchase of an e-bike or e-cargo bike."
@@ -219,8 +219,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $10,000 to install a ground source (geothermal) heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
@@ -247,8 +247,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
@@ -275,8 +275,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$150+ back on installation of heat pump, depending on size. Additional funding available to replace electric baseboard resistance heating."
@@ -304,8 +304,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "10-25% back on installation costs up to $5,000. Includes electricity-generating solar panels and solar domestic hot water technologies."
@@ -331,8 +331,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
@@ -358,8 +358,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers."
@@ -385,8 +385,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Additional $1,500 towards a used EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers. First-come, first-served."
@@ -412,8 +412,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $1,000 back after purchase or lease of a used EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
@@ -438,8 +438,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters."
@@ -465,8 +465,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $600 back on a qualifying electric heat pump water heater when replacing an existing electric water heater or installing in a new home."
@@ -491,8 +491,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Additional $500 for an electrical service upgrade at the same time as installation of a heat pump or heat pump water heater."

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -33,8 +33,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
@@ -57,8 +57,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%."
@@ -81,8 +81,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "more_than_80_ami",
       "eligible": true,
       "short_description": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits."
@@ -105,8 +105,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500."
@@ -129,8 +129,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households."
@@ -153,8 +153,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600."
@@ -178,8 +178,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840."
@@ -203,8 +203,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate."
@@ -228,8 +228,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
@@ -253,8 +253,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2022,
-      "end_date": 2032,
+      "start_date": "2022",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
@@ -278,8 +278,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2022,
-      "end_date": 2032,
+      "start_date": "2022",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
@@ -303,8 +303,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "agi_max_limit": 300000,
       "filing_status": "joint",
@@ -330,8 +330,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "agi_max_limit": 150000,
       "filing_status": "joint",
@@ -356,8 +356,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
@@ -380,8 +380,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
@@ -404,8 +404,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows, and energy audits. Yearly reset."
@@ -429,8 +429,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities."
@@ -453,8 +453,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -33,8 +33,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
@@ -57,8 +57,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Rebate up to $8,000 for low and moderate income households and up to $4,000 for all other households for energy efficiency retrofits."
@@ -81,8 +81,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Rebate up to $4,000 for electrical panel costs. Low-income households receive 100%. Moderate-income households receive 50%."
@@ -105,8 +105,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Electrification rebates for electric wiring. Low-income: 100% coverage up to $2,500. Moderate-income: 50% up to $2,500."
@@ -129,8 +129,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Rebate up to $1,750 for heat pump water heaters: 100% for low-income households, 50% for moderate-income households."
@@ -153,8 +153,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Weatherization rebates cover insulation, air sealing, ventilation. Low-income: 100% up to $1,600. Moderate-income: 50% up to $1,600."
@@ -178,8 +178,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Electrification rebates for electric and induction stoves. Low-income: 100% coverage up to $840. Moderate-income: 50% up to $840."
@@ -203,8 +203,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": "less_than_80_ami",
       "eligible": true,
       "short_description": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate."
@@ -228,8 +228,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
@@ -253,8 +253,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2022,
-      "end_date": 2032,
+      "start_date": "2022",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
@@ -278,8 +278,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2022,
-      "end_date": 2032,
+      "start_date": "2022",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
@@ -303,8 +303,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "agi_max_limit": 300000,
       "filing_status": "joint",
@@ -330,8 +330,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "agi_max_limit": 150000,
       "filing_status": "joint",
@@ -356,8 +356,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
@@ -380,8 +380,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
@@ -404,8 +404,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows, and energy audits. Yearly reset."
@@ -429,8 +429,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities."
@@ -453,8 +453,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2032,
+      "start_date": "2023",
+      "end_date": "2032",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -42,8 +42,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$500 off a heat pump water heater UEF 3.0. Max rebate: $1000 per home."
@@ -69,8 +69,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$500 off a heat pump water heater UEF 3.0. Max rebate: $1000 per home."
@@ -96,8 +96,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$300 off a heat pump water heater UEF 2.0. Max rebate: $1000 per home."
@@ -123,8 +123,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$300 off a heat pump water heater UEF 2.0. Max rebate: $1000 per home."

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -38,8 +38,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Weatherization improvements for homes for limited-income customers."
@@ -64,8 +64,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$400 rebate for TEP residential customers who purchase and install an Energy Star HPWH equipped with a wireless, programmable controller."

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -38,8 +38,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Assistance available for energy efficient retrofitting to homes of income-qualifying customers."
@@ -64,8 +64,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $900 rebate for retiring an existing, qualified system and installing an Energy Star heat pump/AC purchase via a qualified contractor."
@@ -90,8 +90,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $650 rebate for an Energy Star heat pump/AC purchase and installation through a qualified contractor."

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -52,8 +52,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$600 per heating ton for qualifying Ground Source Heat Pumps."
@@ -79,8 +79,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$2200 for qualifying Cold Climate Air Source Heat Pumps."
@@ -106,8 +106,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$2200 for qualifying Cold Climate Mini Split Heat Pumps."
@@ -133,8 +133,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1700 for qualifying High Efficiency Air Source Heat Pumps."
@@ -160,8 +160,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1700 for qualifying Mini Split Heat Pumps."
@@ -186,8 +186,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Free Home Energy Assessment for households with income at 150% of Area Median Income or less."
@@ -213,8 +213,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Weatherization is free for qualifying low-income households. Includes a professional home audit to determine necessary energy-conserving updates."
@@ -240,8 +240,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Income-qualified Coloradans can receive a $6,000 rebate to replace old or high-emitting vehicles with a new EV or PHEV."
@@ -267,8 +267,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Income-qualified Coloradans can receive a $4,000 rebate to replace old or high-emitting vehicles with a used EV or PHEV."
@@ -294,8 +294,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualitying households."
@@ -321,8 +321,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualitying households."
@@ -348,8 +348,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualitying households."
@@ -375,8 +375,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualitying households."
@@ -402,8 +402,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualitying households."
@@ -429,8 +429,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualitying households."
@@ -456,8 +456,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualitying households."
@@ -483,8 +483,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualitying households."
@@ -510,8 +510,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualitying households."
@@ -536,8 +536,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualitying households."
@@ -563,8 +563,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualitying households."
@@ -590,8 +590,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for weatherization projects such as air/duct sealing, insulation, and more, capped annually at $3,000."
@@ -617,8 +617,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate air source heat pumps, capped annually at $3,000."
@@ -644,8 +644,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate air to water heat pumps, capped annually at $3,000."
@@ -671,8 +671,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate ground source heat pumps, capped annually at $3,000."
@@ -698,8 +698,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for qualifying ductless heat pumps, capped annually at $3,000."
@@ -725,8 +725,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for heat pump water heaters, capped annually at $3,000."
@@ -752,8 +752,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for heat pump clothes dryer, capped annually at $3,000."
@@ -779,8 +779,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for wiring projects related to electrification, capped annually at $3,000."
@@ -806,8 +806,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for panel upgrades related to electrification, capped annually at $3,000."
@@ -832,8 +832,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for WiFi-enabled smart thermostats or programmable thermostats, capped annually at $3,000."
@@ -859,8 +859,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates of up to 25% of project costs for induction cooktops and stoves, capped annually at $3,000."
@@ -887,8 +887,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebates for solar photovoltaic installation: $250/kW from 0-6 kW, and $100/kW from 6-25 kW."
@@ -913,8 +913,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
@@ -940,8 +940,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "12.9% discount on battery storage systems through Colorado State tax credit and sales tax exemption."
@@ -967,8 +967,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "State tax credit of $5,000 for the purchase or lease of a new EV (max MSRP: $80,000)."
@@ -994,8 +994,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Additional state tax credit of $2,500 for Coloradans purchasing or leasing an EV with a max MSRP of $35,000."

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -42,8 +42,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "The Home Energy Solutions program provides income-eligible households with no-cost energy assessments and incentives for weatherization services."
@@ -70,8 +70,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$3,000 rebate for a qualifying used electric vehicle for income-qualifying individuals."
@@ -97,8 +97,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$2,250 rebate for a qualifying new electric vehicle."
@@ -124,8 +124,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Bonus $2,000 off a qualifying new electric vehicle for income-eligible individuals."
@@ -152,8 +152,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,500 per ton after-purchase rebate for qualifying ground source heat pumps, up to $15,000."
@@ -180,8 +180,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$750 per ton after-purchase rebate for qualifying air source heat pumps."
@@ -206,8 +206,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$650 off eligible Energy Star certified Heat Pump Water Heaters."
@@ -232,8 +232,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Bonus $500 off ground source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months."
@@ -258,8 +258,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Bonus $500 off air source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months."

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -44,8 +44,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for switching to ducted heating systems. Income-qualified residents only."
@@ -71,8 +71,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for switching to ductless heating systems. Income-qualified residents only."
@@ -98,8 +98,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for switching to electric resistance stoves. Income-qualified residents only."
@@ -125,8 +125,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for switching to induction cooktops. Income-qualified residents only."
@@ -152,8 +152,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for switching to heat pump water heaters. Income-qualified residents only."
@@ -179,8 +179,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for upgrading electrical panels. Income-qualified residents only."
@@ -206,8 +206,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for home weatherization (insulation and air sealing). Income-qualified residents only."
@@ -233,8 +233,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for income-qualified homeowners to have solar photovoltaic (PV) systems installed by local contractors."
@@ -260,8 +260,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$375-$700 rebate for qualified ducted air source heat pump systems."
@@ -287,8 +287,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$375-$700 rebate for qualified variable speed (ductless) mini-split heat pumps systems."
@@ -313,8 +313,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$500 rebate for electric riding lawn mowers."
@@ -340,8 +340,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$75-$200 rebate for ENERGY STAR® or ENERGY STAR® Most Efficient qualified clothes dryers."
@@ -366,8 +366,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$75 rebate for electric push lawn mowers."
@@ -392,8 +392,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 rebate for ENERGY STAR® qualified smart thermostats."

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -39,8 +39,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $250 for attic insulation. Addition of R-38 or greater required."
@@ -66,8 +66,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $300 for air sealing. Must be completed by a participating program contractor."
@@ -93,8 +93,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $300 for duct sealing."
@@ -119,8 +119,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $75 for smart thermostats."
@@ -146,8 +146,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $1,000 for ENERGY STAR certified mini-split and ground source heat pumps."
@@ -173,8 +173,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $500 for ENERGY STAR certified heat pump water heaters."
@@ -200,8 +200,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Rebate for 50% of cost up to $50 for ENERGY STAR certified electric vehicle chargers. Must be 208/240 volt level 2 charger with dedicated circuit."

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -39,8 +39,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,500 rebate on a purchased or leased new electric vehicle."
@@ -65,8 +65,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1000 for ductless heat pumps. Must be 18+ SEER and HSPF 8.8+, or 17+ SEER2 and HSPF2 7.5+."
@@ -91,8 +91,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$850 for 19+ SEER or 18+ SEER2 Air Source Heat Pump."
@@ -117,8 +117,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$800 for 17+ SEER or 16+ EER2 Ground Source Heat Pump."
@@ -143,8 +143,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$750 for 18 SEER or 17-17.99 SEER2 Air Source Heat Pump."
@@ -170,8 +170,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$500 rebate when you buy or lease an EV, enroll in an eligible Time of Day rate and install a Level 2 charger."
@@ -196,8 +196,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$250 for 16-17 SEER or 15.2-16.99 SEER2 Air Source Heat Pump."
@@ -223,8 +223,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $250 for a qualifying ENERGY STAR heat pump clothes dryer."
@@ -249,8 +249,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$150 for 15 SEER or 14.3-15.19 SEER2 Air Source Heat Pump."
@@ -275,8 +275,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$125 for roof & attic insulation. Must insulate a minimum of 500 square feet of attic area."
@@ -301,8 +301,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$125 for above-grade wall insulation. Must insulate a minimum of 250 square feet of attic area."
@@ -326,8 +326,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 for new Wi-Fi enabled thermostat."
@@ -352,8 +352,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 for rim/band joist insulation. Must insulate a minimum of 50 square feet and all accessible rim joist areas."
@@ -378,8 +378,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 for basement wall insulation. Must insulate a minimum of 200 square feet of wall area."
@@ -404,8 +404,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 for crawl space wall insulation. Must insulate a minimum of 100 square feet of wall area."
@@ -430,8 +430,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 for floor insulation. Must insulate a minimum of 100 square feet of wall area."
@@ -456,8 +456,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$40 for glass patio door unit / sliding patio door or picture window. No limit."
@@ -482,8 +482,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$25 for kneewall insulation. Must insulate a minimum of 100 square feet of attic area."
@@ -508,8 +508,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$15 per window rebate for window replacement. No limit on number of windows."

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -48,8 +48,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Free replacement of electric dryers (10 years or older) when you meet income eligibility requirements."
@@ -74,8 +74,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Receive a free Smart Thermostat valued at $300 with free professional installation."
@@ -101,8 +101,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $4,000 income qualified instant rebate from qualifying distributors when you replace old air condition system with an air source heat pump."
@@ -127,8 +127,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $3,600 income qualified instant rebate when you replace your old air condition system with higher efficiency equipment."
@@ -153,8 +153,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $3,200 income qualified discount from qualifying distributors when your replace your old air conditioning system with a ductless heat pump."
@@ -180,8 +180,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $2,400 instant rebate from qualifying distributors when you replace your old air condition system with an air source heat pump."
@@ -206,8 +206,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Receive up to $1,600 instant rebate from qualifying distributors when you replace your old air condition system with higher efficiency equipment."
@@ -232,8 +232,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $1,600 discount from qualifying distributors when your replace your old air conditioning system with a ductless heat pump."
@@ -258,8 +258,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$400 rebate for ENERGY STAR certified heat pump water heaters. Redeemable at Lowe's. Limit 1 per customer."
@@ -285,8 +285,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$200 rebate for ENERGY STAR certified heat pump dryers. Redeemable at Home Depot. Limit 1 per customer."
@@ -312,8 +312,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 rebate for ENERGY STAR certified electric dryers. Redeemable at Home Depot. Limit 1 per customer."
@@ -340,8 +340,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "NV Energy provides a rebate of up to $400 for weather stripping, duct sealing, and insulation."

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -45,8 +45,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $7,500 in weatherization and health and safety services for income eligible households."
@@ -73,8 +73,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Instant rebate for $500-$2,000 off a new electric vehicle when purchased from a participating dealer. Can be combined with the federal tax credit."
@@ -100,8 +100,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Instant or mail-in rebate for $1,000 off an eligible Energy Star certified heat pump water heater when purchased at a participating retailer."
@@ -127,8 +127,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$450 to $600 off an Energy Star certified air source heat pump when installed by an eligible contractor."
@@ -153,8 +153,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$600 off an Energy Star certified heat pump water heater when installed by a participating contractor."
@@ -179,8 +179,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$600 off an eligible high efficiency cold climate ducted heat pump system, when installed by a participating contractor."
@@ -205,8 +205,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $240 off an Energy Star certified ductless mini-split heat pump system when installed by a participating contractor."
@@ -232,8 +232,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,000 to $4,000 in incentives available for seal and insulate packages to improve your home's comfort."
@@ -259,8 +259,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Tax credit for 25% of the cost for a qualifying geothermal energy system, including installation costs, up to $5,000."

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -38,8 +38,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Receive no cost energy efficient weatherization upgrades for qualified income and age levels by qualified service providers."
@@ -65,8 +65,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Receive up to a $400 rebate for installing a heat pump water heater above 40 gallons in capacity."
@@ -91,8 +91,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Participate in Dominion Energy's EV charging control events using your level 2 charger and receive a $125 rebate."
@@ -117,8 +117,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Dominion Energy customers can receive a $100 rebate on a new electric clothes dryer."

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -44,8 +44,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "The Weatherization Assistance Program offers free services including energy audits, insulation and air sealing for eligible income based households."
@@ -72,8 +72,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "The MileageSmart program covers 25% of the upfront cost of a used high efficiency vehicle, up to $5,000, for low/moderate income car buyers."
@@ -100,8 +100,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "agi_max_limit": 90001,
       "filing_status": "joint",
@@ -130,8 +130,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "The incentive amount for scrapping an eligible Internal Combustion Engine (ICE) vehicle is $5,000 based on income eligibility."
@@ -159,8 +159,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "agi_max_limit": 90001,
       "filing_status": "joint",
@@ -189,8 +189,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "agi_max_limit": 100001,
       "agi_min_limit": 60001,
@@ -221,8 +221,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "agi_max_limit": 100001,
       "agi_min_limit": 60001,
@@ -251,8 +251,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Work with a contractor to install your ducted heat pump and get a $1,000-$2,000 instant discount."
@@ -278,8 +278,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor."
@@ -306,8 +306,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Hire a contractor and get a $300-$600 discount from your utility or Efficiency Vermont."
@@ -333,8 +333,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Receive up to $400 cash back on qualifying ENERGY STAR® electric clothes dryer models."
@@ -360,8 +360,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $8,750 on heat pump installation."
@@ -387,8 +387,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "BED customers may receive a rebate up to $2,500 on qualifying HPs, plus an additional $500 for a second HP."
@@ -414,8 +414,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $900 back on qualifying level 2 charger purchased within 60 days of vehicle purchase or lease."
@@ -441,8 +441,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project cost up to $4,000."
@@ -468,8 +468,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project costs up to $9,500."
@@ -496,8 +496,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Hire a participating contractor and get up to $2,100 cash back per ton on qualifying equipment for a Ground Source HP."
@@ -524,8 +524,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "BED customers may receive a post purchase rebate up to $12,000 when you install an air-to-water heat pump."
@@ -552,8 +552,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "BED customers may receive a rebate up to $2,500 on qualifying GSHPs, plus an additional $500 for a second GSHP."
@@ -580,8 +580,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Work with an Efficiency Excellence Network contractor to install your air-to-water heat pump and get up to $6,000 back."
@@ -607,8 +607,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible Vermonters can get a $500 rebate for working with an Efficiency Excellence Network contractor to install an air-to-water heat pump."
@@ -634,8 +634,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "BED customers may receive a rebate up to $2,500 on qualifying HPs, plus an additional $500 for a second HP."
@@ -661,8 +661,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible Vermonters qualify for a $500 bonus rebate on eligible Ground Source HP."
@@ -688,8 +688,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "BED customers may receive up to $800 rebate for a HPWH."
@@ -715,8 +715,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible Vermonters who are BED customers are eligible for an additional enhanced rebate of $400 when you install a qualified ducted heat pump."
@@ -742,8 +742,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible BED customers qualify for a $400 enhanced rebate for a ductless HP."
@@ -769,8 +769,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "Income-eligible Vermonters/BED customers are eligible for an additional enhanced rebate of $400 for installing a qualified air-to-water heat pump."
@@ -796,8 +796,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Vermonters whose household income is at or below the moderate income guidelines qualify for a $200-$800 bonus rebate on a ducted heat pump."
@@ -823,8 +823,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible Vermonters qualify for a $200-$1,000 bonus rebate on a ductless heat pump, depending on their utility."
@@ -850,8 +850,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Income-eligible Vermonters may qualify for a $200 bonus rebate on HPWH."
@@ -877,8 +877,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing."

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -38,8 +38,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Instant discounts for electric heat pump water heaters starting at $300 through a Trade Ally contractor."
@@ -65,8 +65,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,125 for ENERGY STAR Qualified Air Sealing for income-qualified customers. Must be completed with Trade Ally contractor installed insulation."
@@ -92,8 +92,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,000 for Air Source Heat Pump replacing natural gas or electric primary heating source."
@@ -119,8 +119,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,000 for Certified Geothermal Heat Pump (with natural gas service)."
@@ -146,8 +146,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$750 for Certified Geothermal Heat Pump (with no natural gas service)."
@@ -173,8 +173,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$675 for ENERGY STAR Qualified Air Sealing. Must be completed with Trade Ally contractor installed attic or wall insulation improvements."
@@ -200,8 +200,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$675 for Attic Insulation for income-qualified customers."
@@ -227,8 +227,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$525 for Attic Insulation."
@@ -254,8 +254,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$500 for qualifying solar electric systems. Available to rural residential customers."
@@ -281,8 +281,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$450 for Wall Insulation."
@@ -308,8 +308,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$400 for Air Source Heat Pump replacing propane, oil, existing heat pump etc."
@@ -335,8 +335,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$225 for Foundation Insulation for income-qualified customers. Must be completed along with Trade Ally contractor installed insulation."
@@ -362,8 +362,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$200 cash back for self-installed attic insulation and air sealing."
@@ -389,8 +389,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$200 cash back for qualified self-installed attic insulation and air sealing."
@@ -416,8 +416,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$150 for Foundation Insulation. Must be completed along with Trade Ally contractor installed attic or wall insulation improvements."
@@ -443,8 +443,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$75 for Duct Sealing & Insulation. Must be completed along with Trade Ally contractor installed attic or wall insulation improvements."
@@ -470,8 +470,8 @@
         "homeowner",
         "renter"
       ],
-      "start_date": 2023,
-      "end_date": 2024,
+      "start_date": "2023",
+      "end_date": "2024",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$50 for Smart Thermostats. Available as instant discounts in the online marketplace or as rebates."

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'tap';
+import { START_END_DATE_REGEX } from '../../src/lib/dates';
+
+const VALID_DATES = [
+  '2024',
+  '2024-09',
+  '2024-09-30',
+  '2024Q1',
+  '2024Q4',
+  '2024H1',
+];
+
+const INVALID_DATES = [
+  '',
+  '202',
+  '2024/09/30',
+  '9/30/2024',
+  '09/30/2024',
+  '2024-13-01',
+  '2024-12-32',
+  '2024H3',
+  '2024Q5',
+  '2024HQ',
+  '2024 H1',
+  '2024 Q1',
+];
+
+test('valid dates match the regex', async t => {
+  VALID_DATES.forEach(date => {
+    t.ok(START_END_DATE_REGEX.test(date), `${date} should be valid`);
+  });
+});
+
+test('invalid dates do not match the regex', async t => {
+  INVALID_DATES.forEach(date => {
+    t.notOk(START_END_DATE_REGEX.test(date), `${date} should be invalid`);
+  });
+});

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -180,63 +180,63 @@ test('correctly evaluates scenerio "Single w/ $120k Household income in the Bron
   const posRebates = _.keyBy(pos_rebate_incentives, 'item');
   t.equal(posRebates['electric_panel'].eligible, true);
   t.equal(posRebates['electric_panel'].amount.number, 4000);
-  t.equal(posRebates['electric_panel'].start_date, 2023);
+  t.equal(posRebates['electric_panel'].start_date, '2023');
   t.equal(posRebates['electric_stove'].eligible, true);
   t.equal(posRebates['electric_stove'].amount.number, 840);
-  t.equal(posRebates['electric_stove'].start_date, 2023);
+  t.equal(posRebates['electric_stove'].start_date, '2023');
   t.equal(posRebates['electric_wiring'].eligible, true);
   t.equal(posRebates['electric_wiring'].amount.number, 2500);
-  t.equal(posRebates['electric_wiring'].start_date, 2023);
+  t.equal(posRebates['electric_wiring'].start_date, '2023');
   t.equal(posRebates['heat_pump_water_heater'].eligible, true);
   t.equal(posRebates['heat_pump_water_heater'].amount.number, 1750);
-  t.equal(posRebates['heat_pump_water_heater'].start_date, 2023);
+  t.equal(posRebates['heat_pump_water_heater'].start_date, '2023');
   t.equal(posRebates['heat_pump_air_conditioner_heater'].eligible, true);
   t.equal(posRebates['heat_pump_air_conditioner_heater'].amount.number, 8000);
-  t.equal(posRebates['heat_pump_air_conditioner_heater'].start_date, 2023);
+  t.equal(posRebates['heat_pump_air_conditioner_heater'].start_date, '2023');
   t.equal(posRebates['heat_pump_clothes_dryer'].eligible, true);
   t.equal(posRebates['heat_pump_clothes_dryer'].amount.number, 840);
-  t.equal(posRebates['heat_pump_clothes_dryer'].start_date, 2023);
+  t.equal(posRebates['heat_pump_clothes_dryer'].start_date, '2023');
   t.equal(posRebates['weatherization'].eligible, true);
   t.equal(posRebates['weatherization'].amount.number, 1600);
-  t.equal(posRebates['weatherization'].start_date, 2023);
+  t.equal(posRebates['weatherization'].start_date, '2023');
 
   t.equal(performance_rebate_incentives[0].eligible, true);
   t.equal(performance_rebate_incentives[0].amount.number, 4000);
-  t.equal(performance_rebate_incentives[0].start_date, 2023);
+  t.equal(performance_rebate_incentives[0].start_date, '2023');
 
   const taxCredits = _.keyBy(tax_credit_incentives, 'item');
   t.equal(taxCredits['battery_storage_installation'].eligible, true);
   t.equal(taxCredits['battery_storage_installation'].amount.number, 0.3); // will be displayed as 30%
-  t.equal(taxCredits['battery_storage_installation'].start_date, 2023);
+  t.equal(taxCredits['battery_storage_installation'].start_date, '2023');
   t.equal(taxCredits['geothermal_heating_installation'].eligible, true);
   t.equal(taxCredits['geothermal_heating_installation'].amount.number, 0.3); // will be displayed as 30%
-  t.equal(taxCredits['geothermal_heating_installation'].start_date, 2022);
+  t.equal(taxCredits['geothermal_heating_installation'].start_date, '2022');
   t.equal(taxCredits['electric_panel'].eligible, true);
   t.equal(taxCredits['electric_panel'].amount.number, 600);
-  t.equal(taxCredits['electric_panel'].start_date, 2023);
+  t.equal(taxCredits['electric_panel'].start_date, '2023');
   t.equal(taxCredits['electric_vehicle_charger'].eligible, true);
   t.equal(taxCredits['electric_vehicle_charger'].amount.number, 1000);
-  t.equal(taxCredits['electric_vehicle_charger'].start_date, 2023);
+  t.equal(taxCredits['electric_vehicle_charger'].start_date, '2023');
   t.equal(taxCredits['new_electric_vehicle'].eligible, true);
   t.equal(taxCredits['new_electric_vehicle'].amount.number, 7500);
-  t.equal(taxCredits['new_electric_vehicle'].start_date, 2023);
+  t.equal(taxCredits['new_electric_vehicle'].start_date, '2023');
   t.equal(taxCredits['heat_pump_air_conditioner_heater'].eligible, true);
   t.equal(taxCredits['heat_pump_air_conditioner_heater'].amount.number, 2000);
-  t.equal(taxCredits['heat_pump_air_conditioner_heater'].start_date, 2023);
+  t.equal(taxCredits['heat_pump_air_conditioner_heater'].start_date, '2023');
   t.equal(taxCredits['heat_pump_water_heater'].eligible, true);
   t.equal(taxCredits['heat_pump_water_heater'].amount.number, 2000);
-  t.equal(taxCredits['heat_pump_water_heater'].start_date, 2023);
+  t.equal(taxCredits['heat_pump_water_heater'].start_date, '2023');
   t.equal(taxCredits['rooftop_solar_installation'].eligible, true);
   t.equal(taxCredits['rooftop_solar_installation'].amount.number, 0.3);
   t.equal(taxCredits['rooftop_solar_installation'].amount.representative, 4770);
-  t.equal(taxCredits['rooftop_solar_installation'].start_date, 2022);
+  t.equal(taxCredits['rooftop_solar_installation'].start_date, '2022');
   t.equal(taxCredits['weatherization'].eligible, true);
   t.equal(taxCredits['weatherization'].amount.number, 1200);
-  t.equal(taxCredits['weatherization'].start_date, 2023);
+  t.equal(taxCredits['weatherization'].start_date, '2023');
   // everything except used EV should be eligible for tax credit (agi limit is 75k)
   t.equal(taxCredits['used_electric_vehicle'].eligible, false);
   t.equal(taxCredits['used_electric_vehicle'].amount.number, 4000);
-  t.equal(taxCredits['used_electric_vehicle'].start_date, 2023);
+  t.equal(taxCredits['used_electric_vehicle'].start_date, '2023');
 });
 
 test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k Household income in San Francisco"', async t => {
@@ -290,63 +290,63 @@ test('correctly evaluates scenerio "Married filing jointly w/ 2 kids and $250k H
   const posRebates = _.keyBy(pos_rebate_incentives, 'item');
   t.equal(posRebates['electric_panel'].eligible, true);
   t.equal(posRebates['electric_panel'].amount.number, 4000);
-  t.equal(posRebates['electric_panel'].start_date, 2023);
+  t.equal(posRebates['electric_panel'].start_date, '2023');
   t.equal(posRebates['electric_stove'].eligible, true);
   t.equal(posRebates['electric_stove'].amount.number, 840);
-  t.equal(posRebates['electric_stove'].start_date, 2023);
+  t.equal(posRebates['electric_stove'].start_date, '2023');
   t.equal(posRebates['electric_wiring'].eligible, true);
   t.equal(posRebates['electric_wiring'].amount.number, 2500);
-  t.equal(posRebates['electric_wiring'].start_date, 2023);
+  t.equal(posRebates['electric_wiring'].start_date, '2023');
   t.equal(posRebates['heat_pump_water_heater'].eligible, true);
   t.equal(posRebates['heat_pump_water_heater'].amount.number, 1750);
-  t.equal(posRebates['heat_pump_water_heater'].start_date, 2023);
+  t.equal(posRebates['heat_pump_water_heater'].start_date, '2023');
   t.equal(posRebates['heat_pump_air_conditioner_heater'].eligible, true);
   t.equal(posRebates['heat_pump_air_conditioner_heater'].amount.number, 8000);
-  t.equal(posRebates['heat_pump_air_conditioner_heater'].start_date, 2023);
+  t.equal(posRebates['heat_pump_air_conditioner_heater'].start_date, '2023');
   t.equal(posRebates['heat_pump_clothes_dryer'].eligible, true);
   t.equal(posRebates['heat_pump_clothes_dryer'].amount.number, 840);
-  t.equal(posRebates['heat_pump_clothes_dryer'].start_date, 2023);
+  t.equal(posRebates['heat_pump_clothes_dryer'].start_date, '2023');
   t.equal(posRebates['weatherization'].eligible, true);
   t.equal(posRebates['weatherization'].amount.number, 1600);
-  t.equal(posRebates['weatherization'].start_date, 2023);
+  t.equal(posRebates['weatherization'].start_date, '2023');
 
   t.equal(performance_rebate_incentives[0].eligible, true);
   t.equal(performance_rebate_incentives[0].amount.number, 4000);
-  t.equal(performance_rebate_incentives[0].start_date, 2023);
+  t.equal(performance_rebate_incentives[0].start_date, '2023');
 
   const taxCredits = _.keyBy(tax_credit_incentives, 'item');
   t.equal(taxCredits['battery_storage_installation'].eligible, true);
   t.equal(taxCredits['battery_storage_installation'].amount.number, 0.3); // will be displayed as 30%
-  t.equal(taxCredits['battery_storage_installation'].start_date, 2023);
+  t.equal(taxCredits['battery_storage_installation'].start_date, '2023');
   t.equal(taxCredits['geothermal_heating_installation'].eligible, true);
   t.equal(taxCredits['geothermal_heating_installation'].amount.number, 0.3); // will be displayed as 30%
-  t.equal(taxCredits['geothermal_heating_installation'].start_date, 2022);
+  t.equal(taxCredits['geothermal_heating_installation'].start_date, '2022');
   t.equal(taxCredits['electric_panel'].eligible, true);
   t.equal(taxCredits['electric_panel'].amount.number, 600);
-  t.equal(taxCredits['electric_panel'].start_date, 2023);
+  t.equal(taxCredits['electric_panel'].start_date, '2023');
   t.equal(taxCredits['electric_vehicle_charger'].eligible, true);
   t.equal(taxCredits['electric_vehicle_charger'].amount.number, 1000);
-  t.equal(taxCredits['electric_vehicle_charger'].start_date, 2023);
+  t.equal(taxCredits['electric_vehicle_charger'].start_date, '2023');
   t.equal(taxCredits['new_electric_vehicle'].eligible, true);
   t.equal(taxCredits['new_electric_vehicle'].amount.number, 7500);
-  t.equal(taxCredits['new_electric_vehicle'].start_date, 2023);
+  t.equal(taxCredits['new_electric_vehicle'].start_date, '2023');
   t.equal(taxCredits['heat_pump_air_conditioner_heater'].eligible, true);
   t.equal(taxCredits['heat_pump_air_conditioner_heater'].amount.number, 2000);
-  t.equal(taxCredits['heat_pump_air_conditioner_heater'].start_date, 2023);
+  t.equal(taxCredits['heat_pump_air_conditioner_heater'].start_date, '2023');
   t.equal(taxCredits['heat_pump_water_heater'].eligible, true);
   t.equal(taxCredits['heat_pump_water_heater'].amount.number, 2000);
-  t.equal(taxCredits['heat_pump_water_heater'].start_date, 2023);
+  t.equal(taxCredits['heat_pump_water_heater'].start_date, '2023');
   t.equal(taxCredits['rooftop_solar_installation'].eligible, true);
   t.equal(taxCredits['rooftop_solar_installation'].amount.number, 0.3);
   t.equal(taxCredits['rooftop_solar_installation'].amount.representative, 4572);
-  t.equal(taxCredits['rooftop_solar_installation'].start_date, 2022);
+  t.equal(taxCredits['rooftop_solar_installation'].start_date, '2022');
   t.equal(taxCredits['weatherization'].eligible, true);
   t.equal(taxCredits['weatherization'].amount.number, 1200);
-  t.equal(taxCredits['weatherization'].start_date, 2023);
+  t.equal(taxCredits['weatherization'].start_date, '2023');
   // everything except used EV should be eligible for tax credit (agi limit is 75k)
   t.equal(taxCredits['used_electric_vehicle'].eligible, false);
   t.equal(taxCredits['used_electric_vehicle'].amount.number, 4000);
-  t.equal(taxCredits['used_electric_vehicle'].start_date, 2023);
+  t.equal(taxCredits['used_electric_vehicle'].start_date, '2023');
 });
 
 test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in Missisippi"', async t => {
@@ -400,67 +400,67 @@ test('correctly evaluates scenerio "Hoh w/ 6 kids and $500k Household income in 
   const posRebates = _.keyBy(pos_rebate_incentives, 'item');
   t.equal(posRebates['electric_panel'].eligible, false);
   t.equal(posRebates['electric_panel'].amount.number, 4000);
-  t.equal(posRebates['electric_panel'].start_date, 2023);
+  t.equal(posRebates['electric_panel'].start_date, '2023');
   t.equal(posRebates['electric_stove'].eligible, false);
   t.equal(posRebates['electric_stove'].amount.number, 840);
-  t.equal(posRebates['electric_stove'].start_date, 2023);
+  t.equal(posRebates['electric_stove'].start_date, '2023');
   t.equal(posRebates['electric_wiring'].eligible, false);
   t.equal(posRebates['electric_wiring'].amount.number, 2500);
-  t.equal(posRebates['electric_wiring'].start_date, 2023);
+  t.equal(posRebates['electric_wiring'].start_date, '2023');
   t.equal(posRebates['heat_pump_water_heater'].eligible, false);
   t.equal(posRebates['heat_pump_water_heater'].amount.number, 1750);
-  t.equal(posRebates['heat_pump_water_heater'].start_date, 2023);
+  t.equal(posRebates['heat_pump_water_heater'].start_date, '2023');
   t.equal(posRebates['heat_pump_air_conditioner_heater'].eligible, false);
   t.equal(posRebates['heat_pump_air_conditioner_heater'].amount.number, 8000);
-  t.equal(posRebates['heat_pump_air_conditioner_heater'].start_date, 2023);
+  t.equal(posRebates['heat_pump_air_conditioner_heater'].start_date, '2023');
   t.equal(posRebates['heat_pump_clothes_dryer'].eligible, false);
   t.equal(posRebates['heat_pump_clothes_dryer'].amount.number, 840);
-  t.equal(posRebates['heat_pump_clothes_dryer'].start_date, 2023);
+  t.equal(posRebates['heat_pump_clothes_dryer'].start_date, '2023');
   t.equal(posRebates['weatherization'].eligible, false);
   t.equal(posRebates['weatherization'].amount.number, 1600);
-  t.equal(posRebates['weatherization'].start_date, 2023);
+  t.equal(posRebates['weatherization'].start_date, '2023');
 
   // only items.efficiency_rebates are eligible here:
   t.equal(performance_rebate_incentives[0].eligible, true);
   t.equal(performance_rebate_incentives[0].amount.number, 4000);
-  t.equal(performance_rebate_incentives[0].start_date, 2023);
+  t.equal(performance_rebate_incentives[0].start_date, '2023');
 
   const taxCredits = _.keyBy(tax_credit_incentives, 'item');
   t.equal(taxCredits['battery_storage_installation'].eligible, true);
   t.equal(taxCredits['battery_storage_installation'].amount.number, 0.3); // will be displayed as 30%
-  t.equal(taxCredits['battery_storage_installation'].start_date, 2023);
+  t.equal(taxCredits['battery_storage_installation'].start_date, '2023');
   t.equal(taxCredits['geothermal_heating_installation'].eligible, true);
   t.equal(taxCredits['geothermal_heating_installation'].amount.number, 0.3); // will be displayed as 30%
-  t.equal(taxCredits['geothermal_heating_installation'].start_date, 2022);
+  t.equal(taxCredits['geothermal_heating_installation'].start_date, '2022');
   t.equal(taxCredits['electric_panel'].eligible, true);
   t.equal(taxCredits['electric_panel'].amount.number, 600);
-  t.equal(taxCredits['electric_panel'].start_date, 2023);
+  t.equal(taxCredits['electric_panel'].start_date, '2023');
   t.equal(taxCredits['electric_vehicle_charger'].eligible, true);
   t.equal(taxCredits['electric_vehicle_charger'].amount.number, 1000);
-  t.equal(taxCredits['electric_vehicle_charger'].start_date, 2023);
+  t.equal(taxCredits['electric_vehicle_charger'].start_date, '2023');
   t.equal(taxCredits['heat_pump_air_conditioner_heater'].eligible, true);
   t.equal(taxCredits['heat_pump_air_conditioner_heater'].amount.number, 2000);
-  t.equal(taxCredits['heat_pump_air_conditioner_heater'].start_date, 2023);
+  t.equal(taxCredits['heat_pump_air_conditioner_heater'].start_date, '2023');
   t.equal(taxCredits['heat_pump_water_heater'].eligible, true);
   t.equal(taxCredits['heat_pump_water_heater'].amount.number, 2000);
-  t.equal(taxCredits['heat_pump_water_heater'].start_date, 2023);
+  t.equal(taxCredits['heat_pump_water_heater'].start_date, '2023');
   t.equal(taxCredits['rooftop_solar_installation'].eligible, true);
   t.equal(taxCredits['rooftop_solar_installation'].amount.number, 0.3);
   t.equal(
     taxCredits['rooftop_solar_installation'].amount.representative,
     4428.9,
   );
-  t.equal(taxCredits['rooftop_solar_installation'].start_date, 2022);
+  t.equal(taxCredits['rooftop_solar_installation'].start_date, '2022');
   t.equal(taxCredits['weatherization'].eligible, true);
   t.equal(taxCredits['weatherization'].amount.number, 1200);
-  t.equal(taxCredits['weatherization'].start_date, 2023);
+  t.equal(taxCredits['weatherization'].start_date, '2023');
   // new and used EVs should not be eligible:
   t.equal(taxCredits['new_electric_vehicle'].eligible, false);
   t.equal(taxCredits['new_electric_vehicle'].amount.number, 7500);
-  t.equal(taxCredits['new_electric_vehicle'].start_date, 2023);
+  t.equal(taxCredits['new_electric_vehicle'].start_date, '2023');
   t.equal(taxCredits['used_electric_vehicle'].eligible, false);
   t.equal(taxCredits['used_electric_vehicle'].amount.number, 4000);
-  t.equal(taxCredits['used_electric_vehicle'].start_date, 2023);
+  t.equal(taxCredits['used_electric_vehicle'].start_date, '2023');
 });
 
 test('correctly sorts incentives', async t => {
@@ -494,8 +494,8 @@ test('correct filtering of county incentives', async t => {
     id: 'CO',
     authority_type: AuthorityType.County,
     authority: 'mock-county-authority',
-    start_date: 2023,
-    end_date: 2024,
+    start_date: '2023',
+    end_date: '2024',
     payment_methods: [PaymentMethod.AccountCredit],
     item: 'heat_pump_air_conditioner_heater',
     program: 'ri_hvacAndWaterHeaterIncentives',
@@ -556,8 +556,8 @@ test('correct filtering of city incentives', async t => {
     id: 'CO',
     authority_type: AuthorityType.City,
     authority: 'mock-city-authority',
-    start_date: 2023,
-    end_date: 2024,
+    start_date: '2023',
+    end_date: '2024',
     payment_methods: [PaymentMethod.AccountCredit],
     item: 'heat_pump_air_conditioner_heater',
     program: 'ri_hvacAndWaterHeaterIncentives',

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -66,11 +66,11 @@ test('response is valid and correct', async t => {
     ),
   );
 
-  t.same(
+  t.strictSame(
     calculatorResponse.pos_rebate_incentives,
     expectedResponse.pos_rebate_incentives,
   );
-  t.same(
+  t.strictSame(
     calculatorResponse.tax_credit_incentives,
     expectedResponse.tax_credit_incentives,
   );

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -47,7 +47,7 @@ async function validateResponse(
 
   // Verify the specific content of the response
   const expectedResponse = JSON.parse(fs.readFileSync(fixtureFile, 'utf-8'));
-  t.same(
+  t.strictSame(
     calculatorResponse,
     expectedResponse,
     `response does not match ${fixtureFile}`,
@@ -712,6 +712,6 @@ test('/utilities', async t => {
     await validator(utilitiesResponse);
     t.equal(validator.errors, null);
 
-    t.same(utilitiesResponse, expectedResponse);
+    t.strictSame(utilitiesResponse, expectedResponse);
   }
 });


### PR DESCRIPTION
## Description

This is mechanical: just stringifying the `start_date` and `end_date`
of every incentive record, and changing the v1 API to serve them as
strings instead of numbers.

In the process, I made the slightly horrifying discovery that `t.same`
in Tap considers values to be "same" up to type coercion; that is,
`2024` and `"2024"` are considered "same". I changed usages of that
test method to `strictSame`, which doesn't do type coercion.

I'll follow up with a PR to be smarter about parsing the values that
are in spreadsheets -- some state sheets have precise dates.

The new embed frontend has already been updated to handle the dates
being either numbers or strings. (It currently doesn't even read them,
and in fact the server code is hard-overwriting all state incentives'
start/end dates with 2023 and 2024 respectively. I'll be changing the
latter shortly.)

## Test Plan

`yarn lint` and `yarn test`. New test to validate the regex I'm using
to enforce date format in the JSON files.
