### PR TITLE
Update geo groups to be configured similar to low-income thresholds.

### DIFF
--- a/data/geo_groups.json
+++ b/data/geo_groups.json
@@ -6,6 +6,16 @@
         "co-fort-collins-utilities",
         "co-longmont-power-and-communications",
         "co-loveland-water-and-power"
+      ],
+      "incentives": [
+        "CO-81",
+        "CO-82",
+        "CO-83",
+        "CO-84",
+        "CO-85",
+        "CO-86",
+        "CO-87",
+        "CO-88"
       ]
     },
     "co-group-tri-state-g-and-t": {
@@ -27,11 +37,43 @@
         "co-united-power",
         "co-white-river-electric-association",
         "co-y-w-electric-association"
+      ],
+      "incentives": [
+        "CO-301",
+        "CO-302",
+        "CO-303",
+        "CO-304"
       ]
     },
     "co-group-walking-mountains": {
       "counties": [
         "co-unincorporated-eagle-county"
+      ],
+      "incentives": [
+        "CO-494",
+        "CO-495",
+        "CO-496",
+        "CO-497",
+        "CO-498",
+        "CO-499",
+        "CO-500",
+        "CO-501",
+        "CO-502",
+        "CO-503",
+        "CO-504",
+        "CO-505",
+        "CO-506",
+        "CO-507",
+        "CO-508",
+        "CO-509",
+        "CO-510",
+        "CO-511",
+        "CO-512",
+        "CO-513",
+        "CO-514",
+        "CO-515",
+        "CO-516",
+        "CO-517"
       ]
     }
   },
@@ -86,6 +128,10 @@
         "vt-town-of-hardwick-electric-department",
         "vt-town-of-northfield-electric-department",
         "vt-village-of-ludlow-electric-light-department"
+      ],
+      "incentives": [
+        "VT-11",
+        "VT-36"
       ]
     }
   }

--- a/data/geo_groups.json
+++ b/data/geo_groups.json
@@ -81,12 +81,18 @@
     "nv-group-csa-reno": {
       "counties": [
         "nv-washoe-county"
+      ],
+      "incentives": [
+        "NV-74"
       ]
     },
     "nv-group-help-of-southern-nevada": {
       "cities": [
         "nv-city-of-las-vegas",
         "nv-city-of-henderson"
+      ],
+      "incentives": [
+        "NV-77"
       ]
     },
     "nv-group-nevada-rural-housing": {
@@ -96,11 +102,17 @@
         "nv-lyon-county",
         "nv-storey-county",
         "nv-carson-city-county"
+      ],
+      "incentives": [
+        "NV-76"
       ]
     },
     "nv-group-nevada-rural-housing-north-lv": {
       "cities": [
         "nv-city-of-north-las-vegas"
+      ],
+      "incentives": [
+        "NV-79"
       ]
     },
     "nv-group-rural-nevada-development-corporation": {
@@ -115,6 +127,9 @@
         "nv-nye-county",
         "nv-pershing-county",
         "nv-white-pine-county"
+      ],
+      "incentives": [
+        "NV-75"
       ]
     }
   },

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -144,7 +144,7 @@ export function updateGeoGroups(
         utilities: [],
         cities: [],
         counties: [],
-        notes: '',
+        incentives: [],
       };
     }
   }

--- a/src/data/geo_groups.ts
+++ b/src/data/geo_groups.ts
@@ -8,7 +8,7 @@ const GEO_GROUP_SCHEMA = {
     utilities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     cities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     counties: { type: 'array', items: { type: 'string' }, minItems: 1 },
-    notes: { type: 'string' },
+    incentives: { type: 'array', items: { type: 'string' }, minItems: 1 },
   },
   additionalProperties: false,
   anyOf: [
@@ -16,6 +16,7 @@ const GEO_GROUP_SCHEMA = {
     { required: ['cities'] },
     { required: ['counties'] },
   ],
+  required: ['incentives'],
 } as const;
 
 export type GeoGroup = FromSchema<typeof GEO_GROUP_SCHEMA>;

--- a/test/data/geo_groups.test.ts
+++ b/test/data/geo_groups.test.ts
@@ -1,6 +1,13 @@
 import { test } from 'tap';
-import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
+import {
+  AUTHORITIES_BY_STATE,
+  AuthorityType,
+} from '../../src/data/authorities';
 import { GEO_GROUPS_BY_STATE } from '../../src/data/geo_groups';
+import {
+  STATE_INCENTIVES_BY_STATE,
+  StateIncentive,
+} from '../../src/data/state_incentives';
 
 test('geo groups refer to valid authorities', async t => {
   Object.entries(GEO_GROUPS_BY_STATE).forEach(([state, groups]) => {
@@ -19,4 +26,67 @@ test('geo groups refer to valid authorities', async t => {
       );
     });
   });
+});
+
+function computeIdToIncentiveMap(incentives: StateIncentive[]) {
+  const output: { [index: string]: StateIncentive } = {};
+  for (const incentive of incentives) {
+    output[incentive.id] = incentive;
+  }
+  return output;
+}
+
+test('geo groups are equivalent in JSON config and incentives', async t => {
+  // All incentives have the geo group indicated in their config.
+  const map = computeIdToIncentiveMap(
+    Object.values(STATE_INCENTIVES_BY_STATE).flat(),
+  );
+  Object.entries(GEO_GROUPS_BY_STATE).forEach(([, stateGeoGroups]) => {
+    for (const [identifier, geoGroup] of Object.entries(stateGeoGroups)) {
+      for (const incentiveId of geoGroup.incentives) {
+        const incentive = map[incentiveId];
+        t.equal(
+          incentive.eligible_geo_group,
+          identifier,
+          `Geo_group ${identifier} claims incentive ${incentive.id}, but the incentives.json file does not reflect that`,
+        );
+      }
+    }
+  });
+  // Converse: all geo group configs accurately reflect the incentive IDs.
+  for (const [stateId, stateIncentives] of Object.entries(
+    STATE_INCENTIVES_BY_STATE,
+  )) {
+    for (const incentive of stateIncentives) {
+      if (incentive.eligible_geo_group) {
+        const stateGeoGroups = GEO_GROUPS_BY_STATE[stateId];
+        t.hasProp(stateGeoGroups, incentive.eligible_geo_group);
+        t.ok(
+          stateGeoGroups[incentive.eligible_geo_group].incentives.includes(
+            incentive.id,
+          ),
+          `${incentive.id} claims eligible_geo_group ${incentive.eligible_geo_group}, but data/geo_groups.json does not reflect that`,
+        );
+      }
+    }
+  }
+});
+
+test('Only AuthorityType.Other incentives have eligible_geo_group and vice versa', async t => {
+  for (const [, stateIncentives] of Object.entries(STATE_INCENTIVES_BY_STATE)) {
+    for (const incentive of stateIncentives) {
+      if (incentive.authority_type === AuthorityType.Other) {
+        t.hasProp(
+          incentive,
+          'eligible_geo_group',
+          `authority_type 'other' must include a geo group (id ${incentive.id})`,
+        );
+      } else {
+        t.notOk(
+          incentive.eligible_geo_group,
+          `only authority_type 'other' can have a geo group (id ${incentive.id})`,
+        );
+      }
+    }
+  }
 });

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -150,7 +150,6 @@ test('state incentives JSON files match schemas', async tap => {
 
   STATE_INCENTIVE_TESTS.forEach(([stateId, schema, data]) => {
     const authorities = AUTHORITIES_BY_STATE[stateId as string];
-    const stateGeoGroups = GEO_GROUPS_BY_STATE[stateId];
 
     if (!tap.ok(ajv.validate(schema, data), `${stateId} incentives invalid`)) {
       console.error(ajv.errors);
@@ -203,25 +202,6 @@ test('state incentives JSON files match schemas', async tap => {
           authorities[incentive.authority_type]![incentive.authority],
           'city',
           `must define city attribute on corresponding authority ${incentive.authority} for incentives with city authority type`,
-        );
-      }
-
-      if (incentive.authority_type === AuthorityType.Other) {
-        tap.hasProp(
-          incentive,
-          'eligible_geo_group',
-          `authority_type 'other' must include a geo group (id ${incentive.id})`,
-        );
-
-        tap.hasProp(
-          stateGeoGroups,
-          incentive.eligible_geo_group!,
-          `nonexistent geo_group (${stateId}, id ${incentive.id})`,
-        );
-      } else {
-        tap.notOk(
-          incentive.eligible_geo_group,
-          `only authority_type 'other' can have a geo group (id ${incentive.id})`,
         );
       }
 

--- a/test/scripts/authority-and-program-updater.test.ts
+++ b/test/scripts/authority-and-program-updater.test.ts
@@ -456,6 +456,7 @@ test('add geo groups for new state', async tap => {
     CO: {
       'co-group-something': {
         utilities: ['co-some-utility'],
+        incentives: [],
       },
     },
   };
@@ -479,12 +480,13 @@ test('add geo groups for new state', async tap => {
         utilities: [],
         cities: [],
         counties: [],
-        notes: '',
+        incentives: [],
       },
     },
     CO: {
       'co-group-something': {
         utilities: ['co-some-utility'],
+        incentives: [],
       },
     },
   });
@@ -495,6 +497,7 @@ test('add geo groups to existing state', async tap => {
     CO: {
       'co-group-something': {
         utilities: ['co-some-utility'],
+        incentives: [],
       },
     },
   };
@@ -518,10 +521,11 @@ test('add geo groups to existing state', async tap => {
         utilities: [],
         cities: [],
         counties: [],
-        notes: '',
+        incentives: [],
       },
       'co-group-something': {
         utilities: ['co-some-utility'],
+        incentives: [],
       },
     },
   });

--- a/test/scripts/data-refiner.test.ts
+++ b/test/scripts/data-refiner.test.ts
@@ -1,0 +1,93 @@
+import _ from 'lodash';
+import { test } from 'tap';
+import { DataRefiner } from '../../scripts/lib/data-refiner';
+import { AuthorityType } from '../../src/data/authorities';
+import { GeoGroupsByState } from '../../src/data/geo_groups';
+import { LowIncomeThresholdsMap } from '../../src/data/low_income_thresholds';
+import { CollectedIncentive } from '../../src/data/state_incentives';
+import { AmountType } from '../../src/data/types/amount';
+
+test('correctly associates low-income thresholds with record', tap => {
+  const thresholds: LowIncomeThresholdsMap = {
+    CT: {
+      'ct-low-income-program': {
+        incentives: ['CT-1'],
+        source_url: 'foo.com',
+        thresholds: {},
+      },
+    },
+  };
+
+  const refiner = new DataRefiner(thresholds);
+  const input: CollectedIncentive = {
+    id: 'CT-1',
+    data_urls: [],
+    authority_type: AuthorityType.State,
+    authority_name: 'The Power Company',
+    program_title: 'Bar',
+    program_url: 'bar.com',
+    item: 'other',
+    short_description: { en: 'An incentive' },
+    program_status: '',
+    payment_methods: [],
+    rebate_value: '',
+    amount: { type: AmountType.DollarAmount, number: 100 },
+    owner_status: [],
+    income_restrictions: 'Some free text about the CT low income program.',
+  };
+
+  // Normal case – association is made.
+  const output = refiner.refineCollectedData('CT', input);
+  tap.equal(output.low_income, 'ct-low-income-program');
+
+  // Error case – if config references the ID, but the record
+  // has no data in the free-text field.
+  const noIncomeRestrictions = _.omit(input, 'income_restrictions');
+  tap.throws(
+    () => refiner.refineCollectedData('CT', noIncomeRestrictions),
+    new Error('Incentive CT-1 has a low-income program configured'),
+  );
+  tap.end();
+});
+
+test('correctly associate geo groups with record', tap => {
+  const geoGroups: GeoGroupsByState = {
+    CT: {
+      'ct-group-of-note': {
+        incentives: ['CT-1'],
+        counties: [],
+      },
+    },
+  };
+
+  const refiner = new DataRefiner(null, geoGroups);
+  const input: CollectedIncentive = {
+    id: 'CT-1',
+    data_urls: [],
+    authority_type: AuthorityType.State,
+    authority_name: 'The Power Company',
+    geo_eligibility: 'Some free text about the geo group',
+    program_title: 'Bar',
+    program_url: 'bar.com',
+    item: 'other',
+    short_description: { en: 'An incentive' },
+    program_status: '',
+    payment_methods: [],
+    rebate_value: '',
+    amount: { type: AmountType.DollarAmount, number: 100 },
+    owner_status: [],
+  };
+
+  // Normal case – association is made.
+  const output = refiner.refineCollectedData('CT', input);
+  tap.equal(output.eligible_geo_group, 'ct-group-of-note');
+
+  // Error case – if config references the ID, but the record
+  // has no data in the free-text field.
+  const noGeoEligibility = _.omit(input, 'geo_eligibility');
+  tap.throws(
+    () => refiner.refineCollectedData('CT', noGeoEligibility),
+    new Error('Incentive CT-1 has a geo group configured'),
+  );
+  tap.end();
+});


### PR DESCRIPTION
The implementation in refineCollectedData is a little repetitive, but I didn't see an obvious way to refactor it.