### PR TITLE
Remove location parameter from v1

### DIFF
--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -14,7 +14,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=80212\
+?zip=80212\
 &owner_status=homeowner\
 &household_income=80000\
 &tax_filing=joint\
@@ -23,7 +23,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=02807\
+?zip=02807\
 &owner_status=homeowner\
 &household_income=65000\
 &tax_filing=joint\
@@ -36,7 +36,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=02903\
+?zip=02903\
 &owner_status=homeowner\
 &household_income=65000\
 &tax_filing=joint\
@@ -49,7 +49,7 @@ curl \
 # TODO: Remove beta states argument when AZ is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=85701\
+?zip=85701\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=28000\
@@ -63,7 +63,7 @@ curl \
 # TODO: Remove beta states argument when AZ is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=85702\
+?zip=85702\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=28000\
@@ -77,7 +77,7 @@ curl \
 # TODO: Remove beta states argument when CT is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=06002\
+?zip=06002\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=35000\
@@ -91,7 +91,7 @@ curl \
 # TODO: Remove beta states argument when GA is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=30033\
+?zip=30033\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=40000\
@@ -104,7 +104,7 @@ curl \
 # TODO: Remove beta states argument when IL is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator?\
-location%5Bzip%5D=60304\
+zip=60304\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=35000\
@@ -117,7 +117,7 @@ location%5Bzip%5D=60304\
 # TODO: Remove beta states argument when MI is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=48103\
+?zip=48103\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=40000\
@@ -130,7 +130,7 @@ curl \
 # TODO: Remove beta states argument when NV is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=89108\
+?zip=89108\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=40000\
@@ -143,7 +143,7 @@ curl \
 # TODO: Remove &include_beta_states when NY is launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=11557\
+?zip=11557\
 &owner_status=homeowner\
 &household_income=50000\
 &tax_filing=joint\
@@ -157,7 +157,7 @@ curl \
 # TODO: Remove beta states argument when VA is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=22030\
+?zip=22030\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=40000\
@@ -170,7 +170,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=05401\
+?zip=05401\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=40000\
@@ -184,7 +184,7 @@ curl \
 # TODO: Remove beta states argument when CO is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=81657\
+?zip=81657\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=100000\
@@ -198,7 +198,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=15289\
+?zip=15289\
 &owner_status=homeowner\
 &household_income=80000\
 &tax_filing=joint\
@@ -208,7 +208,7 @@ curl \
 # TODO: Remove beta states argument when DC is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=20303\
+?zip=20303\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=95797\
@@ -220,7 +220,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=80517\
+?zip=80517\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=80000\
@@ -235,7 +235,7 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?location\[zip\]=80517\
+?zip=80517\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=80000\
@@ -251,7 +251,7 @@ curl \
 # TODO: Remove beta states argument when WI is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator?\
-location%5Bzip%5D=53703\
+zip=53703\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=50000\

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -263,7 +263,7 @@ zip=53703\
 # TODO: Remove beta states argument when OR is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator?\
-location%5Bzip%5D=97001\
+zip=97001\
 &include_beta_states=true\
 &owner_status=homeowner\
 &household_income=50000\

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -18,7 +18,6 @@ import {
   API_CALCULATOR_SCHEMA,
 } from '../schemas/v1/calculator-endpoint';
 import { APIIncentive, API_INCENTIVE_SCHEMA } from '../schemas/v1/incentive';
-import { APIRequestLocation } from '../schemas/v1/location';
 import { API_UTILITIES_SCHEMA } from '../schemas/v1/utilities-endpoint';
 
 function transformIncentives(
@@ -46,13 +45,14 @@ export default async function (
   fastify: FastifyInstance & { sqlite: Database },
 ) {
   async function fetchAMIsForLocation(
-    location: Partial<APIRequestLocation>,
+    zip: string | undefined,
+    address: string | undefined,
   ): Promise<IncomeInfo | null> {
-    if (location.address) {
+    if (address) {
       // TODO: make sure bad addresses are handled here, and don't return anything
-      return await fetchAMIsForAddress(fastify.sqlite, location.address);
-    } else if (location.zip) {
-      return await fetchAMIsForZip(fastify.sqlite, location.zip);
+      return await fetchAMIsForAddress(fastify.sqlite, address);
+    } else if (zip) {
+      return await fetchAMIsForZip(fastify.sqlite, zip);
     } else {
       // NOTE: this should never happen, APICalculatorSchema should block it:
       throw new UnexpectedInputError(
@@ -77,16 +77,15 @@ export default async function (
     { schema: API_CALCULATOR_SCHEMA },
     async (request, reply) => {
       const language = request.query.language ?? 'en';
-      const queryLocation = request.query.location ?? {
-        zip: request.query.zip,
-        address: request.query.address,
-      };
-      const incomeInfo = await fetchAMIsForLocation(queryLocation);
+      const incomeInfo = await fetchAMIsForLocation(
+        request.query.zip,
+        request.query.address,
+      );
 
       if (!incomeInfo) {
         throw fastify.httpErrors.createError(
           404,
-          queryLocation.zip
+          request.query.zip
             ? t('errors', 'zip_code_doesnt_exist', language)
             : t('errors', 'cannot_locate_address', language),
           { field: 'location' },
@@ -129,16 +128,14 @@ export default async function (
     { schema: API_UTILITIES_SCHEMA },
     async (request, reply) => {
       const language = request.query.language ?? 'en';
-      const queryLocation = request.query.location ?? {
-        zip: request.query.zip,
-        address: request.query.address,
-      };
-      const location = (await fetchAMIsForLocation(queryLocation))?.location;
+      const location = (
+        await fetchAMIsForLocation(request.query.zip, request.query.address)
+      )?.location;
 
       if (!location) {
         throw fastify.httpErrors.createError(
           404,
-          queryLocation.zip
+          request.query.zip
             ? t('errors', 'zip_code_doesnt_exist', language)
             : t('errors', 'cannot_locate_address', language),
           {

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -6,17 +6,12 @@ import { API_COVERAGE_SCHEMA } from '../../data/types/coverage';
 import { ALL_ITEMS } from '../../data/types/items';
 import { OwnerStatus } from '../../data/types/owner-status';
 import { API_INCENTIVE_SCHEMA } from './incentive';
-import {
-  API_REQUEST_LOCATION_SCHEMA,
-  API_RESPONSE_LOCATION_SCHEMA,
-} from './location';
+import { API_RESPONSE_LOCATION_SCHEMA } from './location';
 
 const API_CALCULATOR_REQUEST_SCHEMA = {
   title: 'APICalculatorRequest',
   type: 'object',
   properties: {
-    // TODO: remove location param once frontend is not using it
-    location: API_REQUEST_LOCATION_SCHEMA,
     zip: {
       type: 'string',
       description:
@@ -107,7 +102,6 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
   },
   additionalProperties: false,
   oneOf: [
-    { required: ['location'] },
     { required: ['zip'] },
     { required: ['address'] },
   ],

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -1,43 +1,6 @@
 import { FromSchema } from 'json-schema-to-ts';
 
 /**
- * The format of the location given to us by the calculator user. It can be
- * either a ZIP code, or an address string that we pass to Geocodio.
- */
-export const API_REQUEST_LOCATION_SCHEMA = {
-  type: 'object',
-  properties: {
-    zip: {
-      type: 'string',
-      description:
-        'Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.',
-      maxLength: 5,
-      minLength: 5,
-    },
-    address: {
-      type: 'string',
-      description:
-        "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
-    },
-  },
-  oneOf: [
-    {
-      required: [
-        'zip',
-      ],
-    },
-    {
-      required: [
-        'address',
-      ],
-    },
-  ],
-  maxProperties: 1,
-  minProperties: 1,
-  additionalProperties: false,
-} as const;
-
-/**
  * During incentive calculation, we compute some information about the user's
  * location (as given in the request). This structure lets us reflect some of
  * that in the response.
@@ -68,7 +31,6 @@ export const API_RESPONSE_LOCATION_SCHEMA = {
   additionalProperties: false,
 } as const;
 
-export type APIRequestLocation = FromSchema<typeof API_REQUEST_LOCATION_SCHEMA>;
 export type APIResponseLocation = FromSchema<
   typeof API_RESPONSE_LOCATION_SCHEMA
 >;

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -1,7 +1,4 @@
-import {
-  API_REQUEST_LOCATION_SCHEMA,
-  API_RESPONSE_LOCATION_SCHEMA,
-} from './location';
+import { API_RESPONSE_LOCATION_SCHEMA } from './location';
 
 export const API_UTILITIES_RESPONSE_SCHEMA = {
   $id: 'APIUtilitiesResponse',
@@ -27,8 +24,6 @@ export const API_UTILITIES_SCHEMA = {
   querystring: {
     type: 'object',
     properties: {
-      // TODO remove location param once frontend is not using it
-      location: API_REQUEST_LOCATION_SCHEMA,
       zip: {
         type: 'string',
         description:
@@ -58,10 +53,10 @@ export const API_UTILITIES_SCHEMA = {
       },
     },
     oneOf: [
-      { required: ['location'] },
       { required: ['zip'] },
       { required: ['address'] },
     ],
+    additionalProperties: false,
   },
   response: {
     200: {

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -58,7 +58,7 @@ test('response is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '80212' },
+      zip: '80212',
       owner_status: 'homeowner',
       household_income: 80000,
       tax_filing: 'joint',
@@ -87,7 +87,7 @@ test('parent ZCTA is used', async t => {
     {
       // This does not correspond to physical land area, but its parent ZCTA
       // is 15213, which does.
-      location: { zip: '15289' },
+      zip: '15289',
       owner_status: 'homeowner',
       household_income: 80000,
       tax_filing: 'joint',
@@ -101,7 +101,7 @@ test('response with state and utility is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '02903' },
+      zip: '02903',
       owner_status: 'homeowner',
       // Qualifies as low-income for RI DHS but not Rhode Island Energy.
       household_size: 4,
@@ -118,7 +118,7 @@ test('response with state and item filtering is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '02807' },
+      zip: '02807',
       owner_status: 'homeowner',
       household_size: 4,
       household_income: 65000,
@@ -135,7 +135,7 @@ test('AZ low income response with state and utility filtering for Tuscon Electri
   await validateResponse(
     t,
     {
-      location: { zip: '85701' },
+      zip: '85701',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 28000,
@@ -154,7 +154,7 @@ test('AZ low income response with state and utility filtering for UniSource is v
   await validateResponse(
     t,
     {
-      location: { zip: '85702' },
+      zip: '85702',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 28000,
@@ -174,7 +174,7 @@ test('CO low income response with state and utility filtering is valid and corre
     t,
     {
       // Eagle County, which gets Walking Mountains incentives
-      location: { zip: '81657' },
+      zip: '81657',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 100000,
@@ -193,7 +193,7 @@ test('CO incentive for PRPA shows up as intended', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '80517' },
+      zip: '80517',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 80000,
@@ -210,7 +210,7 @@ test('CO incentive for PRPA shows up as intended', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '80517' },
+      zip: '80517',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 80000,
@@ -231,7 +231,7 @@ test('CT low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '06002' },
+      zip: '06002',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 35000,
@@ -250,7 +250,7 @@ test('DC low income response with state and city filtering is valid and correct'
   await validateResponse(
     t,
     {
-      location: { zip: '20303' },
+      zip: '20303',
       owner_status: 'homeowner',
       household_size: 4,
       household_income: 95796,
@@ -269,7 +269,7 @@ test('GA response with utility filtering is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '30033' },
+      zip: '30033',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 35000,
@@ -288,7 +288,7 @@ test('IL low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '60304' },
+      zip: '60304',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 35000,
@@ -307,7 +307,7 @@ test('MI response with state and utility is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '48103' },
+      zip: '48103',
       owner_status: 'homeowner',
       // Qualifies as low-income for MI DTE.
       household_size: 1,
@@ -326,7 +326,7 @@ test('NV low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '89108' },
+      zip: '89108',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 40000,
@@ -364,7 +364,7 @@ test('NY response with state and utility is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      location: { zip: '11557' },
+      zip: '11557',
       owner_status: 'homeowner',
       // Qualifies as low-income for NY PSEG Long Island utility.
       household_size: 1,
@@ -383,7 +383,7 @@ test('VA low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '22030' },
+      zip: '22030',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 40000,
@@ -402,7 +402,7 @@ test('VT low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '05401' },
+      zip: '05401',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 40000,
@@ -421,7 +421,7 @@ test('WI low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '53703' },
+      zip: '53703',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 50000,
@@ -459,27 +459,27 @@ const BAD_QUERIES = [
   },
   // bad owner_status:
   {
-    location: { zip: '80212' },
+    zip: '80212',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: '',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'aaa',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: -1,
     household_income: 80000,
     tax_filing: 'joint',
@@ -487,55 +487,55 @@ const BAD_QUERIES = [
   },
   // bad household_income:
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: null,
     tax_filing: 'joint',
     household_size: 4,
   }, // null is the JSON encoding of NaN
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: -1,
     tax_filing: 'joint',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 100000001,
     tax_filing: 'joint',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     tax_filing: 'joint',
     household_size: 4,
   },
   // bad tax_filing:
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: '',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'foo',
     household_size: 4,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: null,
@@ -543,34 +543,34 @@ const BAD_QUERIES = [
   },
   // bad household_size:
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 0,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 'a',
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 9,
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
@@ -579,7 +579,7 @@ const BAD_QUERIES = [
     authority_types: ['utility'],
   },
   {
-    location: { zip: '02861' },
+    zip: '02861',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
@@ -588,7 +588,7 @@ const BAD_QUERIES = [
     utility: 'nonexistent-utility',
   },
   {
-    location: { zip: '80212' },
+    zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
@@ -634,7 +634,7 @@ test('non-existent zips', async t => {
 
   for (const zip of BAD_ZIPS) {
     const res = await getCalculatorResponse(t, {
-      location: { zip },
+      zip,
       owner_status: 'homeowner',
       household_income: 0,
       household_size: 1,
@@ -720,7 +720,7 @@ test('/utilities', async t => {
 
   for (const [zip, beta, expectedResponse] of UTILITIES) {
     const searchParams = qs.stringify(
-      { location: { zip }, include_beta_states: beta },
+      { zip, include_beta_states: beta },
       { encodeValuesOnly: true },
     );
     const res = await app.inject({ url: `/api/v1/utilities?${searchParams}` });

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -345,7 +345,7 @@ test('OR low income response with state and utility filtering is valid and corre
   await validateResponse(
     t,
     {
-      location: { zip: '97001' },
+      zip: '97001',
       owner_status: 'homeowner',
       household_size: 1,
       household_income: 50000,
@@ -444,14 +444,14 @@ const BAD_QUERIES = [
     household_size: 4,
   },
   {
-    location: null,
+    zip: null,
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
   },
   {
-    location: {},
+    zip: {},
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,11 +1629,40 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dotenv-cli@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/dotenv-cli/-/dotenv-cli-7.3.0.tgz#21e33e7944713001677658d68856063968edfbd2"
   integrity sha512-314CA4TyK34YEJ6ntBf80eUY+t1XaFLyem1k9P0sX1gn30qThZ5qZr/ZwE318gEnzyYP9yj9HJk6SqwE0upkfw==
-
   dependencies:
     cross-spawn "^7.0.3"
     dotenv "^16.3.0"
@@ -2046,11 +2075,6 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
-
-follow-redirects@^1.15.4:
-  version "1.15.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
-  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 follow-redirects@^1.15.4:
   version "1.15.5"


### PR DESCRIPTION
## Description

This is the final step of migrating to separate top-level `zip` and
`address` parameters: removing the old nested parameter.

The embed frontend is already switched over, and there should be no
other clients of v1, so although this is a breaking change it should
be safe.

## Test Plan

`yarn lint`, `yarn test`. Run the update-fixtures script and make sure
the updates all succeed and there are no changes.
