### PR TITLE
Don't use the fs/promises API in generate-utility-data

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,7 +34,17 @@ Filling out an entry for `incentive-spreadsheet-registry.ts` consists of creatin
 - Optionally declaring the header row number, if not the top row of the spreadsheet, in `headerRowNumber`
 
 First, **edit `authorities.json` manually** to include a top-level entry for
-the state you're adding, if it's not already present.
+the state you're adding, if it's not already present, like this:
+
+```json
+{
+  "<state-abbreviation>": {
+    "state": {},
+    "utility": {}
+  },
+  ...
+}
+```
 
 Then, run [`generate-utility-data.ts`](generate-utility-data.ts) to populate the list of utilities for the state in the authorities file. See [below](#utility-data) for details on that.
 

--- a/scripts/generate-utility-data.ts
+++ b/scripts/generate-utility-data.ts
@@ -9,7 +9,7 @@
  */
 
 import { stringify } from 'csv-stringify';
-import fs from 'fs/promises';
+import fs from 'fs';
 import _ from 'lodash';
 import fetch from 'make-fetch-happen';
 import minimist from 'minimist';
@@ -193,7 +193,7 @@ enum Col {
   });
 
   const rawSheet = args.file
-    ? await fs.readFile(args.file)
+    ? fs.readFileSync(args.file)
     : await fetch(
         'https://downloads.energystar.gov/bi/portfolio-manager/Public_Utility_Map_en_US.xlsx',
       ).then(response => response.buffer());
@@ -218,9 +218,7 @@ enum Col {
     columns: ['zip', 'utility_id', 'predominant'],
   });
   zipToUtilityOut.pipe(
-    (
-      await fs.open(path.join(__dirname, 'data/zip-to-utility.csv'))
-    ).createWriteStream(),
+    fs.createWriteStream(path.join(__dirname, 'data/zip-to-utility.csv')),
   );
 
   // For deduplication by utility ID and zip.
@@ -276,7 +274,7 @@ enum Col {
   // Update authorities.json with the utilities from the dataset.
   const authoritiesJsonPath = path.join(__dirname, '../data/authorities.json');
   const authoritiesJson: AuthoritiesByState = JSON.parse(
-    await fs.readFile(authoritiesJsonPath, 'utf-8'),
+    fs.readFileSync(authoritiesJsonPath, 'utf-8'),
   );
 
   utilitiesByState.forEach((utilityMap, state) => {
@@ -298,7 +296,7 @@ enum Col {
     }
   });
 
-  await fs.writeFile(
+  fs.writeFileSync(
     authoritiesJsonPath,
     JSON.stringify(authoritiesJson, null, 2) + '\n',
   );


### PR DESCRIPTION
## Description

There's a filesystem error upon reading the authorities.json file
towards the end of the script. (I don't know why I didn't see this
during testing?) Switching to the synchronous fs APIs seems to fix it,
so just do that rather than sink more time into investigating. None of
these reads/writes would happen concurrently anyway, so there's no
real downside to this.

## Test Plan

Run the script and don't get an `EBADF` error.
