### PR TITLE
Add formula-based description word/char count columns.

### DIFF
--- a/scripts/export-to-google-sheets.ts
+++ b/scripts/export-to-google-sheets.ts
@@ -24,6 +24,7 @@ async function exportToGoogleSheets(state: string, file: IncentiveFile) {
     collected,
     FIELD_MAPPINGS,
     true,
+    FIELD_METADATA['short_description.en'].column_aliases[0],
   );
   if (!sheet.properties) {
     sheet.properties = {};
@@ -63,6 +64,7 @@ async function exportToGoogleSheets(state: string, file: IncentiveFile) {
   const valuesResp = await sheetsClient.spreadsheets.values.get({
     spreadsheetId: resp.data.spreadsheetId,
     range: INCENTIVE_SHEET_NAME, // Entire sheet name is a valid range.
+    valueRenderOption: 'FORMULA',
   });
   if (valuesResp.status !== 200 || !valuesResp.data) {
     throw new Error(`Spreadsheet values read failed: ${valuesResp.statusText}`);

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -54,6 +54,19 @@ test('eligible boolean fields are converted', tap => {
   tap.end();
 });
 
+test('ignored columns are removed', tap => {
+  const objs = [
+    {
+      basicProperty: 'foo',
+      ignoredProperty: 'some values we do not care about',
+    },
+  ];
+  tap.matchOnly(flatToNested(objs, [], [], ['ignoredProperty']), [
+    { basicProperty: 'foo' },
+  ]);
+  tap.end();
+});
+
 test('nested columns properly expanded', tap => {
   const objs = [
     {

--- a/test/scripts/google-sheets/incentives-sheet-exporter.test.ts
+++ b/test/scripts/google-sheets/incentives-sheet-exporter.test.ts
@@ -10,7 +10,7 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
       { bar: true, baz: 10 },
     ],
   };
-  const output = spreadsheetToGoogleSheet(input, false);
+  const output = spreadsheetToGoogleSheet(input, false, 'baz');
 
   const expected = {
     data: [
@@ -82,6 +82,40 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
                   },
                 },
               },
+              {
+                userEnteredFormat: {
+                  horizontalAlignment: 'CENTER',
+                  textFormat: { bold: true },
+                  wrapStrategy: 'WRAP',
+                  backgroundColorStyle: {
+                    rgbColor: {
+                      red: 0.9529411764705882,
+                      green: 0.9529411764705882,
+                      blue: 0.9529411764705882,
+                      alpha: 1,
+                    },
+                  },
+                },
+                userEnteredValue: {
+                  stringValue: 'Description character count',
+                },
+              },
+              {
+                userEnteredFormat: {
+                  horizontalAlignment: 'CENTER',
+                  textFormat: { bold: true },
+                  wrapStrategy: 'WRAP',
+                  backgroundColorStyle: {
+                    rgbColor: {
+                      red: 0.9529411764705882,
+                      green: 0.9529411764705882,
+                      blue: 0.9529411764705882,
+                      alpha: 1,
+                    },
+                  },
+                },
+                userEnteredValue: { stringValue: 'Description word count' },
+              },
             ],
           },
           {
@@ -136,6 +170,34 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
                   verticalAlignment: 'TOP',
                 },
               },
+              {
+                userEnteredFormat: {
+                  borders: {
+                    top: { style: 'SOLID' },
+                    bottom: { style: 'SOLID' },
+                    left: { style: 'SOLID' },
+                    right: { style: 'SOLID' },
+                  },
+                  wrapStrategy: 'WRAP',
+                  verticalAlignment: 'TOP',
+                },
+                userEnteredValue: { formulaValue: '=LEN(C2)' },
+              },
+              {
+                userEnteredFormat: {
+                  borders: {
+                    top: { style: 'SOLID' },
+                    bottom: { style: 'SOLID' },
+                    left: { style: 'SOLID' },
+                    right: { style: 'SOLID' },
+                  },
+                  wrapStrategy: 'WRAP',
+                  verticalAlignment: 'TOP',
+                },
+                userEnteredValue: {
+                  formulaValue: '=IF(C2="","",COUNTA(SPLIT(C2," ")))',
+                },
+              },
             ],
           },
           {
@@ -188,6 +250,34 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
                   },
                   wrapStrategy: 'WRAP',
                   verticalAlignment: 'TOP',
+                },
+              },
+              {
+                userEnteredFormat: {
+                  borders: {
+                    top: { style: 'SOLID' },
+                    bottom: { style: 'SOLID' },
+                    left: { style: 'SOLID' },
+                    right: { style: 'SOLID' },
+                  },
+                  wrapStrategy: 'WRAP',
+                  verticalAlignment: 'TOP',
+                },
+                userEnteredValue: { formulaValue: '=LEN(C3)' },
+              },
+              {
+                userEnteredFormat: {
+                  borders: {
+                    top: { style: 'SOLID' },
+                    bottom: { style: 'SOLID' },
+                    left: { style: 'SOLID' },
+                    right: { style: 'SOLID' },
+                  },
+                  wrapStrategy: 'WRAP',
+                  verticalAlignment: 'TOP',
+                },
+                userEnteredValue: {
+                  formulaValue: '=IF(C3="","",COUNTA(SPLIT(C3," ")))',
                 },
               },
             ],


### PR DESCRIPTION
Two related but separate changes:

1. introduce an argument to drop columns when reading them in in the flatToNested method.
2. introduce an argument to add the formula columns when writing them. They're hard-coded to the word/char count formulas, but the approach should work for other formulas if we need to add them in the future. It works because Google Sheets API has a valueRenderOption param that recognizes formulas when reading spreadsheet data.

The API is a bit awkward because it's not clear from the name `descriptionColumnName` that it would control formulas. If you prefer, we can introduce an additional boolean param called `addDescriptionFormulaColumns`, and if it's true, we require the column name as well.

Testing: unit tests, and ran on Colorado to make sure that we were dropping the columns on the way in, and adding them back on the way out. Output: https://docs.google.com/spreadsheets/d/1A18zvzRtVYiOghdRqCGBd_DWUGmrx7bgdsdItocklIw/edit#gid=0

