### PR TITLE
Address PA QA findings and Duquesne feedback

### DIFF
--- a/data/PA/incentives.json
+++ b/data/PA/incentives.json
@@ -13,8 +13,7 @@
       "number": 1
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Free energy audit and weatherization services for income-qualified residents. Average value per household is $7,669 depending on results.",
@@ -30,14 +29,13 @@
       "assistance_program"
     ],
     "item": "weatherization",
-    "program": "pa_duquesneLightCompany_homeWeatherization",
+    "program": "pa_duquesneLightCompany_duquesneHomeWeatherization",
     "amount": {
       "type": "percent",
       "number": 1
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Free energy audit and weatherization services for income-qualified residents.",
@@ -61,11 +59,10 @@
       "maximum": 425
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "Up to $425 rebate for air source heat pumps. Rebate depends on model and efficiency.",
+      "en": "Up to $425 rebate per unit for air source heat pumps. Rebate depends on model and efficiency.",
       "es": "Reembolso de hasta $425 dólares para bombas de calor de fuente de aire. El reembolso depende del modelo y de la eficiencia."
     },
     "start_date": "2021-06-01",
@@ -85,8 +82,7 @@
       "number": 375
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$375 rebate per unit for a cold climate air source heat pump.",
@@ -110,8 +106,7 @@
       "maximum": 160
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$160 rebate per unit for a ductless mini split heat pump.",
@@ -134,8 +129,7 @@
       "number": 150
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$150 rebate per unit for an eligible cold climate ductless mini-split heat pump.",
@@ -158,8 +152,7 @@
       "number": 300
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$300 rebate per unit for ENERGY STAR® certified heat pump water heater.",
@@ -182,8 +175,7 @@
       "number": 50
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$50 rebate per ENERGY STAR® certified smart thermostat.",
@@ -206,12 +198,11 @@
       "number": 150
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$150 rebate per unit for central air conditioner.",
-      "es": "Reembolso de $150 dólares por unidad de aire acondicionado central"
+      "en": "Up to $250 rebate per unit for central air conditioner.",
+      "es": "Reembolso de hasta $250 dólares por unidad de aire acondicionado central"
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -231,8 +222,7 @@
       "maximum": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $400 rebate for home air sealing. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
@@ -256,8 +246,7 @@
       "maximum": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $400 rebate for duct insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
@@ -281,8 +270,7 @@
       "maximum": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $400 rebate for attic insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
@@ -306,8 +294,7 @@
       "maximum": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $400 rebate for basement/crawl space wall insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
@@ -331,8 +318,7 @@
       "maximum": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $400 rebate for knee wall insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
@@ -356,12 +342,11 @@
       "number": 200
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$200 rebate for ENERGY STAR certified ductless mini-split AC.",
-      "es": "Reembolso de $200 dólares para aire acondicionado mini-split sin ductos con certificación ENERGY STAR"
+      "en": "$200 rebate for ENERGY STAR® certified ductless mini-split AC.",
+      "es": "Reembolso de $200 dólares para aire acondicionado mini-split sin ductos con certificación ENERGY STAR®"
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -381,12 +366,11 @@
       "number": 200
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$200 rebate for ENERGY STAR certified ductless mini-split heat pump.",
-      "es": "Reembolso de $200 dólares para una bomba de calor sin ductos mini-split con certificación ENERGY STAR"
+      "en": "$200 rebate for ENERGY STAR® certified ductless mini-split heat pump.",
+      "es": "Reembolso de $200 dólares para una bomba de calor sin ductos mini-split con certificación ENERGY STAR®"
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -406,12 +390,11 @@
       "number": 650
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$650 rebate for ENERGY STAR® certified geothermal heat pumps.",
-      "es": "Reembolso de $650 dólares para bombas de calor geotérmicas con certificación ENERGY STAR"
+      "es": "Reembolso de $650 dólares para bombas de calor geotérmicas con certificación ENERGY STAR®"
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -431,12 +414,11 @@
       "number": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$400 rebate for ENERGY STAR certified air-to-water heat pumps.",
-      "es": "Reembolso de $400 dólares para bombas de calor de aire a agua con certificación ENERGY STAR."
+      "en": "$400 rebate for ENERGY STAR® certified air-to-water heat pumps.",
+      "es": "Reembolso de $400 dólares para bombas de calor de aire a agua con certificación ENERGY STAR®."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -457,12 +439,11 @@
       "maximum": 500
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "Up to $500 rebate for ENERGY STAR certified air source heat pumps meeting qualifications. Rebate value depends on efficiency.",
-      "es": "Reembolso de hasta $500 dólares para bombas de calor con fuente de aire y certificación ENERGY STAR que cumplan los requisitos. El monto del reembolso depende de la eficiencia."
+      "en": "Up to $500 rebate for ENERGY STAR® certified air source heat pumps meeting qualifications. Rebate value depends on efficiency.",
+      "es": "Reembolso de hasta $500 dólares para bombas de calor con fuente de aire y certificación ENERGY STAR® que cumplan los requisitos. El monto del reembolso depende de la eficiencia."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -482,12 +463,11 @@
       "number": 50
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$50 rebate for ENERGY STAR certified smart thermostats.",
-      "es": "Reembolso de $50 dólares para termostatos inteligentes con certificación ENERGY STAR."
+      "en": "$50 rebate for ENERGY STAR® certified smart thermostats.",
+      "es": "Reembolso de $50 dólares para termostatos inteligentes con certificación ENERGY STAR®."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -508,12 +488,11 @@
       "maximum": 75
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$75 rebate for ENERGY STAR certified smart thermostats for income-qualified residents.",
-      "es": "Reembolso de $75 dólares por termostatos inteligentes con certificación ENERGY STAR para residentes que cumplan  los requisitos de nivel de ingresos."
+      "en": "$75 rebate for ENERGY STAR® certified smart thermostats for income-qualified residents.",
+      "es": "Reembolso de $75 dólares por termostatos inteligentes con certificación ENERGY STAR® para residentes que cumplan  los requisitos de nivel de ingresos."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31",
@@ -534,12 +513,11 @@
       "number": 500
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$500 rebate for ENERGY STAR certified heat pump water heaters.",
-      "es": "Un reembolso de $500 para calentadores de agua con bomba de calor de certificación ENERGY STAR."
+      "en": "$500 rebate for ENERGY STAR® certified heat pump water heaters.",
+      "es": "Un reembolso de $500 para calentadores de agua con bomba de calor de certificación ENERGY STAR®."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -560,12 +538,11 @@
       "maximum": 50
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$50 rebate for ENERGY STAR certified clothes dryer.",
-      "es": "Reembolso de $50 dólares por una secadora de ropa con certificación ENERGY STAR."
+      "en": "$50 rebate for ENERGY STAR® certified clothes dryer.",
+      "es": "Reembolso de $50 dólares por una secadora de ropa con certificación ENERGY STAR®."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"
@@ -586,12 +563,11 @@
       "maximum": 75
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$75 rebate for ENERGY STAR certified clothes dryer for income-qualified residents.",
-      "es": "Reembolso de $75 dólares por una secadora de ropa con certificación ENERGY STAR para residentes que cumplan  requisitos de nivel de ingresos."
+      "en": "$75 rebate for ENERGY STAR® certified clothes dryer for income-qualified residents.",
+      "es": "Reembolso de $75 dólares por una secadora de ropa con certificación ENERGY STAR® para residentes que cumplan  requisitos de nivel de ingresos."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31",
@@ -606,14 +582,13 @@
       "assistance_program"
     ],
     "item": "weatherization",
-    "program": "pa_firstEnergy_wARMProgram",
+    "program": "pa_firstEnergy_firstEnergyWARMProgram",
     "amount": {
       "type": "percent",
       "number": 1
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Free energy audit and weatherization services for income-qualified residents.",
@@ -635,8 +610,7 @@
       "number": 350
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $350 rebate for an in-home audit for electric heating and/or central A/C.",
@@ -657,11 +631,10 @@
       "number": 300
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "Up to $300 rebate for central air conditioner. Rebate value depends on equipment efficiency.",
+      "en": "Up to $300 rebate for central air conditioner. $300 for SEER2 16.3 / EER2 12.9. $200 for SEER2 of 15.2 and EER2 of 12.",
       "es": "Un reembolso de hasta $300 dólares por aire acondicionado central. El valor del reembolso depende de la eficiencia del equipo."
     },
     "bonus_available": true
@@ -681,8 +654,7 @@
       "maximum": 1000
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Rebate for 75% of costs up to $1000 for insulation in an electric heated house. Up to $500 for attic insulation and $500 for basement wall insulation.",
@@ -705,8 +677,7 @@
       "maximum": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Rebate for 75% of costs up to $400 for insulation in non-electric heated homes with central AC. Up to $200 for attic and $200 for basement insulation.",
@@ -729,8 +700,7 @@
       "maximum": 200
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$200 rebate for air sealing. Air infiltration reduction (@ CFM50) x $0.25 up to a max of $200.",
@@ -752,8 +722,7 @@
       "number": 100
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $100 rebate for ENERGY STAR® certified smart thermostat. $50 for self-installed, $100 for professionally installed.",
@@ -774,8 +743,7 @@
       "number": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$400 rebate for heat pump water heater with UEF of 3.3.",
@@ -798,11 +766,10 @@
       "maximum": 450
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "Up to $450 rebate for air source heat pump. Rebate value depends on equipment efficiency.",
+      "en": "Up to $450 rebate for air source heat pump. $450 for SEER2 of 16.3, EER2 of 12.9, HSPF2 of 8.2. $350 for SEER2 of 15.2, EER2 of 11.7, HSPF2 of 7.8.",
       "es": "Reembolso de hasta $450 dólares por bomba de calor de fuente de aire. El monto del reembolso depende de la eficiencia del equipo."
     },
     "bonus_available": true
@@ -821,8 +788,7 @@
       "number": 400
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$400 rebate per outdoor unit for ductless mini-split heat pump with SEER2 of 15.2, EER2 of 11.7, and HSPF2 of 7.8.",
@@ -844,12 +810,11 @@
       "number": 15
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$15 rebate for ENERGY STAR certified electric clothes dryers.",
-      "es": "Reembolso de $15 dólares para secadoras de ropa eléctricas con certificación ENERGY STAR."
+      "en": "$15 rebate for ENERGY STAR® certified electric clothes dryers.",
+      "es": "Reembolso de $15 dólares para secadoras de ropa eléctricas con certificación ENERGY STAR®."
     },
     "start_date": "2024-01-01",
     "end_date": "2024-12-31"
@@ -868,8 +833,7 @@
       "number": 75
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "$75 rebate for heat pump clothes dryers.",
@@ -892,12 +856,11 @@
       "number": 350
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$350 rebate for ENERGY STAR certified heat pump hot water heaters.",
-      "es": "Reembolso de $350 dólares para calentadores de agua con bomba de calor de certificación ENERGY STAR. "
+      "en": "$350 rebate for ENERGY STAR® certified heat pump hot water heaters.",
+      "es": "Reembolso de $350 dólares para calentadores de agua con bomba de calor de certificación ENERGY STAR®. "
     },
     "start_date": "2024-01-01",
     "end_date": "2024-12-31"
@@ -916,12 +879,11 @@
       "number": 50
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
-      "en": "$50 rebate for ENERGY STAR certified smart thermostats.",
-      "es": "Reembolso de $50 dólares para termostatos inteligentes con certificación ENERGY STAR."
+      "en": "$50 rebate for ENERGY STAR® certified smart thermostats.",
+      "es": "Reembolso de $50 dólares para termostatos inteligentes con certificación ENERGY STAR®."
     },
     "start_date": "2024-01-01",
     "end_date": "2024-12-31"
@@ -941,8 +903,7 @@
       "maximum": 300
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $300 rebate for air source heat pumps. Rebate value depends on the equipment efficiency.",
@@ -966,8 +927,7 @@
       "maximum": 300
     },
     "owner_status": [
-      "homeowner",
-      "renter"
+      "homeowner"
     ],
     "short_description": {
       "en": "Up to $300 rebate for ductless mini-split heat pumps. Rebate value depends on the equipment efficiency.",

--- a/data/PA/incentives.json
+++ b/data/PA/incentives.json
@@ -195,7 +195,9 @@
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
       "type": "dollar_amount",
-      "number": 150
+      "number": 250,
+      "minimum": 200,
+      "maximum": 250
     },
     "owner_status": [
       "homeowner"

--- a/data/PA/incentives.json
+++ b/data/PA/incentives.json
@@ -935,5 +935,51 @@
     },
     "start_date": "2024-01-01",
     "end_date": "2024-12-31"
+  },
+  {
+    "id": "PA-45",
+    "authority_type": "utility",
+    "authority": "pa-duquesne-light-company",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "new_electric_vehicle",
+    "program": "pa_duquesneLightCompany_dLCEVRegistrationIncentive",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 50
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$50 rebate per new electric vehicle you own or lease. Must be either full electric or plug-in hybrid."
+    },
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31"
+  },
+  {
+    "id": "PA-46",
+    "authority_type": "utility",
+    "authority": "pa-duquesne-light-company",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "used_electric_vehicle",
+    "program": "pa_duquesneLightCompany_dLCEVRegistrationIncentive",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 50
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$50 rebate per used electric vehicle you own or lease. Must be either full electric or plug-in hybrid."
+    },
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31"
   }
 ]

--- a/src/data/programs/pa_programs.ts
+++ b/src/data/programs/pa_programs.ts
@@ -24,6 +24,14 @@ export const PA_PROGRAMS = {
       en: 'https://duquesne.clearesult.com/',
     },
   },
+  pa_duquesneLightCompany_dLCEVRegistrationIncentive: {
+    name: {
+      en: 'DLC EV Registration Incentive',
+    },
+    url: {
+      en: 'https://frontdoor.portal.poweredbyefi.org/initiative/duqpev',
+    },
+  },
   pa_firstEnergy_residentialProductsRebateProgram: {
     name: {
       en: 'Residential Products Rebate Program',

--- a/src/data/programs/pa_programs.ts
+++ b/src/data/programs/pa_programs.ts
@@ -8,12 +8,12 @@ export const PA_PROGRAMS = {
         en: 'https://dced.pa.gov/programs/weatherization-assistance-program-wap/',
       },
     },
-  pa_duquesneLightCompany_homeWeatherization: {
+  pa_duquesneLightCompany_duquesneHomeWeatherization: {
     name: {
-      en: 'Home Weatherization',
+      en: 'Duquesne Home Weatherization',
     },
     url: {
-      en: 'https://duquesnelight.com/account-billing/payment-assistance/home-weatherization',
+      en: 'https://duquesnelight.com/account-billing/payment-assistance/income-eligible-energy-assessment',
     },
   },
   pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram: {
@@ -32,9 +32,9 @@ export const PA_PROGRAMS = {
       en: 'https://rebates.energysavepa.com/',
     },
   },
-  pa_firstEnergy_wARMProgram: {
+  pa_firstEnergy_firstEnergyWARMProgram: {
     name: {
-      en: 'WARM Program',
+      en: 'First Energy WARM Program',
     },
     url: {
       en: 'https://www.firstenergycorp.com/save_energy/save_energy_pennsylvania/met_ed/for_your_home/warm-info.html',

--- a/test/fixtures/v1-pa-17555-state-lowincome.json
+++ b/test/fixtures/v1-pa-17555-state-lowincome.json
@@ -39,8 +39,7 @@
         "number": 1
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "ami_qualification": null,
       "eligible": true,
@@ -52,7 +51,7 @@
       ],
       "authority_type": "other",
       "authority": "pa-first-energy",
-      "program": "WARM Program",
+      "program": "First Energy WARM Program",
       "program_url": "https://www.firstenergycorp.com/save_energy/save_energy_pennsylvania/met_ed/for_your_home/warm-info.html",
       "item": {
         "type": "weatherization",
@@ -64,8 +63,7 @@
         "number": 1
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "ami_qualification": null,
       "eligible": true,
@@ -89,14 +87,13 @@
         "number": 500
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$500 rebate for ENERGY STAR certified heat pump water heaters."
+      "short_description": "$500 rebate for ENERGY STAR® certified heat pump water heaters."
     },
     {
       "payment_methods": [
@@ -116,14 +113,13 @@
         "maximum": 75
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$75 rebate for ENERGY STAR certified smart thermostats for income-qualified residents."
+      "short_description": "$75 rebate for ENERGY STAR® certified smart thermostats for income-qualified residents."
     },
     {
       "payment_methods": [
@@ -142,14 +138,13 @@
         "number": 50
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": false,
-      "short_description": "$50 rebate for ENERGY STAR certified smart thermostats."
+      "short_description": "$50 rebate for ENERGY STAR® certified smart thermostats."
     },
     {
       "payment_methods": [
@@ -169,8 +164,7 @@
         "number": 650
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
@@ -197,14 +191,13 @@
         "maximum": 500
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Up to $500 rebate for ENERGY STAR certified air source heat pumps meeting qualifications. Rebate value depends on efficiency."
+      "short_description": "Up to $500 rebate for ENERGY STAR® certified air source heat pumps meeting qualifications. Rebate value depends on efficiency."
     },
     {
       "payment_methods": [
@@ -224,14 +217,13 @@
         "number": 400
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$400 rebate for ENERGY STAR certified air-to-water heat pumps."
+      "short_description": "$400 rebate for ENERGY STAR® certified air-to-water heat pumps."
     },
     {
       "payment_methods": [
@@ -250,14 +242,13 @@
         "number": 200
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$200 rebate for ENERGY STAR certified ductless mini-split AC."
+      "short_description": "$200 rebate for ENERGY STAR® certified ductless mini-split AC."
     },
     {
       "payment_methods": [
@@ -277,14 +268,13 @@
         "number": 200
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$200 rebate for ENERGY STAR certified ductless mini-split heat pump."
+      "short_description": "$200 rebate for ENERGY STAR® certified ductless mini-split heat pump."
     },
     {
       "payment_methods": [
@@ -305,14 +295,13 @@
         "maximum": 75
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$75 rebate for ENERGY STAR certified clothes dryer for income-qualified residents."
+      "short_description": "$75 rebate for ENERGY STAR® certified clothes dryer for income-qualified residents."
     },
     {
       "payment_methods": [
@@ -333,14 +322,13 @@
         "maximum": 50
       },
       "owner_status": [
-        "homeowner",
-        "renter"
+        "homeowner"
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
       "ami_qualification": null,
       "eligible": false,
-      "short_description": "$50 rebate for ENERGY STAR certified clothes dryer."
+      "short_description": "$50 rebate for ENERGY STAR® certified clothes dryer."
     }
   ]
 }


### PR DESCRIPTION
Fixing QA issues that came up during the testing party today, as well as some feedback we got from our contacts at Duquesne who have been reviewing the incentives spreadsheet. 

Main changes:
- Add 2 additional EV incentives. Duquesne emailed and wanted these included. Technically 1 incentive but we need to list twice, once for new and once for used EV
- Originally I had all PA incentives listed as applies to both homeowner and renter because none of the programs specified homeowner only, so I assumed both were eligible. However Hannah brought up [this mapping](https://github.com/rewiringamerica/incentive-data-llm/blob/main/src/constants.ts#L16) that we can use, so in this PR I've updated to be consistent with that mapping
- Added ® to all references to Energy Star
- Updated a couple weatherization program names to be more specific. This was a little confusing because there's a state-wide free weatherization assistance program and a few utility ones, so I just added the authority name
- Couple other changes reported by our Duquesne point of contact in the spreadsheet, one for incentive amount for PA-9 and one for incentive link for PA-2