### PR TITLE
Add more_info_url to the v1 API; make program_url required

### DIFF
--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -48,8 +48,6 @@ const ira_programs = {
     },
     url: {
       en: 'https://www.irs.gov/credits-deductions/used-clean-vehicle-credit',
-      // TODO this page's content isn't translated into Spanish, but this is
-      // the URL where it should appear when they get it translated
       es: 'https://www.irs.gov/es/credits-deductions/used-clean-vehicle-credit',
     },
   },

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -17,7 +17,7 @@ import { LocalizableString } from './types/localizable-string';
 
 export type Program = {
   name: LocalizableString;
-  url?: LocalizableString;
+  url: LocalizableString;
 };
 
 const ira_programs = {
@@ -26,11 +26,19 @@ const ira_programs = {
       en: 'Federal Alternative Fuel Vehicle Refueling Property Credit (30C)',
       es: 'Crédito a la propiedad para el repostaje de vehículos de combustible alternativo (30C)',
     },
+    url: {
+      en: 'https://www.irs.gov/credits-deductions/alternative-fuel-vehicle-refueling-property-credit',
+      es: 'https://www.irs.gov/es/credits-deductions/alternative-fuel-vehicle-refueling-property-credit',
+    },
   },
   cleanVehicleCredit: {
     name: {
       en: 'Federal Clean Vehicle Credit (30D)',
       es: 'Crédito para vehículos limpios (30D)',
+    },
+    url: {
+      en: 'https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after',
+      es: 'https://www.irs.gov/es/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after',
     },
   },
   creditForPreviouslyOwnedCleanVehicles: {
@@ -38,11 +46,21 @@ const ira_programs = {
       en: 'Federal Credit for Previously-Owned Clean Vehicles (25E)',
       es: 'Crédito para vehículos limpios de propiedad anterior (25E)',
     },
+    url: {
+      en: 'https://www.irs.gov/credits-deductions/used-clean-vehicle-credit',
+      // TODO this page's content isn't translated into Spanish, but this is
+      // the URL where it should appear when they get it translated
+      es: 'https://www.irs.gov/es/credits-deductions/used-clean-vehicle-credit',
+    },
   },
   energyEfficientHomeImprovementCredit: {
     name: {
       en: 'Federal Energy Efficient Home Improvement Credit (25C)',
       es: 'Crédito para la mejora de la eficiencia energética en el hogar (25C)',
+    },
+    url: {
+      en: 'https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit',
+      es: 'https://www.irs.gov/es/credits-deductions/energy-efficient-home-improvement-credit',
     },
   },
   homeElectrificationAndApplianceRebates: {
@@ -50,17 +68,33 @@ const ira_programs = {
       en: 'Federal Home Electrification and Appliance Rebates (HEAR)',
       es: 'Reembolsos de Electrificación y Electrodomésticos (HEAR)',
     },
+    url: {
+      // Normally, program URLs should be first-party pages, but there's no
+      // such thing for these.
+      en: 'https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates',
+      es: 'https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico',
+    },
   },
   homeEfficiencyRebates: {
     name: {
       en: 'Federal Home Efficiency Rebates (HER)',
       es: 'Reembolsos de Eficiencia en el Consumo de Energía en el Hogar (HER)',
     },
+    url: {
+      // Normally, program URLs should be first-party pages, but there's no
+      // such thing for these.
+      en: 'https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates',
+      es: 'https://www.rewiringamerica.org/app/ira-calculator/information/climatizacion',
+    },
   },
   residentialCleanEnergyCredit: {
     name: {
       en: 'Federal Residential Clean Energy Credit (25D)',
       es: 'Crédito de energía limpia residencial (25D)',
+    },
+    url: {
+      en: 'https://www.irs.gov/credits-deductions/residential-clean-energy-credit',
+      es: 'https://www.irs.gov/es/credits-deductions/residential-clean-energy-credit',
     },
   },
 } as const;

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -36,8 +36,12 @@ function transformIncentives(
         : t('urls', incentive.item, language),
     },
     program: tr(PROGRAMS[incentive.program as keyof Programs].name, language),
-    program_url: PROGRAMS[incentive.program as keyof Programs].url
-      ? tr(PROGRAMS[incentive.program as keyof Programs].url!, language)
+    program_url: tr(
+      PROGRAMS[incentive.program as keyof Programs].url,
+      language,
+    ),
+    more_info_url: incentive.more_info_url
+      ? tr(incentive.more_info_url, language)
       : undefined,
     short_description: tr(incentive.short_description, language),
   }));

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -14,6 +14,7 @@ export const API_INCENTIVE_SCHEMA = {
     'payment_methods',
     'authority_type',
     'program',
+    'program_url',
     'item',
     'amount',
     'owner_status',
@@ -38,6 +39,9 @@ export const API_INCENTIVE_SCHEMA = {
       type: 'string',
     },
     program_url: {
+      type: 'string',
+    },
+    more_info_url: {
       type: 'string',
     },
     item: {

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -29,6 +29,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -154,6 +156,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Clean Vehicle Credit (30D)",
+      "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
       "item": {
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle",
@@ -181,6 +185,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -20,6 +20,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -45,6 +47,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_panel",
         "name": "Electric Panel",
@@ -69,6 +73,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Efficiency Rebates (HER)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "efficiency_rebates",
         "name": "Efficiency Rebates",
@@ -93,6 +99,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_wiring",
         "name": "Electric Wiring",
@@ -117,6 +125,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -141,6 +151,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "weatherization",
         "name": "Weatherization",
@@ -165,6 +177,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_stove",
         "name": "Electric/Induction Stove",
@@ -190,6 +204,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer",
@@ -215,6 +231,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Residential Clean Energy Credit (25D)",
+      "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
       "item": {
         "type": "battery_storage_installation",
         "name": "Battery Storage Installation",
@@ -240,6 +258,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Residential Clean Energy Credit (25D)",
+      "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
       "item": {
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation",
@@ -265,6 +285,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Residential Clean Energy Credit (25D)",
+      "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
       "item": {
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation",
@@ -290,6 +312,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Clean Vehicle Credit (30D)",
+      "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
       "item": {
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle",
@@ -317,6 +341,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Credit for Previously-Owned Clean Vehicles (25E)",
+      "program_url": "https://www.irs.gov/credits-deductions/used-clean-vehicle-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
       "item": {
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle",
@@ -344,6 +370,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -368,6 +396,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -392,6 +422,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
       "item": {
         "type": "weatherization",
         "name": "Weatherization",
@@ -416,6 +448,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Alternative Fuel Vehicle Refueling Property Credit (30C)",
+      "program_url": "https://www.irs.gov/credits-deductions/alternative-fuel-vehicle-refueling-property-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
       "item": {
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger",
@@ -441,6 +475,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
       "item": {
         "type": "electric_panel",
         "name": "Electric Panel",

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -20,6 +20,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -45,6 +47,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Efficiency Rebates (HER)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "efficiency_rebates",
         "name": "Efficiency Rebates",
@@ -69,6 +73,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_panel",
         "name": "Electric Panel",
@@ -93,6 +99,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_wiring",
         "name": "Electric Wiring",
@@ -117,6 +125,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -141,6 +151,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "weatherization",
         "name": "Weatherization",
@@ -165,6 +177,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_stove",
         "name": "Electric/Induction Stove",
@@ -190,6 +204,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
+      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer",
@@ -215,6 +231,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Residential Clean Energy Credit (25D)",
+      "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
       "item": {
         "type": "battery_storage_installation",
         "name": "Battery Storage Installation",
@@ -240,6 +258,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Residential Clean Energy Credit (25D)",
+      "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
       "item": {
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation",
@@ -265,6 +285,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Residential Clean Energy Credit (25D)",
+      "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
       "item": {
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation",
@@ -290,6 +312,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Clean Vehicle Credit (30D)",
+      "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
       "item": {
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle",
@@ -317,6 +341,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Credit for Previously-Owned Clean Vehicles (25E)",
+      "program_url": "https://www.irs.gov/credits-deductions/used-clean-vehicle-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
       "item": {
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle",
@@ -344,6 +370,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater",
@@ -368,6 +396,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
       "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater",
@@ -392,6 +422,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
       "item": {
         "type": "weatherization",
         "name": "Weatherization",
@@ -416,6 +448,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Alternative Fuel Vehicle Refueling Property Credit (30C)",
+      "program_url": "https://www.irs.gov/credits-deductions/alternative-fuel-vehicle-refueling-property-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
       "item": {
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger",
@@ -441,6 +475,8 @@
       ],
       "authority_type": "federal",
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
       "item": {
         "type": "electric_panel",
         "name": "Electric Panel",


### PR DESCRIPTION
## Description

Putting links to our info about the IRA programs in `item.url` doesn't
make conceptual sense. This adds an optional `more_info_url` field at
the top level of incentives, and makes `program_url` required.

To make `program_url` required, I had to add program URLs to the IRA
programs in the data. There are official IRS pages for all the tax
credits, so I used those. The rebate programs don't have official
pages, so I just reused the URLs we're using as the more-info URLs on
those incentives.

https://app.asana.com/0/1206661332626418/1206843501113812

## Test Plan

`yarn test`
