### PR TITLE
Update IL Utility names to use common names after audit. 

### DIFF
--- a/data/authorities.json
+++ b/data/authorities.json
@@ -562,9 +562,6 @@
       "il-city-of-naperville": {
         "name": "City of Naperville"
       },
-      "il-city-of-peru": {
-        "name": "City of Peru"
-      },
       "il-city-of-princeton": {
         "name": "City of Princeton"
       },
@@ -625,6 +622,12 @@
       "il-norris-electric-cooperative": {
         "name": "Norris Electric Cooperative"
       },
+      "il-peru-municipal-electric-department": {
+        "name": "Peru Municipal Electric Department"
+      },
+      "il-rantoul-utilities": {
+        "name": "Rantoul Utilities"
+      },
       "il-rochelle-municipal-utilities": {
         "name": "Rochelle Municipal Utilities"
       },
@@ -654,9 +657,6 @@
       },
       "il-tri-county-electric-cooperative": {
         "name": "Tri-County Electric Cooperative"
-      },
-      "il-village-of-rantoul": {
-        "name": "Village of Rantoul"
       },
       "il-village-of-winnetka": {
         "name": "Village of Winnetka"

--- a/scripts/data/zip-to-utility.csv
+++ b/scripts/data/zip-to-utility.csv
@@ -43560,7 +43560,7 @@ zip,utility_id,predominant
 61285,il-jo-carroll-energy-cooperative,0
 61299,il-mid-american-energy,1
 61301,il-ameren-illinois,1
-61301,il-city-of-peru,0
+61301,il-peru-municipal-electric-department,0
 61301,il-corn-belt-energy,0
 61310,il-commonwealth-edison,1
 61311,il-commonwealth-edison,1
@@ -43576,7 +43576,7 @@ zip,utility_id,predominant
 61318,il-commonwealth-edison,1
 61319,il-commonwealth-edison,1
 61320,il-ameren-illinois,1
-61320,il-city-of-peru,0
+61320,il-peru-municipal-electric-department,0
 61320,il-corn-belt-energy,0
 61321,il-commonwealth-edison,1
 61322,il-ameren-illinois,1
@@ -43592,7 +43592,7 @@ zip,utility_id,predominant
 61327,il-corn-belt-energy,0
 61328,il-corn-belt-energy,1
 61329,il-ameren-illinois,1
-61329,il-city-of-peru,0
+61329,il-peru-municipal-electric-department,0
 61329,il-corn-belt-energy,0
 61330,il-ameren-illinois,1
 61330,il-commonwealth-edison,0
@@ -43627,7 +43627,7 @@ zip,utility_id,predominant
 61346,il-commonwealth-edison,0
 61346,il-corn-belt-energy,0
 61348,il-ameren-illinois,1
-61348,il-city-of-peru,0
+61348,il-peru-municipal-electric-department,0
 61348,il-commonwealth-edison,0
 61348,il-corn-belt-energy,0
 61349,il-ameren-illinois,1
@@ -43638,7 +43638,7 @@ zip,utility_id,predominant
 61350,il-corn-belt-energy,0
 61353,il-commonwealth-edison,1
 61354,il-ameren-illinois,1
-61354,il-city-of-peru,0
+61354,il-peru-municipal-electric-department,0
 61354,il-corn-belt-energy,0
 61356,il-ameren-illinois,1
 61356,il-city-of-princeton,0
@@ -44089,7 +44089,7 @@ zip,utility_id,predominant
 61865,il-eastern-illinois-electric-cooperative,0
 61866,il-ameren-illinois,1
 61866,il-eastern-illinois-electric-cooperative,0
-61866,il-village-of-rantoul,0
+61866,il-rantoul-utilities,0
 61870,il-ameren-illinois,1
 61870,il-eastern-illinois-electric-cooperative,0
 61871,il-ameren-illinois,1
@@ -44107,7 +44107,7 @@ zip,utility_id,predominant
 61877,il-eastern-illinois-electric-cooperative,0
 61878,il-ameren-illinois,1
 61878,il-eastern-illinois-electric-cooperative,0
-61878,il-village-of-rantoul,0
+61878,il-rantoul-utilities,0
 61880,il-ameren-illinois,1
 61880,il-eastern-illinois-electric-cooperative,0
 61882,il-ameren-illinois,1

--- a/scripts/generate-utility-data.ts
+++ b/scripts/generate-utility-data.ts
@@ -101,6 +101,8 @@ const OVERRIDES = new Map<string | number, string>([
   [1143, 'Pepco'], // Potomac Electric Power
 
   // IL
+  [14840, 'Peru Municipal Electric Department'],
+  [15686, 'Rantoul Utilities'],
   [4362, 'Corn Belt Energy'],
   [16420, 'Rural Electric Convenience Cooperative'],
   [56697, 'Ameren Illinois'],


### PR DESCRIPTION
Addresses, the following. 
In https://github.com/rewiringamerica/api.rewiringamerica.org/pull/368, new logic was added to generate all the utilities in authorities.json from the utility CSVs we have. This added a bunch of utilities to existing states, but these weren't audited. This ticket is to go through the utilities for IL in authorities.json and figure out:
Are any of them gas only?
Are any of them referencing the same utility (ex: in PA I had PECO and PECO Electric Corp which were referencing the same utility)
Do any of them have different customer-facing names?
How to fix these issues is documented here: https://github.com/rewiringamerica/api.rewiringamerica.org/blob/main/scripts/README.md#utility-data

Ticket: https://app.asana.com/0/1206629812394927/1206892313217560/f