### PR TITLE
Add Electrify DC logo to data partners

### DIFF
--- a/data/data_partners.json
+++ b/data/data_partners.json
@@ -1,4 +1,14 @@
 {
+  "DC": {
+    "dc-electrify-dc": {
+      "name": "Electrify DC",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-electrify-dc-blue.png",
+        "width": 300,
+        "height": 200
+      }
+    }
+  },
   "NV": {
     "nv-nevada-clean-energy-fund": {
       "name": "Nevada Clean Energy Fund",

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -21,7 +21,16 @@
     "city": "Washington",
     "county": "District of Columbia"
   },
-  "data_partners": {},
+  "data_partners": {
+    "dc-electrify-dc": {
+      "name": "Electrify DC",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-electrify-dc-blue.png",
+        "width": 300,
+        "height": 200
+      }
+    }
+  },
   "incentives": [
     {
       "payment_methods": [


### PR DESCRIPTION
Adds Electrify DC's logo to the list of data partners for DC

![electrify-dc-logo-blue](https://storage.googleapis.com/rewiring-america-incentives-assets/dc-electrify-dc-blue.png)
