### PR TITLE
Add method to export collected incentives to a Google sheet.

### DIFF
--- a/scripts/export-to-google-sheets.ts
+++ b/scripts/export-to-google-sheets.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import { google, sheets_v4 } from 'googleapis';
+import minimist from 'minimist';
+import { CollectedIncentive } from '../src/data/state_incentives';
+import { FILES, IncentiveFile } from './incentive-spreadsheet-registry';
+import { authorize } from './lib/auth-helper';
+import { collectedIncentiveToGoogleSheet } from './lib/format-converter';
+import { FIELD_MAPPINGS } from './lib/spreadsheet-mappings';
+
+async function exportToGoogleSheets(state: string, file: IncentiveFile) {
+  if (!file.collectedFilepath)
+    throw new Error(
+      `No collected data defined for state ${state}; modify spreadsheet registry.`,
+    );
+
+  const collected: CollectedIncentive[] = JSON.parse(
+    fs.readFileSync(file.collectedFilepath!, 'utf-8'),
+  );
+  const sheet = collectedIncentiveToGoogleSheet(collected, FIELD_MAPPINGS);
+  if (!sheet.properties) {
+    sheet.properties = {};
+  }
+  sheet.properties.title = 'Incentives Data';
+
+  const workbook: sheets_v4.Schema$Spreadsheet = {
+    sheets: [
+      sheet,
+    ],
+  };
+  const auth = await authorize();
+  if (auth) {
+    const sheetsClient = google.sheets({ version: 'v4', auth: auth });
+    const resp = await sheetsClient.spreadsheets.create({
+      requestBody: workbook,
+    });
+
+    console.log(`\nGoogle spreadsheet created: ${resp.data.spreadsheetUrl}\n`);
+  }
+}
+
+(async function () {
+  const args = minimist(process.argv.slice(2));
+
+  const bad = args._.filter(f => !(f in FILES));
+  if (bad.length) {
+    console.error(
+      `${bad.join(', ')} not valid (choices: ${Object.keys(FILES).join(', ')})`,
+    );
+    process.exit(1);
+  }
+
+  args._.forEach(async fileIdent => {
+    await exportToGoogleSheets(fileIdent, FILES[fileIdent]);
+  });
+})();

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -36,10 +36,13 @@ export class SpreadsheetStandardizer {
     valueMap: { [index: string]: AliasMap } = VALUE_MAPPINGS,
     strict: boolean = true,
   ) {
+    // These first two maps are stored to translate from canonical column or
+    // value to an alias, which is needed when writing JSON back to human-
+    // readable version.
     this.fieldMap = fieldMap;
     this.valueMap = valueMap;
-    // We reverse the input map for easier runtime use, since
-    // we need to go from alias back to canonical name.
+    // We reverse the input maps for easier runtime use when converting from
+    // spreadsheet to JSON, since we need to go from aliases to canonical.
     this.fieldAliasToCanonical = reverseMap(fieldMap);
     this.valueAliasToCanonical = reverseValueMap(valueMap);
     this.strict = strict;

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -101,16 +101,28 @@ export class SpreadsheetStandardizer {
     return output;
   }
 
+  // This method expects already flattened input (i.e. no nested objects).
+  // Arrays as values are allowed.
   convertToAliases(input: StringKeyed): StringKeyed {
     const output: StringKeyed = {};
-    for (const [fieldName, field] of Object.entries(input)) {
+    for (const [fieldName, fieldValue] of Object.entries(input)) {
       let outputFieldName = fieldName;
       if (this.fieldMap[fieldName] && this.fieldMap[fieldName][0]) {
         outputFieldName = this.fieldMap[fieldName][0];
       }
-      let val = field;
-      if (this.valueMap[fieldName] && this.valueMap[fieldName][field]) {
-        val = this.valueMap[fieldName][field][0];
+      let val = fieldValue;
+      if (Array.isArray(val)) {
+        // Special handling for arrays: try to rename each value.
+        val = val.map(component => {
+          if (this.valueMap[fieldName] && this.valueMap[fieldName][component]) {
+            return this.valueMap[fieldName][component][0];
+          }
+          return component;
+        });
+      } else {
+        if (this.valueMap[fieldName] && this.valueMap[fieldName][fieldValue]) {
+          val = this.valueMap[fieldName][fieldValue][0];
+        }
       }
       output[outputFieldName] = val;
     }

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -1,6 +1,7 @@
 import { DateTimeFormatter, LocalDate } from '@js-joda/core';
 import { Locale } from '@js-joda/locale_en-us';
 import { START_END_DATE_REGEX } from '../../src/lib/dates';
+import { StringKeyed } from './format-converter';
 import {
   AliasMap,
   FIELD_MAPPINGS,
@@ -19,8 +20,10 @@ const DATE_FIELDS = ['start_date', 'end_date'];
 
 // Standardize column names or values in an incentive spreadsheet.
 export class SpreadsheetStandardizer {
-  private fieldMap: FlatAliasMap;
-  private valueMap: { [index: string]: FlatAliasMap };
+  private fieldMap: AliasMap;
+  private valueMap: { [index: string]: AliasMap };
+  private fieldAliasToCanonical: FlatAliasMap;
+  private valueAliasToCanonical: { [index: string]: FlatAliasMap };
   private strict: boolean;
 
   /**
@@ -33,10 +36,12 @@ export class SpreadsheetStandardizer {
     valueMap: { [index: string]: AliasMap } = VALUE_MAPPINGS,
     strict: boolean = true,
   ) {
+    this.fieldMap = fieldMap;
+    this.valueMap = valueMap;
     // We reverse the input map for easier runtime use, since
     // we need to go from alias back to canonical name.
-    this.fieldMap = reverseMap(fieldMap);
-    this.valueMap = reverseValueMap(valueMap);
+    this.fieldAliasToCanonical = reverseMap(fieldMap);
+    this.valueAliasToCanonical = reverseValueMap(valueMap);
     this.strict = strict;
   }
 
@@ -48,10 +53,12 @@ export class SpreadsheetStandardizer {
     return components
       .map((component: string) => {
         if (
-          this.valueMap[colName] !== undefined &&
-          this.valueMap[colName][cleanFieldName(component)] !== undefined
+          this.valueAliasToCanonical[colName] !== undefined &&
+          this.valueAliasToCanonical[colName][cleanFieldName(component)] !==
+            undefined
         ) {
-          component = this.valueMap[colName][cleanFieldName(component)];
+          component =
+            this.valueAliasToCanonical[colName][cleanFieldName(component)];
         }
         return component;
       })
@@ -79,14 +86,30 @@ export class SpreadsheetStandardizer {
     const output: Record<string, string> = {};
     for (const key in input) {
       const cleaned = cleanFieldName(key);
-      if (this.fieldMap[cleaned] === undefined && this.strict) {
+      if (this.fieldAliasToCanonical[cleaned] === undefined && this.strict) {
         throw new Error(`Invalid column found: ${cleaned}; original: ${key}`);
       }
 
-      const newCol = this.fieldMap[cleaned] || key;
+      const newCol = this.fieldAliasToCanonical[cleaned] || key;
       const val = this.convertToCanonical(input[key], newCol);
 
       output[newCol] = this.handleSpecialCases(val, newCol);
+    }
+    return output;
+  }
+
+  convertToAliases(input: StringKeyed): StringKeyed {
+    const output: StringKeyed = {};
+    for (const [fieldName, field] of Object.entries(input)) {
+      let outputFieldName = fieldName;
+      if (this.fieldMap[fieldName] && this.fieldMap[fieldName][0]) {
+        outputFieldName = this.fieldMap[fieldName][0];
+      }
+      let val = field;
+      if (this.valueMap[fieldName] && this.valueMap[fieldName][field]) {
+        val = this.valueMap[fieldName][field][0];
+      }
+      output[outputFieldName] = val;
     }
     return output;
   }

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -235,6 +235,7 @@ test('CollectedIncentives are converted back into Google Sheets format', tap => 
       },
       owner_status: [
         OwnerStatus.Homeowner,
+        OwnerStatus.Renter,
       ],
       short_description: {
         en: 'Receive a $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
@@ -242,6 +243,7 @@ test('CollectedIncentives are converted back into Google Sheets format', tap => 
       },
       start_date: '2022-01-01',
       end_date: '2026-12-31',
+      omit_from_api: true,
     },
   ];
   const output = collectedIncentiveToGoogleSheet(incentives, FIELD_MAPPINGS);
@@ -260,12 +262,11 @@ test('CollectedIncentives are converted back into Google Sheets format', tap => 
               { userEnteredValue: { stringValue: 'Program Title *' } },
               { userEnteredValue: { stringValue: 'Program URL' } },
               { userEnteredValue: { stringValue: 'Technology *' } },
-              { userEnteredValue: { stringValue: 'Program Status' } },
-              { userEnteredValue: { stringValue: 'Rebate Value *' } },
-              { userEnteredValue: { stringValue: 'Rebate Type' } },
-              { userEnteredValue: { stringValue: 'Amount Type *' } },
-              { userEnteredValue: { stringValue: 'Number *' } },
-              { userEnteredValue: { stringValue: 'Homeowner / Renter' } },
+              {
+                userEnteredValue: {
+                  stringValue: "Technology (If selected 'Other')",
+                },
+              },
               {
                 userEnteredValue: {
                   stringValue: 'Program Description (guideline)',
@@ -276,29 +277,64 @@ test('CollectedIncentives are converted back into Google Sheets format', tap => 
                   stringValue: 'Program Description (Spanish)',
                 },
               },
+              { userEnteredValue: { stringValue: 'Program Status' } },
               { userEnteredValue: { stringValue: 'Program Start' } },
               { userEnteredValue: { stringValue: 'Program End' } },
+              { userEnteredValue: { stringValue: 'Rebate Type' } },
+              { userEnteredValue: { stringValue: 'Rebate Value *' } },
+              { userEnteredValue: { stringValue: 'Amount Type *' } },
+              { userEnteredValue: { stringValue: 'Number *' } },
+              { userEnteredValue: { stringValue: 'Unit' } },
+              { userEnteredValue: { stringValue: 'Amount Minimum' } },
+              { userEnteredValue: { stringValue: 'Amount Maximum' } },
+              {
+                userEnteredValue: {
+                  stringValue:
+                    'Amount Representative (only for average values)',
+                },
+              },
+              { userEnteredValue: { stringValue: 'Bonus Description' } },
+              {
+                userEnteredValue: {
+                  stringValue: 'Equipment Standards Restrictions',
+                },
+              },
+              {
+                userEnteredValue: {
+                  stringValue: 'Equipment Capacity Restrictions',
+                },
+              },
+              { userEnteredValue: { stringValue: 'Contractor Restrictions' } },
+              { userEnteredValue: { stringValue: 'Income Restrictions' } },
+              {
+                userEnteredValue: {
+                  stringValue: 'Tax - filing Status Restrictions',
+                },
+              },
+              { userEnteredValue: { stringValue: 'Homeowner / Renter' } },
+              { userEnteredValue: { stringValue: 'Other Restrictions' } },
+              { userEnteredValue: { stringValue: 'Stacking Details' } },
+              { userEnteredValue: { stringValue: 'Financing Details' } },
+              { userEnteredValue: { stringValue: 'Editorial Notes' } },
+              { userEnteredValue: { stringValue: 'Questions' } },
+              { userEnteredValue: { stringValue: 'Omit from API?' } },
             ],
           },
           {
             values: [
               { userEnteredValue: { stringValue: 'VA-1' } },
               { userEnteredValue: { stringValue: 'appalachia.com' } },
-              { userEnteredValue: { stringValue: 'Appalachian Power' } },
               { userEnteredValue: { stringValue: 'Utility' } },
+              { userEnteredValue: { stringValue: 'Appalachian Power' } },
+              {},
+              { userEnteredValue: { stringValue: 'The Appalachian Program' } },
+              { userEnteredValue: { stringValue: 'appalachianprogram.com' } },
               {
                 userEnteredValue: {
                   stringValue: 'Heat Pump Dryers / Clothes Dryer',
                 },
               },
-              { userEnteredValue: { stringValue: 'The Appalachian Program' } },
-              { userEnteredValue: { stringValue: 'appalachianprogram.com' } },
-              { userEnteredValue: { stringValue: 'Active' } },
-              { userEnteredValue: { stringValue: '$50 flat rate' } },
-              { userEnteredValue: { stringValue: 'Rebate (Post Purchase)' } },
-              { userEnteredValue: { stringValue: 'Dollar Amount' } },
-              { userEnteredValue: { stringValue: '50' } },
-              { userEnteredValue: { stringValue: 'Homeowner' } },
+              {},
               {
                 userEnteredValue: {
                   stringValue:
@@ -308,8 +344,30 @@ test('CollectedIncentives are converted back into Google Sheets format', tap => 
               {
                 userEnteredValue: { stringValue: 'Unas palabras en español.' },
               },
+              { userEnteredValue: { stringValue: 'Active' } },
               { userEnteredValue: { stringValue: '2022-01-01' } },
               { userEnteredValue: { stringValue: '2026-12-31' } },
+              { userEnteredValue: { stringValue: 'Rebate (Post Purchase)' } },
+              { userEnteredValue: { stringValue: '$50 flat rate' } },
+              { userEnteredValue: { stringValue: 'Dollar Amount' } },
+              { userEnteredValue: { numberValue: 50 } },
+              {},
+              {},
+              {},
+              {},
+              {},
+              {},
+              {},
+              {},
+              {},
+              {},
+              { userEnteredValue: { stringValue: 'Homeowner, Renter' } },
+              {},
+              {},
+              {},
+              {},
+              {},
+              { userEnteredValue: { boolValue: true } },
             ],
           },
         ],

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -1,16 +1,11 @@
 import { GaxiosPromise, GaxiosResponse } from 'gaxios';
 import { sheets_v4 } from 'googleapis';
 import { test } from 'tap';
-<<<<<<< HEAD
 import { IncentiveFile } from '../../scripts/incentive-spreadsheet-registry';
 import {
   SheetsClient,
   extractIdsFromUrl,
   retrieveGoogleSheet,
-=======
-import {
-  extractIdsFromUrl,
->>>>>>> edc75f1 (Add way to read Google Sheets API and retrieve hyperlinks.)
   spreadsheetToJson,
 } from '../../scripts/incentive-spreadsheet-to-json';
 import { DataRefiner } from '../../scripts/lib/data-refiner';

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -1,11 +1,16 @@
 import { GaxiosPromise, GaxiosResponse } from 'gaxios';
 import { sheets_v4 } from 'googleapis';
 import { test } from 'tap';
+<<<<<<< HEAD
 import { IncentiveFile } from '../../scripts/incentive-spreadsheet-registry';
 import {
   SheetsClient,
   extractIdsFromUrl,
   retrieveGoogleSheet,
+=======
+import {
+  extractIdsFromUrl,
+>>>>>>> edc75f1 (Add way to read Google Sheets API and retrieve hyperlinks.)
   spreadsheetToJson,
 } from '../../scripts/incentive-spreadsheet-to-json';
 import { DataRefiner } from '../../scripts/lib/data-refiner';


### PR DESCRIPTION
This is the other half of Google Sheet <-> JSON conversion; a continuation of https://github.com/rewiringamerica/api.rewiringamerica.org/pull/373. They're largely independent, though they both rely on the authentication helper and the changes to the spreadsheet-registry.

This is the CollectedIncentives -> Google Sheet direction. It uses the Google Sheets API to create a new spreadsheet. Right now, we only have the incentives data itself, but as a follow-up, I'll create other worksheets like the data model and the standardized enum values so that it is more comparable to our existing sheets (plus add data validation).

Notable assumption: the first alias in the FIELD_MAPPINGS and VALUE_MAPPINGS in spreadsheet-mappings.ts is considered the canonical human-readable spreadsheet version. I think this is fine for now, though we may want clearer documentation of it at some point.

Testing: unit tests, and I tried this on Colorado. You can see the round-trip in [this spreadsheet](https://docs.google.com/spreadsheets/d/1vybxSsCChFp1iAwMy1CwUFEjAxh0KxAmoDl7grtlKQ8/edit#gid=406119121). This was running the Sheets -> CollectedIncentives version followed by CollectedIncentives -> Sheets, then copying over the original CO data and comparing. The green cells are where there's a difference (the new value is on top).

 The cell values are the same, except in:
1. places where the original Colorado data used a different alias from the canonical alias
2. dates. The original sheet has these as numbers formatted as dates; the new version has them as strings. In keeping with Owen's direction for dates, I think we want them to be strings anyway.
3. columns missing from the Colorado spreadsheet - there are some, like Editorial Notes, that aren't in the original CO data, but in the interest of standardizing our spreadsheets, I think it's good to be adding them back in.
4. Cells that had hyperlinks (as expected)