### PR TITLE
Launch VA and DC to launched states

### DIFF
--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -56,20 +56,20 @@ export const BETA_STATES: string[] = [
   'AZ',
   'CO',
   'CT',
-  'DC',
   'GA',
   'IL',
   'MI',
   'NV',
   'NY',
   'OR',
-  'VA',
   'VT',
   'WI',
 ];
 
 export const LAUNCHED_STATES: string[] = [
+  'DC',
   'RI',
+  'VA',
 ];
 
 export const isStateIncluded = (

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -238,10 +238,6 @@ test("launched states do not have any values that we don't support for broader c
   STATE_INCENTIVE_TESTS.forEach(([state, , data]) => {
     if (LAUNCHED_STATES.includes(state)) {
       for (const incentive of data) {
-        // TODO: remove once City/County incentives have been beta-tested.
-        tap.not(incentive.authority_type, AuthorityType.City);
-        tap.not(incentive.authority_type, AuthorityType.County);
-
         tap.notOk(incentive.payment_methods.includes(PaymentMethod.Unknown));
       }
     }


### PR DESCRIPTION
Moves VA and DC to the list of launched states

Next step: after launch, remove "beta" state status in tests/fixtures, follow up on Spanish translations