### PR TITLE
Split authorities.json into a file for each state

### DIFF
--- a/data/AZ/authorities.json
+++ b/data/AZ/authorities.json
@@ -1,0 +1,71 @@
+{
+  "state": {},
+  "utility": {
+    "az-ajo-improvement": {
+      "name": "Ajo Improvement"
+    },
+    "az-ak-chin-electric-utility-authority": {
+      "name": "Ak-Chin Electric Utility Authority"
+    },
+    "az-city-of-mesa": {
+      "name": "City of Mesa"
+    },
+    "az-columbus-electric-cooperative": {
+      "name": "Columbus Electric Cooperative"
+    },
+    "az-dixie-power": {
+      "name": "DixiePower"
+    },
+    "az-electrical-district-no-2-pinal-county": {
+      "name": "Electrical District No 2 Pinal County"
+    },
+    "az-electrical-district-no-3-pinal-county": {
+      "name": "Electrical District No 3 Pinal County"
+    },
+    "az-electrical-district-no-4-pinal-county": {
+      "name": "Electrical District No 4 Pinal County"
+    },
+    "az-garkane-energy-cooperative": {
+      "name": "Garkane Energy Cooperative"
+    },
+    "az-graham-county-electric-cooperative": {
+      "name": "Graham County Electric Cooperative"
+    },
+    "az-mohave-electric-cooperative": {
+      "name": "Mohave Electric Cooperative"
+    },
+    "az-morenci-water-and-electric": {
+      "name": "Morenci Water and Electric"
+    },
+    "az-navajo-tribal-utility-authority": {
+      "name": "Navajo Tribal Utility Authority"
+    },
+    "az-navopache-electric-cooperative": {
+      "name": "Navopache Electric Cooperative"
+    },
+    "az-page-utility-enterprises": {
+      "name": "Page Utility Enterprises"
+    },
+    "az-salt-river-project": {
+      "name": "Salt River Project"
+    },
+    "az-sulphur-springs-valley-electric-cooperative": {
+      "name": "Sulphur Springs Valley Electric Cooperative"
+    },
+    "az-tohono-o-odham-utility-authority": {
+      "name": "Tohono O'odham Utility Authority"
+    },
+    "az-trico-electric-cooperative": {
+      "name": "Trico Electric Cooperative"
+    },
+    "az-tucson-electric-power": {
+      "name": "Tucson Electric Power"
+    },
+    "az-uni-source-energy-services": {
+      "name": "UniSource Energy Services"
+    },
+    "az-usbia-san-carlos-project": {
+      "name": "USBIA-San Carlos Project"
+    }
+  }
+}

--- a/data/CO/authorities.json
+++ b/data/CO/authorities.json
@@ -1,0 +1,187 @@
+{
+  "utility": {
+    "co-black-hills-energy": {
+      "name": "Black Hills Energy"
+    },
+    "co-city-of-aspen": {
+      "name": "City of Aspen"
+    },
+    "co-city-of-fort-morgan": {
+      "name": "City of Fort Morgan"
+    },
+    "co-city-of-fountain": {
+      "name": "City of Fountain"
+    },
+    "co-city-of-gunnison": {
+      "name": "City of Gunnison"
+    },
+    "co-colorado-springs-utilities": {
+      "name": "Colorado Springs Utilities"
+    },
+    "co-core-electric-cooperative": {
+      "name": "CORE Electric Cooperative"
+    },
+    "co-delta-montrose-electric-association": {
+      "name": "Delta Montrose Electric Association"
+    },
+    "co-empire-electric-association": {
+      "name": "Empire Electric Association"
+    },
+    "co-estes-park-power-and-communications": {
+      "name": "Estes Park Power and Communications"
+    },
+    "co-fort-collins-utilities": {
+      "name": "Fort Collins Utilities"
+    },
+    "co-glenwood-springs-electric": {
+      "name": "Glenwood Springs Electric"
+    },
+    "co-grand-valley-power": {
+      "name": "Grand Valley Power"
+    },
+    "co-gunnison-county-electric-association": {
+      "name": "Gunnison County Electric Association."
+    },
+    "co-high-west-energy": {
+      "name": "High West Energy"
+    },
+    "co-highline-electric-association": {
+      "name": "Highline Electric Association"
+    },
+    "co-holy-cross-energy": {
+      "name": "Holy Cross Energy"
+    },
+    "co-kc-electric-association": {
+      "name": "K.C. Electric Association"
+    },
+    "co-la-junta-municipal-utilities": {
+      "name": "La Junta Municipal Utilities"
+    },
+    "co-la-plata-electric-association": {
+      "name": "La Plata Electric Association"
+    },
+    "co-longmont-power-and-communications": {
+      "name": "Longmont Power & Communications"
+    },
+    "co-loveland-water-and-power": {
+      "name": "Loveland Water and Power"
+    },
+    "co-moon-lake-electric-association": {
+      "name": "Moon Lake Electric Association"
+    },
+    "co-morgan-county-rea": {
+      "name": "Morgan County REA"
+    },
+    "co-mountain-parks-electric": {
+      "name": "Mountain Parks Electric"
+    },
+    "co-mountain-view-electric-association": {
+      "name": "Mountain View Electric Association"
+    },
+    "co-poudre-valley-rea": {
+      "name": "Poudre Valley REA"
+    },
+    "co-san-isabel-electric": {
+      "name": "San Isabel Electric"
+    },
+    "co-san-luis-valley-rec": {
+      "name": "San Luis Valley REC"
+    },
+    "co-san-miguel-power-association": {
+      "name": "San Miguel Power Association"
+    },
+    "co-sangre-de-cristo-electric-association": {
+      "name": "Sangre de Cristo Electric Association"
+    },
+    "co-southeast-colorado-power-association": {
+      "name": "Southeast Colorado Power Association"
+    },
+    "co-southwestern-electric-cooperative": {
+      "name": "Southwestern Electric Cooperative"
+    },
+    "co-tri-county-electric-cooperative": {
+      "name": "Tri-County Electric Cooperative"
+    },
+    "co-united-power": {
+      "name": "United Power"
+    },
+    "co-wheatland-electric-cooperative": {
+      "name": "Wheatland Electric Cooperative"
+    },
+    "co-white-river-electric-association": {
+      "name": "White River Electric Association"
+    },
+    "co-xcel-energy": {
+      "name": "Xcel Energy"
+    },
+    "co-y-w-electric-association": {
+      "name": "Y-W Electric Association"
+    },
+    "co-yampa-valley-electric-association": {
+      "name": "Yampa Valley Electric Association"
+    }
+  },
+  "city": {
+    "co-city-of-boulder": {
+      "name": "City of Boulder",
+      "city": "Boulder",
+      "county": "Boulder"
+    },
+    "co-town-of-avon": {
+      "name": "Town of Avon",
+      "city": "Avon",
+      "county": "Eagle"
+    },
+    "co-town-of-eagle": {
+      "name": "Town of Eagle",
+      "city": "Eagle",
+      "county": "Eagle"
+    },
+    "co-town-of-erie": {
+      "name": "Town of Erie",
+      "city": "Erie",
+      "county": "Weld"
+    },
+    "co-town-of-vail": {
+      "name": "Town of Vail",
+      "city": "Vail",
+      "county": "Eagle"
+    }
+  },
+  "county": {
+    "co-city-and-county-of-denver": {
+      "name": "City and County of Denver",
+      "county": "Denver"
+    },
+    "co-boulder-county": {
+      "name": "Boulder County",
+      "county": "Boulder"
+    },
+    "co-unincorporated-eagle-county": {
+      "name": "Unincorporated Eagle County",
+      "county": "Eagle"
+    }
+  },
+  "state": {
+    "co-energy-outreach-colorado": {
+      "name": "Energy Outreach Colorado"
+    },
+    "co-colorado-energy-office": {
+      "name": "Colorado Energy Office"
+    },
+    "co-state-of-colorado": {
+      "name": "State of Colorado"
+    }
+  },
+  "other": {
+    "co-platte-river-power-authority": {
+      "name": "Platte River Power Authority"
+    },
+    "co-tri-state-g-and-t": {
+      "name": "Tri-State G&T"
+    },
+    "co-walking-mountains": {
+      "name": "Walking Mountains"
+    }
+  }
+}

--- a/data/CT/authorities.json
+++ b/data/CT/authorities.json
@@ -1,0 +1,33 @@
+{
+  "state": {
+    "ct-deep": {
+      "name": "CT Department of Energy & Environmental Protection"
+    }
+  },
+  "utility": {
+    "ct-bozrah-light-and-power-company": {
+      "name": "Bozrah Light & Power Company"
+    },
+    "ct-eversource": {
+      "name": "Eversource"
+    },
+    "ct-groton-utilities": {
+      "name": "Groton Utilities"
+    },
+    "ct-norwalk-third-taxing-district": {
+      "name": "Norwalk Third Taxing District"
+    },
+    "ct-norwich-public-utilities": {
+      "name": "Norwich Public Utilities"
+    },
+    "ct-south-norwalk-electric-and-water": {
+      "name": "South Norwalk Electric and Water"
+    },
+    "ct-town-of-wallingford": {
+      "name": "Town of Wallingford"
+    },
+    "ct-united-illuminating": {
+      "name": "United Illuminating"
+    }
+  }
+}

--- a/data/DC/authorities.json
+++ b/data/DC/authorities.json
@@ -1,0 +1,19 @@
+{
+  "city": {
+    "dc-dc-sustainable-energy-utility": {
+      "name": "DC Sustainable Energy Utility",
+      "city": "Washington",
+      "county": "District of Columbia"
+    }
+  },
+  "state": {
+    "dc-dc-department-of-energy-and-environment": {
+      "name": "DC Department of Energy and Environment"
+    }
+  },
+  "utility": {
+    "dc-pepco": {
+      "name": "Pepco"
+    }
+  }
+}

--- a/data/GA/authorities.json
+++ b/data/GA/authorities.json
@@ -1,0 +1,230 @@
+{
+  "state": {},
+  "utility": {
+    "ga-albany-water-gas-and-light-comm": {
+      "name": "Albany Water Gas & Light Comm"
+    },
+    "ga-altamaha-electric-member-corp": {
+      "name": "Altamaha Electric Member Corp"
+    },
+    "ga-amicalola-electric-member-corp": {
+      "name": "Amicalola Electric Member Corp"
+    },
+    "ga-blue-ridge-mountain-emc": {
+      "name": "Blue Ridge Mountain EMC"
+    },
+    "ga-canoochee-electric-member-corp": {
+      "name": "Canoochee Electric Member Corp"
+    },
+    "ga-carroll-electric-member-corp": {
+      "name": "Carroll Electric Member Corp"
+    },
+    "ga-central-georgia-el-member-corp": {
+      "name": "Central Georgia El Member Corp"
+    },
+    "ga-city-of-acworth": {
+      "name": "City of Acworth"
+    },
+    "ga-city-of-adel": {
+      "name": "City of Adel"
+    },
+    "ga-city-of-buford": {
+      "name": "City of Buford"
+    },
+    "ga-city-of-cairo": {
+      "name": "City of Cairo"
+    },
+    "ga-city-of-calhoun": {
+      "name": "City of Calhoun"
+    },
+    "ga-city-of-camilla": {
+      "name": "City of Camilla"
+    },
+    "ga-city-of-cartersville": {
+      "name": "City of Cartersville"
+    },
+    "ga-city-of-chattanooga": {
+      "name": "City of Chattanooga"
+    },
+    "ga-city-of-chickamauga": {
+      "name": "City of Chickamauga"
+    },
+    "ga-city-of-college-park": {
+      "name": "City of College Park"
+    },
+    "ga-city-of-covington": {
+      "name": "City of Covington"
+    },
+    "ga-city-of-douglas": {
+      "name": "City of Douglas"
+    },
+    "ga-city-of-east-point": {
+      "name": "City of East Point"
+    },
+    "ga-city-of-elberton": {
+      "name": "City of Elberton"
+    },
+    "ga-city-of-griffin": {
+      "name": "City of Griffin"
+    },
+    "ga-city-of-la-grange": {
+      "name": "City of La Grange"
+    },
+    "ga-city-of-lawrenceville": {
+      "name": "City of Lawrenceville"
+    },
+    "ga-city-of-marietta": {
+      "name": "City of Marietta"
+    },
+    "ga-city-of-monroe": {
+      "name": "City of Monroe"
+    },
+    "ga-city-of-moultrie": {
+      "name": "City of Moultrie"
+    },
+    "ga-city-of-norcross": {
+      "name": "City of Norcross"
+    },
+    "ga-city-of-sylvania": {
+      "name": "City of Sylvania"
+    },
+    "ga-city-of-thomaston": {
+      "name": "City of Thomaston"
+    },
+    "ga-city-of-thomasville": {
+      "name": "City of Thomasville"
+    },
+    "ga-city-of-washington": {
+      "name": "City of Washington"
+    },
+    "ga-coastal-electric-member-corp": {
+      "name": "Coastal Electric Member Corp"
+    },
+    "ga-cobb-electric-membership-corp": {
+      "name": "Cobb Electric Membership Corp"
+    },
+    "ga-colquitt-electric-membership-corp": {
+      "name": "Colquitt Electric Membership Corp"
+    },
+    "ga-coweta-fayette-el-member-corp": {
+      "name": "Coweta-Fayette El Member Corp"
+    },
+    "ga-crisp-county-power-comm": {
+      "name": "Crisp County Power Comm"
+    },
+    "ga-dalton-utilities": {
+      "name": "Dalton Utilities"
+    },
+    "ga-diverse-power-incorporated": {
+      "name": "Diverse Power Incorporated"
+    },
+    "ga-excelsior-electric-member-corp": {
+      "name": "Excelsior Electric Member Corp"
+    },
+    "ga-fitzgerald-wtr-lgt-and-bond-comm": {
+      "name": "Fitzgerald Wtr Lgt & Bond Comm"
+    },
+    "ga-flint-electric-membership-corp": {
+      "name": "Flint Electric Membership Corp"
+    },
+    "ga-fort-valley-utility-comm": {
+      "name": "Fort Valley Utility Comm"
+    },
+    "ga-georgia-power": {
+      "name": "Georgia Power"
+    },
+    "ga-grady-electric-membership-corp": {
+      "name": "Grady Electric Membership Corp"
+    },
+    "ga-grey-stone-power-corporation": {
+      "name": "GreyStone Power Corporation"
+    },
+    "ga-habersham-electric-membership-corp": {
+      "name": "Habersham Electric Membership Corp"
+    },
+    "ga-hart-electric-member-corp": {
+      "name": "Hart Electric Member Corp"
+    },
+    "ga-haywood-electric-member-corp": {
+      "name": "Haywood Electric Member Corp"
+    },
+    "ga-irwin-electric-membership-corp": {
+      "name": "Irwin Electric Membership Corp"
+    },
+    "ga-jackson-electric-member-corp": {
+      "name": "Jackson Electric Member Corp"
+    },
+    "ga-jefferson-energy-cooperative": {
+      "name": "Jefferson Energy Cooperative"
+    },
+    "ga-little-ocmulgee-el-member-corp": {
+      "name": "Little Ocmulgee El Member Corp"
+    },
+    "ga-middle-georgia-el-member-corp": {
+      "name": "Middle Georgia El Member Corp"
+    },
+    "ga-mitchell-electric-member-corp": {
+      "name": "Mitchell Electric Member Corp"
+    },
+    "ga-newnan-wtr-sewer-and-light-comm": {
+      "name": "Newnan Wtr,  Sewer & Light Comm"
+    },
+    "ga-north-georgia-electric-member-corp": {
+      "name": "North Georgia Electric Member Corp"
+    },
+    "ga-ocmulgee-electric-member-corp": {
+      "name": "Ocmulgee Electric Member Corp"
+    },
+    "ga-oconee-electric-member-corp": {
+      "name": "Oconee Electric Member Corp"
+    },
+    "ga-okefenoke-rural-el-member-corp": {
+      "name": "Okefenoke Rural El Member Corp"
+    },
+    "ga-planters-electric-member-corp": {
+      "name": "Planters Electric Member Corp"
+    },
+    "ga-rayle-electric-membership-corp": {
+      "name": "Rayle Electric Membership Corp"
+    },
+    "ga-satilla-rural-electric-member-corporation": {
+      "name": "Satilla Rural Electric Member Corporation"
+    },
+    "ga-sawnee-electric-membership-corporation": {
+      "name": "Sawnee Electric Membership Corporation"
+    },
+    "ga-slash-pine-electric-member-corp": {
+      "name": "Slash Pine Electric Member Corp"
+    },
+    "ga-snapping-shoals-el-member-corp": {
+      "name": "Snapping Shoals El Member Corp"
+    },
+    "ga-south-carolina-electric-and-gas": {
+      "name": "South Carolina Electric & Gas"
+    },
+    "ga-southern-rivers-energy": {
+      "name": "Southern Rivers Energy"
+    },
+    "ga-sumter-electric-member-corp": {
+      "name": "Sumter Electric Member Corp"
+    },
+    "ga-three-notch-electric-member-corp": {
+      "name": "Three Notch Electric Member Corp"
+    },
+    "ga-tri-county-electric-member-corp": {
+      "name": "Tri-County Electric Member Corp"
+    },
+    "ga-tri-state-electric-member-corp": {
+      "name": "Tri-State Electric Member Corp"
+    },
+    "ga-upson-electric-member-corp": {
+      "name": "Upson Electric Member Corp"
+    },
+    "ga-walton-electric-member-corp": {
+      "name": "Walton Electric Member Corp"
+    },
+    "ga-washington-electric-member-corp": {
+      "name": "Washington Electric Member Corp"
+    }
+  }
+}

--- a/data/IL/authorities.json
+++ b/data/IL/authorities.json
@@ -1,0 +1,135 @@
+{
+  "utility": {
+    "il-adams-electric-cooperative": {
+      "name": "Adams Electric Cooperative"
+    },
+    "il-ameren-illinois": {
+      "name": "Ameren Illinois"
+    },
+    "il-city-of-batavia": {
+      "name": "City of Batavia"
+    },
+    "il-city-of-flora": {
+      "name": "City of Flora"
+    },
+    "il-city-of-geneva": {
+      "name": "City of Geneva"
+    },
+    "il-city-of-highland": {
+      "name": "City of Highland"
+    },
+    "il-city-of-naperville": {
+      "name": "City of Naperville"
+    },
+    "il-city-of-princeton": {
+      "name": "City of Princeton"
+    },
+    "il-city-of-springfield": {
+      "name": "City of Springfield"
+    },
+    "il-city-of-st-charles": {
+      "name": "City of St Charles"
+    },
+    "il-clay-electric-cooperative": {
+      "name": "Clay Electric Cooperative"
+    },
+    "il-clinton-county-electric-cooperative": {
+      "name": "Clinton County Electric Cooperative"
+    },
+    "il-coles-moultrie-electric-cooperative": {
+      "name": "Coles-Moultrie Electric Cooperative"
+    },
+    "il-commonwealth-edison": {
+      "name": "Commonwealth Edison"
+    },
+    "il-corn-belt-energy": {
+      "name": "Corn Belt Energy"
+    },
+    "il-eastern-illinois-electric-cooperative": {
+      "name": "Eastern Illinois Electric Cooperative"
+    },
+    "il-egyptian-electric-cooperative-association": {
+      "name": "Egyptian Electric Cooperative Association"
+    },
+    "il-enerstar-power-corp": {
+      "name": "Enerstar Power Corp"
+    },
+    "il-illinois-rural-electric-cooperative": {
+      "name": "Illinois Rural Electric Cooperative"
+    },
+    "il-jo-carroll-energy-cooperative": {
+      "name": "Jo-Carroll Energy Cooperative"
+    },
+    "il-m-j-m-electric-cooperative": {
+      "name": "M J M Electric Cooperative"
+    },
+    "il-mc-donough-power-cooperative": {
+      "name": "McDonough Power Cooperative"
+    },
+    "il-menard-electric-cooperative": {
+      "name": "Menard Electric Cooperative"
+    },
+    "il-mid-american-energy": {
+      "name": "MidAmerican Energy"
+    },
+    "il-monroe-county-electric-cooperative": {
+      "name": "Monroe County Electric Cooperative"
+    },
+    "il-mt-carmel-public-utility": {
+      "name": "Mt Carmel Public Utility"
+    },
+    "il-norris-electric-cooperative": {
+      "name": "Norris Electric Cooperative"
+    },
+    "il-peru-municipal-electric-department": {
+      "name": "Peru Municipal Electric Department"
+    },
+    "il-rantoul-utilities": {
+      "name": "Rantoul Utilities"
+    },
+    "il-rochelle-municipal-utilities": {
+      "name": "Rochelle Municipal Utilities"
+    },
+    "il-rock-energy-cooperative": {
+      "name": "Rock Energy Cooperative"
+    },
+    "il-rural-electric-convenience-cooperative": {
+      "name": "Rural Electric Convenience Cooperative"
+    },
+    "il-scenic-rivers-energy-cooperative": {
+      "name": "Scenic Rivers Energy Cooperative"
+    },
+    "il-shelby-electric-cooperative": {
+      "name": "Shelby Electric Cooperative"
+    },
+    "il-southeastern-il-electric-cooperative": {
+      "name": "Southeastern IL Electric Cooperative"
+    },
+    "il-southern-illinois-electric-cooperative": {
+      "name": "Southern Illinois Electric Cooperative"
+    },
+    "il-southwestern-electric-cooperative": {
+      "name": "Southwestern Electric Cooperative"
+    },
+    "il-springfield-water-light-and-power-dept": {
+      "name": "Springfield Water Light & Power Dept"
+    },
+    "il-tri-county-electric-cooperative": {
+      "name": "Tri-County Electric Cooperative"
+    },
+    "il-village-of-winnetka": {
+      "name": "Village of Winnetka"
+    },
+    "il-wayne-white-counties-electric-cooperative": {
+      "name": "Wayne-White Counties Electric Cooperative"
+    },
+    "il-western-illinois-electric-cooperative": {
+      "name": "Western Illinois Electric Cooperative"
+    }
+  },
+  "state": {
+    "il-state-of-illinois": {
+      "name": "State of Illinois"
+    }
+  }
+}

--- a/data/MI/authorities.json
+++ b/data/MI/authorities.json
@@ -1,0 +1,134 @@
+{
+  "state": {},
+  "utility": {
+    "mi-alger-delta-cooperative-electric-association": {
+      "name": "Alger-Delta Cooperative Electric Association"
+    },
+    "mi-alpena-power": {
+      "name": "Alpena Power"
+    },
+    "mi-bay-city-electric-light-and-power": {
+      "name": "Bay City Electric Light and Power"
+    },
+    "mi-bayfield-electric-cooperative": {
+      "name": "Bayfield Electric Cooperative"
+    },
+    "mi-cherryland-electric-cooperative": {
+      "name": "Cherryland Electric Cooperative"
+    },
+    "mi-city-of-charlevoix": {
+      "name": "City of Charlevoix"
+    },
+    "mi-city-of-crystal-falls": {
+      "name": "City of Crystal Falls"
+    },
+    "mi-city-of-detroit": {
+      "name": "City of Detroit"
+    },
+    "mi-city-of-escanaba": {
+      "name": "City of Escanaba"
+    },
+    "mi-city-of-gladstone": {
+      "name": "City of Gladstone"
+    },
+    "mi-city-of-grand-haven": {
+      "name": "City of Grand Haven"
+    },
+    "mi-city-of-holland": {
+      "name": "City of Holland"
+    },
+    "mi-city-of-lansing": {
+      "name": "City of Lansing"
+    },
+    "mi-city-of-marquette": {
+      "name": "City of Marquette"
+    },
+    "mi-city-of-marshall": {
+      "name": "City of Marshall"
+    },
+    "mi-city-of-negaunee": {
+      "name": "City of Negaunee"
+    },
+    "mi-city-of-niles": {
+      "name": "City of Niles"
+    },
+    "mi-city-of-norway": {
+      "name": "City of Norway"
+    },
+    "mi-city-of-petoskey": {
+      "name": "City of Petoskey"
+    },
+    "mi-city-of-south-haven": {
+      "name": "City of South Haven"
+    },
+    "mi-city-of-sturgis": {
+      "name": "City of Sturgis"
+    },
+    "mi-city-of-traverse-city": {
+      "name": "City of Traverse City"
+    },
+    "mi-city-of-zeeland": {
+      "name": "City of Zeeland"
+    },
+    "mi-cloverland-electric-cooperative": {
+      "name": "Cloverland Electric Cooperative"
+    },
+    "mi-coldwater-board-of-public-utilities": {
+      "name": "Coldwater Board of Public Utilities"
+    },
+    "mi-consumers-energy": {
+      "name": "Consumers Energy"
+    },
+    "mi-dte": {
+      "name": "DTE"
+    },
+    "mi-great-lakes-energy-cooperative": {
+      "name": "Great Lakes Energy Cooperative"
+    },
+    "mi-hillsdale-board-of-public-utilities": {
+      "name": "Hillsdale Board of Public Utilities"
+    },
+    "mi-indiana-michigan-power": {
+      "name": "Indiana Michigan Power"
+    },
+    "mi-lansing-board-of-water-and-light": {
+      "name": "Lansing Board of Water & Light"
+    },
+    "mi-marshall-municipal-utilities": {
+      "name": "Marshall Municipal Utilities"
+    },
+    "mi-midwest-energy-cooperative": {
+      "name": "Midwest Energy Cooperative"
+    },
+    "mi-presque-isle-electric-and-gas-cooperative": {
+      "name": "Presque Isle Electric & Gas Cooperative"
+    },
+    "mi-thumb-electric-cooperative": {
+      "name": "Thumb Electric Cooperative"
+    },
+    "mi-tri-county-electric-cooperative": {
+      "name": "Tri-County Electric Cooperative"
+    },
+    "mi-upper-peninsula-power-company": {
+      "name": "Upper Peninsula Power Company"
+    },
+    "mi-village-of-baraga": {
+      "name": "Village of Baraga"
+    },
+    "mi-village-of-l-anse": {
+      "name": "Village of L'Anse"
+    },
+    "mi-wisconsin-electric-power": {
+      "name": "Wisconsin Electric Power"
+    },
+    "mi-wisconsin-public-service-corp": {
+      "name": "Wisconsin Public Service Corp"
+    },
+    "mi-wyandotte-municipal-services": {
+      "name": "Wyandotte Municipal Services"
+    },
+    "mi-xcel-energy": {
+      "name": "Xcel Energy"
+    }
+  }
+}

--- a/data/NV/authorities.json
+++ b/data/NV/authorities.json
@@ -1,0 +1,144 @@
+{
+  "state": {},
+  "utility": {
+    "nv-city-of-boulder-city": {
+      "name": "City of Boulder City"
+    },
+    "nv-fallon-nv-city-of": {
+      "name": "Fallon NV (City of)"
+    },
+    "nv-harney-electric-cooperative": {
+      "name": "Harney Electric Cooperative"
+    },
+    "nv-idaho-power": {
+      "name": "Idaho Power"
+    },
+    "nv-lincoln-county-power-district-no-1": {
+      "name": "Lincoln County Power District No 1"
+    },
+    "nv-mt-wheeler-power": {
+      "name": "Mt Wheeler Power"
+    },
+    "nv-nv-energy": {
+      "name": "NV Energy"
+    },
+    "nv-overton-power-district-no-5": {
+      "name": "Overton Power District No 5"
+    },
+    "nv-plumas-sierra-rural-electric-cooperative": {
+      "name": "Plumas-Sierra Rural Electric Cooperative"
+    },
+    "nv-raft-rural-electric-cooperative": {
+      "name": "Raft Rural Electric Cooperative"
+    },
+    "nv-sierra-pacific-power": {
+      "name": "Sierra Pacific Power"
+    },
+    "nv-surprise-valley-electrification": {
+      "name": "Surprise Valley Electrification"
+    },
+    "nv-valley-electric-association": {
+      "name": "Valley Electric Association"
+    },
+    "nv-wells-rural-electric": {
+      "name": "Wells Rural Electric"
+    }
+  },
+  "county": {
+    "nv-washoe-county": {
+      "name": "Washoe County",
+      "county": "Washoe"
+    },
+    "nv-churchill-county": {
+      "name": "Churchill County",
+      "county": "Churchill"
+    },
+    "nv-douglas-county": {
+      "name": "Douglas County",
+      "county": "Douglas"
+    },
+    "nv-lyon-county": {
+      "name": "Lyon County",
+      "county": "Lyon"
+    },
+    "nv-storey-county": {
+      "name": "Storey County",
+      "county": "Storey"
+    },
+    "nv-elko-county": {
+      "name": "Elko County",
+      "county": "Elko"
+    },
+    "nv-esmeralda-county": {
+      "name": "Esmeralda County",
+      "county": "Esmeralda"
+    },
+    "nv-eureka-county": {
+      "name": "Eureka County",
+      "county": "Eureka"
+    },
+    "nv-humboldt-county": {
+      "name": "Humboldt County",
+      "county": "Humboldt"
+    },
+    "nv-lander-county": {
+      "name": "Lander County",
+      "county": "Lander"
+    },
+    "nv-lincoln-county": {
+      "name": "Lincoln County",
+      "county": "Lincoln"
+    },
+    "nv-mineral-county": {
+      "name": "Mineral County",
+      "county": "Mineral"
+    },
+    "nv-nye-county": {
+      "name": "Nye County",
+      "county": "Nye"
+    },
+    "nv-pershing-county": {
+      "name": "Pershing County",
+      "county": "Pershing"
+    },
+    "nv-white-pine-county": {
+      "name": "White Pine County",
+      "county": "White Pine"
+    },
+    "nv-carson-city-county": {
+      "name": "Carson City County",
+      "county": "Carson City"
+    }
+  },
+  "city": {
+    "nv-city-of-las-vegas": {
+      "name": "City of Las Vegas",
+      "city": "Las Vegas",
+      "county": "Clark"
+    },
+    "nv-city-of-henderson": {
+      "name": "City of Henderson",
+      "city": "Henderson",
+      "county": "Clark"
+    },
+    "nv-city-of-north-las-vegas": {
+      "name": "City of North Las Vegas",
+      "city": "North Las Vegas",
+      "county": "Clark"
+    }
+  },
+  "other": {
+    "nv-csa-reno": {
+      "name": "CSA Reno"
+    },
+    "nv-rural-nevada-development-corporation": {
+      "name": "Rural Nevada Development Corporation"
+    },
+    "nv-nevada-rural-housing": {
+      "name": "Nevada Rural Housing"
+    },
+    "nv-help-of-southern-nevada": {
+      "name": "HELP of Southern Nevada"
+    }
+  }
+}

--- a/data/NY/authorities.json
+++ b/data/NY/authorities.json
@@ -1,0 +1,75 @@
+{
+  "state": {
+    "ny-state-of-ny": {
+      "name": "State of NY"
+    },
+    "ny-nyserda": {
+      "name": "New York State Energy Research and Development Authority"
+    }
+  },
+  "utility": {
+    "ny-central-hudson-gas-and-electric": {
+      "name": "Central Hudson Gas & Electric"
+    },
+    "ny-city-of-plattsburgh": {
+      "name": "City of Plattsburgh"
+    },
+    "ny-con-edison": {
+      "name": "Con Edison"
+    },
+    "ny-fishers-island-utility-co": {
+      "name": "Fishers Island Utility Co"
+    },
+    "ny-jamestown-board-of-public-util": {
+      "name": "Jamestown Board of Public Util"
+    },
+    "ny-lake-placid-village": {
+      "name": "Lake Placid Village"
+    },
+    "ny-massena-electric": {
+      "name": "Massena Electric"
+    },
+    "ny-national-grid": {
+      "name": "National Grid"
+    },
+    "ny-nyseg": {
+      "name": "NYSEG"
+    },
+    "ny-orange-and-rockland": {
+      "name": "Orange & Rockland"
+    },
+    "ny-penelec": {
+      "name": "Penelec"
+    },
+    "ny-pseg-long-island": {
+      "name": "PSEG Long Island"
+    },
+    "ny-rochester-gas-and-electric": {
+      "name": "Rochester Gas & Electric"
+    },
+    "ny-salamanca-board-of-public-utilities": {
+      "name": "Salamanca Board of Public Utilities"
+    },
+    "ny-steuben-rural-electric-cooperative": {
+      "name": "Steuben Rural Electric Cooperative"
+    },
+    "ny-village-of-arcade": {
+      "name": "Village of Arcade"
+    },
+    "ny-village-of-fairport": {
+      "name": "Village of Fairport"
+    },
+    "ny-village-of-freeport": {
+      "name": "Village of Freeport"
+    },
+    "ny-village-of-rockville-centre": {
+      "name": "Village of Rockville Centre"
+    },
+    "ny-village-of-rouses-point": {
+      "name": "Village of Rouses Point"
+    },
+    "ny-village-of-solvay": {
+      "name": "Village of Solvay"
+    }
+  }
+}

--- a/data/OR/authorities.json
+++ b/data/OR/authorities.json
@@ -1,0 +1,126 @@
+{
+  "state": {
+    "or-energy-trust-of-oregon": {
+      "name": "Energy Trust of Oregon"
+    }
+  },
+  "utility": {
+    "or-blachly-lane-electric-cooperative": {
+      "name": "Blachly-Lane Electric Cooperative"
+    },
+    "or-canby-utility-board": {
+      "name": "Canby Utility Board"
+    },
+    "or-central-electric-cooperative": {
+      "name": "Central Electric Cooperative"
+    },
+    "or-central-lincoln": {
+      "name": "Central Lincoln"
+    },
+    "or-city-of-ashland": {
+      "name": "City of Ashland"
+    },
+    "or-city-of-bandon": {
+      "name": "City of Bandon"
+    },
+    "or-city-of-eugene": {
+      "name": "City of Eugene"
+    },
+    "or-city-of-forest-grove": {
+      "name": "City of Forest Grove"
+    },
+    "or-city-of-hermiston": {
+      "name": "City of Hermiston"
+    },
+    "or-city-of-mc-minnville": {
+      "name": "City of McMinnville"
+    },
+    "or-city-of-milton-freewater": {
+      "name": "City of Milton-Freewater"
+    },
+    "or-city-of-monmouth": {
+      "name": "City of Monmouth"
+    },
+    "or-city-of-springfield": {
+      "name": "City of Springfield"
+    },
+    "or-clatskanie-pud": {
+      "name": "Clatskanie PUD"
+    },
+    "or-clearwater-power-company": {
+      "name": "Clearwater Power Company"
+    },
+    "or-columbia-basin-electric-cooperative": {
+      "name": "Columbia Basin Electric Cooperative"
+    },
+    "or-columbia-power-cooperative-association": {
+      "name": "Columbia Power Cooperative Association"
+    },
+    "or-columbia-river-pud": {
+      "name": "Columbia River PUD"
+    },
+    "or-columbia-rural-electric-association": {
+      "name": "Columbia Rural Electric Association"
+    },
+    "or-consumers-power": {
+      "name": "Consumers Power"
+    },
+    "or-coos-curry-electric-cooperative": {
+      "name": "Coos-Curry Electric Cooperative"
+    },
+    "or-douglas-electric-cooperative": {
+      "name": "Douglas Electric Cooperative"
+    },
+    "or-emerald-people-s-utility-district": {
+      "name": "Emerald People's Utility District"
+    },
+    "or-eugene-water-and-electric-board": {
+      "name": "Eugene Water & Electric Board"
+    },
+    "or-harney-electric-cooperative": {
+      "name": "Harney Electric Cooperative"
+    },
+    "or-hood-river-electric-cooperative": {
+      "name": "Hood River Electric Cooperative"
+    },
+    "or-idaho-power": {
+      "name": "Idaho Power"
+    },
+    "or-lane-electric-cooperative": {
+      "name": "Lane Electric Cooperative"
+    },
+    "or-midstate-electric-cooperative": {
+      "name": "Midstate Electric Cooperative"
+    },
+    "or-northern-wasco-county-pud": {
+      "name": "Northern Wasco County PUD"
+    },
+    "or-nw-natural": {
+      "name": "NW Natural"
+    },
+    "or-oregon-trail-electric-cooperative": {
+      "name": "Oregon Trail Electric Cooperative"
+    },
+    "or-pacific-power": {
+      "name": "Pacific Power"
+    },
+    "or-portland-general-electric": {
+      "name": "Portland General Electric"
+    },
+    "or-salem-electric": {
+      "name": "Salem Electric"
+    },
+    "or-surprise-valley-electrification": {
+      "name": "Surprise Valley Electrification"
+    },
+    "or-tillamook-people-s-utility-district": {
+      "name": "Tillamook People's Utility District"
+    },
+    "or-umatilla-electric-cooperative-association": {
+      "name": "Umatilla Electric Cooperative Association"
+    },
+    "or-wasco-electric-cooperative": {
+      "name": "Wasco Electric Cooperative"
+    }
+  }
+}

--- a/data/PA/authorities.json
+++ b/data/PA/authorities.json
@@ -1,0 +1,95 @@
+{
+  "state": {
+    "pa-department-of-community-and-economic-development": {
+      "name": "Department of Community and Economic Development"
+    }
+  },
+  "other": {
+    "pa-first-energy": {
+      "name": "First Energy"
+    }
+  },
+  "utility": {
+    "pa-adams-electric-cooperative": {
+      "name": "Adams Electric Cooperative"
+    },
+    "pa-bedford-rural-electric-cooperative": {
+      "name": "Bedford Rural Electric Cooperative"
+    },
+    "pa-borough-of-chambersburg": {
+      "name": "Borough of Chambersburg"
+    },
+    "pa-borough-of-ephrata": {
+      "name": "Borough of Ephrata"
+    },
+    "pa-borough-of-lansdale": {
+      "name": "Borough of Lansdale"
+    },
+    "pa-borough-of-quakertown": {
+      "name": "Borough of Quakertown"
+    },
+    "pa-central-electric-cooperative": {
+      "name": "Central Electric Cooperative"
+    },
+    "pa-citizens-electric": {
+      "name": "Citizens Electric"
+    },
+    "pa-claverack-rural-electric-cooperative": {
+      "name": "Claverack Rural Electric Cooperative"
+    },
+    "pa-duquesne-light-company": {
+      "name": "Duquesne Light Company"
+    },
+    "pa-met-ed": {
+      "name": "Met-Ed"
+    },
+    "pa-new-wilmington-pa-borough-of": {
+      "name": "New Wilmington PA (Borough of)"
+    },
+    "pa-northwestern-rural-e-c-a": {
+      "name": "Northwestern Rural E C A"
+    },
+    "pa-peco": {
+      "name": "PECO"
+    },
+    "pa-penelec": {
+      "name": "Penelec"
+    },
+    "pa-penn-power": {
+      "name": "Penn Power"
+    },
+    "pa-pike-county-light-and-power": {
+      "name": "Pike County Light & Power"
+    },
+    "pa-ppl-electric-utilities-corp": {
+      "name": "PPL Electric Utilities Corp"
+    },
+    "pa-rea-energy-cooperative": {
+      "name": "REA Energy Cooperative"
+    },
+    "pa-somerset-rural-electric-cooperative": {
+      "name": "Somerset Rural Electric Cooperative"
+    },
+    "pa-tri-county-rural-electric-cooperative": {
+      "name": "Tri-County Rural Electric Cooperative"
+    },
+    "pa-ugi-utilities": {
+      "name": "UGI Utilities"
+    },
+    "pa-united-electric-cooperative": {
+      "name": "United Electric Cooperative"
+    },
+    "pa-valley-rural-electric-cooperative": {
+      "name": "Valley Rural Electric Cooperative"
+    },
+    "pa-vicinity-energy": {
+      "name": "Vicinity Energy"
+    },
+    "pa-wellsborough-electric": {
+      "name": "Wellsborough Electric"
+    },
+    "pa-west-penn-power-company": {
+      "name": "West Penn Power Company"
+    }
+  }
+}

--- a/data/RI/authorities.json
+++ b/data/RI/authorities.json
@@ -1,0 +1,44 @@
+{
+  "state": {
+    "ri-oer": {
+      "name": "Rhode Island Office of Energy Resources",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-oer.png",
+        "width": 311,
+        "height": 100
+      }
+    },
+    "ri-commerce-corp": {
+      "name": "Rhode Island Commerce Corporation"
+    },
+    "ri-dhs": {
+      "name": "Rhode Island Department of Human Services"
+    }
+  },
+  "utility": {
+    "ri-block-island-power-company": {
+      "name": "Block Island Power Company",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-block-island-power-company.png",
+        "width": 119,
+        "height": 100
+      }
+    },
+    "ri-pascoag-utility-district": {
+      "name": "Pascoag Utility District",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-pascoag-utility-district.svg",
+        "width": 369,
+        "height": 100
+      }
+    },
+    "ri-rhode-island-energy": {
+      "name": "Rhode Island Energy",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/ri-rhode-island-energy.png",
+        "width": 287,
+        "height": 100
+      }
+    }
+  }
+}

--- a/data/VA/authorities.json
+++ b/data/VA/authorities.json
@@ -1,0 +1,86 @@
+{
+  "state": {},
+  "utility": {
+    "va-a-and-n-electric-cooperative": {
+      "name": "A & N Electric Cooperative"
+    },
+    "va-appalachian-power": {
+      "name": "Appalachian Power"
+    },
+    "va-barc-electric-cooperative": {
+      "name": "BARC Electric Cooperative"
+    },
+    "va-bvu-authority": {
+      "name": "BVU Authority"
+    },
+    "va-central-virginia-electric-cooperative": {
+      "name": "Central Virginia Electric Cooperative"
+    },
+    "va-city-of-manassas": {
+      "name": "City of Manassas"
+    },
+    "va-city-of-martinsville": {
+      "name": "City of Martinsville"
+    },
+    "va-city-of-salem": {
+      "name": "City of Salem"
+    },
+    "va-community-electric-cooperative": {
+      "name": "Community Electric Cooperative"
+    },
+    "va-craig-botetourt-electric-cooperative": {
+      "name": "Craig-Botetourt Electric Cooperative"
+    },
+    "va-danville-utilities": {
+      "name": "Danville Utilities"
+    },
+    "va-dominion-energy": {
+      "name": "Dominion Energy"
+    },
+    "va-franklin-municipal-power-and-light": {
+      "name": "Franklin Municipal Power and Light"
+    },
+    "va-kentucky-utilities": {
+      "name": "Kentucky Utilities"
+    },
+    "va-mecklenburg-electric-cooperative": {
+      "name": "Mecklenburg Electric Cooperative"
+    },
+    "va-northern-neck-electric-cooperative": {
+      "name": "Northern Neck Electric Cooperative"
+    },
+    "va-novec": {
+      "name": "NOVEC"
+    },
+    "va-powell-valley-electric-cooperative": {
+      "name": "Powell Valley Electric Cooperative"
+    },
+    "va-prince-george-electric-cooperative": {
+      "name": "Prince George Electric Cooperative"
+    },
+    "va-radford-electric-department": {
+      "name": "Radford Electric Department"
+    },
+    "va-rappahannock-electric-cooperative": {
+      "name": "Rappahannock Electric Cooperative"
+    },
+    "va-shenandoah-valley-electric-cooperative": {
+      "name": "Shenandoah Valley Electric Cooperative"
+    },
+    "va-southside-electric-cooperative": {
+      "name": "Southside Electric Cooperative"
+    },
+    "va-town-of-bedford": {
+      "name": "Town of Bedford"
+    },
+    "va-town-of-culpeper": {
+      "name": "Town of Culpeper"
+    },
+    "va-town-of-front-royal": {
+      "name": "Town of Front Royal"
+    },
+    "va-virginia-tech-electric-service": {
+      "name": "Virginia Tech Electric Service"
+    }
+  }
+}

--- a/data/VT/authorities.json
+++ b/data/VT/authorities.json
@@ -1,0 +1,53 @@
+{
+  "state": {
+    "vt-ev": {
+      "name": "Efficiency Vermont"
+    },
+    "vt-state-of-vermont": {
+      "name": "State of Vermont"
+    }
+  },
+  "utility": {
+    "vt-burlington-electric-department": {
+      "name": "Burlington Electric Department"
+    },
+    "vt-green-mountain-power": {
+      "name": "Green Mountain Power"
+    },
+    "vt-lyndon-electric-department": {
+      "name": "Lyndon Electric Department"
+    },
+    "vt-morrisville-water-and-light": {
+      "name": "Morrisville Water & Light"
+    },
+    "vt-stowe-electric-department": {
+      "name": "Stowe Electric Department"
+    },
+    "vt-swanton-electric": {
+      "name": "Swanton Electric"
+    },
+    "vt-town-of-hardwick-electric-department": {
+      "name": "Town of Hardwick Electric Department"
+    },
+    "vt-town-of-northfield-electric-department": {
+      "name": "Town of Northfield Electric Department"
+    },
+    "vt-vermont-electric-cooperative": {
+      "name": "Vermont Electric Cooperative"
+    },
+    "vt-vgs": {
+      "name": "VGS"
+    },
+    "vt-village-of-ludlow-electric-light-department": {
+      "name": "Village of Ludlow Electric Light Department"
+    },
+    "vt-washington-electric-cooperative": {
+      "name": "Washington Electric Cooperative"
+    }
+  },
+  "other": {
+    "vt-vppsa": {
+      "name": "VPPSA"
+    }
+  }
+}

--- a/data/WI/authorities.json
+++ b/data/WI/authorities.json
@@ -1,0 +1,267 @@
+{
+  "state": {
+    "wi-focus-on-energy": {
+      "name": "Focus On Energy"
+    }
+  },
+  "utility": {
+    "wi-adams-columbia-electric-cooperative": {
+      "name": "Adams-Columbia Electric Cooperative"
+    },
+    "wi-algoma-utility-comm": {
+      "name": "Algoma Utility Comm"
+    },
+    "wi-barron-electric-cooperative": {
+      "name": "Barron Electric Cooperative"
+    },
+    "wi-bayfield-electric-cooperative": {
+      "name": "Bayfield Electric Cooperative"
+    },
+    "wi-brodhead-water-and-lighting-comm": {
+      "name": "Brodhead Water & Lighting Comm"
+    },
+    "wi-cedarburg-light-and-water-comm": {
+      "name": "Cedarburg Light & Water Comm"
+    },
+    "wi-central-wisconsin-electric-cooperative": {
+      "name": "Central Wisconsin Electric Cooperative"
+    },
+    "wi-chippewa-valley-electric-cooperative": {
+      "name": "Chippewa Valley Electric Cooperative"
+    },
+    "wi-city-of-black-river-falls": {
+      "name": "City of Black River Falls"
+    },
+    "wi-city-of-boscobel": {
+      "name": "City of Boscobel"
+    },
+    "wi-city-of-clintonville": {
+      "name": "City of Clintonville"
+    },
+    "wi-city-of-columbus": {
+      "name": "City of Columbus"
+    },
+    "wi-city-of-cuba-city": {
+      "name": "City of Cuba City"
+    },
+    "wi-city-of-eagle-river": {
+      "name": "City of Eagle River"
+    },
+    "wi-city-of-elkhorn": {
+      "name": "City of Elkhorn"
+    },
+    "wi-city-of-evansville": {
+      "name": "City of Evansville"
+    },
+    "wi-city-of-kaukauna": {
+      "name": "City of Kaukauna"
+    },
+    "wi-city-of-lodi": {
+      "name": "City of Lodi"
+    },
+    "wi-city-of-marshfield": {
+      "name": "City of Marshfield"
+    },
+    "wi-city-of-medford": {
+      "name": "City of Medford"
+    },
+    "wi-city-of-menasha": {
+      "name": "City of Menasha"
+    },
+    "wi-city-of-new-holstein": {
+      "name": "City of New Holstein"
+    },
+    "wi-city-of-new-richmond": {
+      "name": "City of New Richmond"
+    },
+    "wi-city-of-plymouth": {
+      "name": "City of Plymouth"
+    },
+    "wi-city-of-richland-center": {
+      "name": "City of Richland Center"
+    },
+    "wi-city-of-river-falls": {
+      "name": "City of River Falls"
+    },
+    "wi-city-of-sheboygan-falls": {
+      "name": "City of Sheboygan Falls"
+    },
+    "wi-city-of-stoughton": {
+      "name": "City of Stoughton"
+    },
+    "wi-city-of-sturgeon-bay": {
+      "name": "City of Sturgeon Bay"
+    },
+    "wi-city-of-westby": {
+      "name": "City of Westby"
+    },
+    "wi-clark-electric-cooperative": {
+      "name": "Clark Electric Cooperative"
+    },
+    "wi-consolidated-water-power": {
+      "name": "Consolidated Water Power"
+    },
+    "wi-dahlberg-light-and-power": {
+      "name": "Dahlberg Light & Power"
+    },
+    "wi-dunn-county-electric-cooperative": {
+      "name": "Dunn County Electric Cooperative"
+    },
+    "wi-east-central-energy": {
+      "name": "East Central Energy"
+    },
+    "wi-eau-claire-electric-cooperative": {
+      "name": "Eau Claire Electric Cooperative"
+    },
+    "wi-florence-utility-comm": {
+      "name": "Florence Utility Comm"
+    },
+    "wi-hartford-electric": {
+      "name": "Hartford Electric"
+    },
+    "wi-hustisford-utilities": {
+      "name": "Hustisford Utilities"
+    },
+    "wi-jackson-electric-cooperative": {
+      "name": "Jackson Electric Cooperative"
+    },
+    "wi-jefferson-utilities": {
+      "name": "Jefferson Utilities"
+    },
+    "wi-jump-river-electric-cooperative": {
+      "name": "Jump River Electric Cooperative"
+    },
+    "wi-juneau-utility-comm": {
+      "name": "Juneau Utility Comm"
+    },
+    "wi-lake-mills-light-and-water": {
+      "name": "Lake Mills Light & Water"
+    },
+    "wi-madison-gas-and-electric": {
+      "name": "Madison Gas & Electric"
+    },
+    "wi-manitowoc-public-utilities": {
+      "name": "Manitowoc Public Utilities"
+    },
+    "wi-new-london-electric-and-water-util": {
+      "name": "New London Electric&Water Util"
+    },
+    "wi-north-central-power-co": {
+      "name": "North Central Power Co"
+    },
+    "wi-northwestern-wisconsin-electric": {
+      "name": "Northwestern Wisconsin Electric"
+    },
+    "wi-oakdale-electric-cooperative": {
+      "name": "Oakdale Electric Cooperative"
+    },
+    "wi-oconomowoc-utilities": {
+      "name": "Oconomowoc Utilities"
+    },
+    "wi-oconto-electric-cooperative": {
+      "name": "Oconto Electric Cooperative"
+    },
+    "wi-oconto-falls-water-and-light-comm": {
+      "name": "Oconto Falls Water & Light Comm"
+    },
+    "wi-pierce-pepin-cooperative-services": {
+      "name": "Pierce-Pepin Cooperative Services"
+    },
+    "wi-pioneer-power-and-light": {
+      "name": "Pioneer Power and Light"
+    },
+    "wi-polk-burnett-electric-cooperative": {
+      "name": "Polk-Burnett Electric Cooperative"
+    },
+    "wi-price-electric-cooperative": {
+      "name": "Price Electric Cooperative"
+    },
+    "wi-reedsburg-utility-comm": {
+      "name": "Reedsburg Utility Comm"
+    },
+    "wi-rice-lake-utilities": {
+      "name": "Rice Lake Utilities"
+    },
+    "wi-riverland-energy-cooperative": {
+      "name": "Riverland Energy Cooperative"
+    },
+    "wi-rock-energy-cooperative": {
+      "name": "Rock Energy Cooperative"
+    },
+    "wi-scenic-rivers-energy-cooperative": {
+      "name": "Scenic Rivers Energy Cooperative"
+    },
+    "wi-shawano-municipal-utilities": {
+      "name": "Shawano Municipal Utilities"
+    },
+    "wi-slinger-utilities": {
+      "name": "Slinger Utilities"
+    },
+    "wi-st-croix-electric-cooperative": {
+      "name": "St Croix Electric Cooperative"
+    },
+    "wi-sun-prairie-utilities": {
+      "name": "Sun Prairie Utilities"
+    },
+    "wi-superior-water-and-light": {
+      "name": "Superior Water and Light"
+    },
+    "wi-taylor-electric-cooperative": {
+      "name": "Taylor Electric Cooperative"
+    },
+    "wi-two-rivers-water-and-light": {
+      "name": "Two Rivers Water & Light"
+    },
+    "wi-vernon-electric-cooperative": {
+      "name": "Vernon Electric Cooperative"
+    },
+    "wi-village-of-bangor": {
+      "name": "Village of Bangor"
+    },
+    "wi-village-of-mt-horeb": {
+      "name": "Village of Mt. Horeb"
+    },
+    "wi-village-of-muscoda": {
+      "name": "Village of Muscoda"
+    },
+    "wi-village-of-new-glarus": {
+      "name": "Village of New Glarus"
+    },
+    "wi-village-of-prairie-du-sac": {
+      "name": "Village of Prairie Du Sac"
+    },
+    "wi-village-of-waunakee": {
+      "name": "Village of Waunakee"
+    },
+    "wi-washington-island-electric-cooperative": {
+      "name": "Washington Island Electric Cooperative"
+    },
+    "wi-waterloo-light-and-water-comm": {
+      "name": "Waterloo Light & Water Comm"
+    },
+    "wi-waupun-utilities": {
+      "name": "Waupun Utilities"
+    },
+    "wi-westfield-electric-company": {
+      "name": "Westfield Electric Company"
+    },
+    "wi-whitehall-electric-utility": {
+      "name": "Whitehall Electric Utility"
+    },
+    "wi-wisconsin-electric-power": {
+      "name": "Wisconsin Electric Power"
+    },
+    "wi-wisconsin-power-and-light": {
+      "name": "Wisconsin Power & Light"
+    },
+    "wi-wisconsin-public-service-corp": {
+      "name": "Wisconsin Public Service Corp"
+    },
+    "wi-wisconsin-rapids-w-w-and-l-comm": {
+      "name": "Wisconsin Rapids W W & L Comm"
+    },
+    "wi-xcel-energy": {
+      "name": "Xcel Energy"
+    }
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,20 +34,9 @@ Filling out an entry for `incentive-spreadsheet-registry.ts` consists of creatin
 - Optionally declaring the header row number, if not the top row of the spreadsheet, in `headerRowNumber`
 - Optionally naming a filepath where _collected_ incentives will be written in `collectedFilepath`. This is experimental and affects how some of the scripts work, so you shouldn't do this for now unless you know what you're doing.
 
-First, **edit `authorities.json` manually** to include a top-level entry for
-the state you're adding, if it's not already present, like this:
+First, create a subdirectory in `data/` named with the new state's abbreviation.
 
-```json
-{
-  "<state-abbreviation>": {
-    "state": {},
-    "utility": {}
-  },
-  ...
-}
-```
-
-Then, run [`generate-utility-data.ts`](generate-utility-data.ts) to populate the list of utilities for the state in the authorities file. See [below](#utility-data) for details on that.
+Then, run [`generate-utility-data.ts`](generate-utility-data.ts) to populate the list of utilities in the state's authorities.json file. See [below](#utility-data) for details on that.
 
 [`generate-misc-state-data.ts`](generate-misc-state-data.ts) adds values to ancillary files to reflect the programs and authorities that will be needed for the JSON. This needs to happen first because our data schemas actually require an incentive's program/authority to be one of the listed members, and if that's not the case, the incentive will fail validation.
 
@@ -80,7 +69,7 @@ To encode relationships between incentives, see the [`relationships-README`](htt
 
 ## Utility Data
 
-`generate-utility-data.ts` reads a [dataset](https://downloads.energystar.gov/bi/portfolio-manager/Public_Utility_Map_en_US.xlsx) published by ENERGY STAR to create a mapping from ZIP codes to utilities. It writes to a CSV file in `scripts/data`, which is then imported into the SQLite database by `build.sh`. It also modifies `authorities.json` to include the utility IDs and names. This data is used in the `/api/v1/utilities` endpoint.
+`generate-utility-data.ts` reads a [dataset](https://downloads.energystar.gov/bi/portfolio-manager/Public_Utility_Map_en_US.xlsx) published by ENERGY STAR to create a mapping from ZIP codes to utilities. It writes to a CSV file in `scripts/data`, which is then imported into the SQLite database by `build.sh`. For any state with a subdirectory in `data`, it also modifies that state's `authorities.json` to include the utility IDs and names. This data is used in the `/api/v1/utilities` endpoint.
 
 The script has no required arguments. It downloads the data file from ENERGY STAR by default; you can pass `--file <file>` to have it read a local file instead (useful when testing).
 
@@ -92,7 +81,7 @@ At the top, the script defines a set of "exclusions" and "overrides", which patc
 
 When adding support for a new state, you should vet and clean up the utility data we have for that state, using this process:
 
-1. Look in authorities.json at the list of utilities for your state. For each one, try to determine:
+1. After running the script once, look at the list of utilities in your state's authorities.json. For each one, try to determine:
 
    - Does the utility provide electricity? If not, exclude them (see below).
    - Does the utility have a different customer-facing name? (E.g. the data tends to name municipal utilities as `City of XYZ`, but they often brand themselves as `XYZ Public Utilities` or similar.) If so, add an override (see below). We prefer to use the name that's at the top of their website / in their logo.
@@ -124,7 +113,7 @@ When adding support for a new state, you should vet and clean up the utility dat
    3. If there's no numeric Utility Code (i.e. it says `Not Available` in that column), then do the step above but with the Utility Name from the spreadsheet instead.
 
 3. As you add exclusions and overrides, rerun the script and `yarn build` to reflect your changes in the CSVs and SQLite.
-4. When all the cleanup is done, make sure the set of utilities for the state in `authorities.json` is a subset of the utility IDs in SQLite. (There is a test for this.)
+4. When all the cleanup is done, make sure the set of utilities in the state's `authorities.json` is a subset of the utility IDs in SQLite. (There is a test for this: `test/data/utilities.test.ts`.)
 
 ## spreadsheets-health.test.ts
 

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -108,8 +108,7 @@ export function updateAuthorities(
 ): AuthorityTypeMap {
   // Preserve existing utilities. Those are generated from an external dataset
   // by generate-utility-data.ts.
-  const existingUtilities = existingJson.utility;
-  const json: AuthorityTypeMap = {};
+  const json: AuthorityTypeMap = { utility: existingJson.utility };
 
   const [utilities, nonUtilities] = _.partition(
     Object.entries(authorityMap),
@@ -118,10 +117,11 @@ export function updateAuthorities(
 
   // Make sure all utilities already exist in JSON.
   for (const [utilityId] of utilities) {
-    if (!(utilityId in existingUtilities)) {
+    if (!(utilityId in json.utility)) {
       throw new Error(
         `Utility ${utilityId} is in spreadsheet but not in authorities.json. ` +
-          'Run generate-utility-data.ts before this script, or fix the ' +
+          'Run generate-utility-data.ts before this script (possibly after ' +
+          "updating it to override the utility's name), or fix the " +
           'utility name in the spreadsheet.',
       );
     }
@@ -136,7 +136,6 @@ export function updateAuthorities(
     };
   }
 
-  json.utility = existingUtilities;
   return sortMapByKey(json);
 }
 

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import _ from 'lodash';
+import path from 'path';
 import * as prettier from 'prettier';
 import { Project, SourceFile } from 'ts-morph';
 import { GeoGroup } from '../../src/data/geo_groups';
@@ -13,7 +14,6 @@ const PROGRAMS_TS_FILE = 'src/data/programs.ts';
 project.addSourceFileAtPath(PROGRAMS_TS_FILE);
 const globalSourceFile = project.getSourceFileOrThrow(PROGRAMS_TS_FILE);
 
-const AUTHORITIES_JSON_FILE = 'data/authorities.json';
 const GEOGROUPS_JSON_FILE = 'data/geo_groups.json';
 
 const wordSeparators =
@@ -103,24 +103,13 @@ export function sortMapByKey<T>(json: Record<string, T>): Record<string, T> {
 }
 
 export function updateAuthorities(
-  json: StateToAuthorityTypeMap,
-  state: string,
+  existingJson: AuthorityTypeMap,
   authorityMap: AuthorityMap,
-): StateToAuthorityTypeMap {
-  const stateUpper = state.toUpperCase();
+): AuthorityTypeMap {
   // Preserve existing utilities. Those are generated from an external dataset
   // by generate-utility-data.ts.
-  const existingUtilities = json[stateUpper]?.utility;
-
-  if (!existingUtilities) {
-    throw new Error(
-      `authorities.json has no entry for ${stateUpper}. Make sure there is a ` +
-        `top-level entry for ${stateUpper}, and run generate-utility-data.ts ` +
-        'before running this script.',
-    );
-  }
-
-  json[stateUpper] = {};
+  const existingUtilities = existingJson.utility;
+  const json: AuthorityTypeMap = {};
 
   const [utilities, nonUtilities] = _.partition(
     Object.entries(authorityMap),
@@ -139,17 +128,15 @@ export function updateAuthorities(
   }
 
   for (const [authorityShort, authority] of nonUtilities) {
-    if (
-      json[stateUpper][authority.authority_type.toLowerCase()] === undefined
-    ) {
-      json[stateUpper][authority.authority_type.toLowerCase()] = {};
+    if (json[authority.authority_type.toLowerCase()] === undefined) {
+      json[authority.authority_type.toLowerCase()] = {};
     }
-    json[stateUpper][authority.authority_type.toLowerCase()][authorityShort] = {
+    json[authority.authority_type.toLowerCase()][authorityShort] = {
       name: authority.name,
     };
   }
 
-  json[stateUpper].utility = existingUtilities;
+  json.utility = existingUtilities;
   return sortMapByKey(json);
 }
 
@@ -305,7 +292,7 @@ type JsonAuthorities = {
   [index: AuthorityKey]: { name: string };
 };
 type AuthorityType = string;
-type AuthorityTypeMap = {
+export type AuthorityTypeMap = {
   [index: AuthorityType]: JsonAuthorities;
 };
 export type StateToAuthorityTypeMap = {
@@ -366,15 +353,22 @@ export class AuthorityAndProgramUpdater {
   }
 
   updateAuthoritiesJson() {
-    const json: StateToAuthorityTypeMap = JSON.parse(
-      fs.readFileSync(AUTHORITIES_JSON_FILE, 'utf-8'),
+    const filepath = path.join(
+      __dirname,
+      `../../data/${this.state}/authorities.json`,
     );
-    const updated = updateAuthorities(json, this.state, this.authorityMap);
-    fs.writeFileSync(
-      AUTHORITIES_JSON_FILE,
-      JSON.stringify(updated, null, 2),
-      'utf-8',
+    if (!fs.existsSync(filepath)) {
+      throw new Error(
+        `No authorities.json file for ${this.state}. ` +
+          `Make sure the directory data/${this.state} exists, then run ` +
+          'generate-utility-data.ts, then run this script again.',
+      );
+    }
+    const json: AuthorityTypeMap = JSON.parse(
+      fs.readFileSync(filepath, 'utf-8'),
     );
+    const updated = updateAuthorities(json, this.authorityMap);
+    fs.writeFileSync(filepath, JSON.stringify(updated, null, 2), 'utf-8');
   }
 
   async updatePrograms() {

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -63,7 +63,7 @@ export const SCHEMA = {
       county: authoritiesMapSchema,
       other: authoritiesMapSchema,
     },
-    required: ['state', 'utility'],
+    required: ['utility'],
     additionalProperties: false,
   },
   required: [],
@@ -72,6 +72,13 @@ export const SCHEMA = {
 export type AuthoritiesByType = { [index: string]: AuthoritiesById };
 export type AuthoritiesByState = FromSchema<typeof SCHEMA>;
 
-export const AUTHORITIES_BY_STATE: AuthoritiesByState = JSON.parse(
-  fs.readFileSync('./data/authorities.json', 'utf-8'),
-);
+export const AUTHORITIES_BY_STATE: AuthoritiesByState = (() => {
+  const result: AuthoritiesByState = {};
+  for (const state of STATES_PLUS_DC) {
+    const filepath = `./data/${state}/authorities.json`;
+    if (fs.existsSync(filepath)) {
+      result[state] = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+    }
+  }
+  return result;
+})();

--- a/test/scripts/authority-and-program-updater.test.ts
+++ b/test/scripts/authority-and-program-updater.test.ts
@@ -3,6 +3,7 @@ import { test } from 'tap';
 import { Project, QuoteKind } from 'ts-morph';
 import {
   AuthorityMap,
+  AuthorityTypeMap,
   StateToAuthorityTypeMap,
   StateToGeoGroupMap,
   createProgramsContent,
@@ -129,28 +130,26 @@ test('correctly sort state authority information by state', tap => {
 });
 
 test('replace existing state', tap => {
-  const initial: StateToAuthorityTypeMap = {
-    CT: {
-      state: {
-        'ct-deep': {
-          name: 'CT Department of Energy & Environmental Protection',
-        },
+  const initial: AuthorityTypeMap = {
+    state: {
+      'ct-deep': {
+        name: 'CT Department of Energy & Environmental Protection',
       },
-      city: {
-        'ct-city': {
-          name: 'City',
-        },
-        'ct-town': {
-          name: 'Town',
-        },
+    },
+    city: {
+      'ct-city': {
+        name: 'City',
       },
-      utility: {
-        'ct-utility': {
-          name: 'Utility',
-        },
-        'ct-other-utility': {
-          name: 'Other utility',
-        },
+      'ct-town': {
+        name: 'Town',
+      },
+    },
+    utility: {
+      'ct-utility': {
+        name: 'Utility',
+      },
+      'ct-other-utility': {
+        name: 'Other utility',
       },
     },
   };
@@ -175,31 +174,29 @@ test('replace existing state', tap => {
     },
   };
 
-  const expected: StateToAuthorityTypeMap = {
-    CT: {
-      state: {
-        'ct-deep': {
-          name: 'CT Department of Energy & Environmental Protection',
-        },
+  const expected: AuthorityTypeMap = {
+    state: {
+      'ct-deep': {
+        name: 'CT Department of Energy & Environmental Protection',
       },
-      city: {
-        'ct-metropolis': {
-          name: 'Metropolis',
-        },
+    },
+    city: {
+      'ct-metropolis': {
+        name: 'Metropolis',
       },
-      utility: {
-        // AuthorityMap had a different name for this, but original is kept
-        'ct-utility': {
-          name: 'Utility',
-        },
-        // This utility is still here even though it's not in authorityMap
-        'ct-other-utility': {
-          name: 'Other utility',
-        },
+    },
+    utility: {
+      // AuthorityMap had a different name for this, but original is kept
+      'ct-utility': {
+        name: 'Utility',
+      },
+      // This utility is still here even though it's not in authorityMap
+      'ct-other-utility': {
+        name: 'Other utility',
       },
     },
   };
-  tap.matchOnly(updateAuthorities(initial, 'CT', authorityMap), expected);
+  tap.matchOnly(updateAuthorities(initial, authorityMap), expected);
   tap.end();
 });
 
@@ -213,24 +210,8 @@ test('error on utility not in authorities', tap => {
   };
 
   tap.throws(
-    () => updateAuthorities(unorderedFixture, 'CT', authorityMap),
+    () => updateAuthorities(unorderedFixture.CT, authorityMap),
     /Utility ct-new-utility is in spreadsheet but not in authorities/,
-  );
-  tap.end();
-});
-
-test('error on nonexistent state', tap => {
-  const authorityMap: AuthorityMap = {
-    'de-state': {
-      name: 'Delaware State Energy',
-      authority_type: 'state',
-      programs: {},
-    },
-  };
-
-  tap.throws(
-    () => updateAuthorities(unorderedFixture, 'DE', authorityMap),
-    /authorities.json has no entry for DE./,
   );
   tap.end();
 });


### PR DESCRIPTION
## Description

We're about to populate authorities for every state's utilities in one
go, and that would make authorities.json unmanageably large. Since its
top-level key is already states, that makes it easy to split into one
file per state.

There's basically no downstream effect in the API server;
`authorities.ts` just recreates the same map that was previously in
the unified authorities.json. The scripts side is actually simplified
a bit.

The `state` key in a state's authorities is now optional, because we'll
be generating files with only a `utility` key.

https://app.asana.com/0/1206661332626418/1206882125337116

## Test Plan

`yarn lint` and `yarn test`.

Followed the new-state process (running generate-utility-data and then
authority-and-program-updater) for CA to make sure it goes smoothly.
