### PR TITLE
Add data validations and sheet protection.

### DIFF
--- a/scripts/export-to-google-sheets.ts
+++ b/scripts/export-to-google-sheets.ts
@@ -25,6 +25,7 @@ async function exportToGoogleSheets(state: string, file: IncentiveFile) {
     FIELD_MAPPINGS,
     true,
     FIELD_METADATA['short_description.en'].column_aliases[0],
+    Object.values(FIELD_METADATA),
   );
   if (!sheet.properties) {
     sheet.properties = {};

--- a/scripts/lib/google-sheets/standardized-enums.ts
+++ b/scripts/lib/google-sheets/standardized-enums.ts
@@ -137,6 +137,18 @@ export function generateStandardEnumsSheet(metadata: {
     ],
     properties: {
       title: 'Standardized Enum List Values',
+      sheetId: 1,
     },
+    protectedRanges: [
+      {
+        range: {
+          sheetId: 1,
+        },
+        requestingUserCanEdit: true,
+        // We discourage changes, but want to enable data collectors to make
+        // them when there need to be changes to our schema.
+        warningOnly: true,
+      },
+    ],
   };
 }

--- a/test/scripts/google-sheets/incentives-sheet-exporter.test.ts
+++ b/test/scripts/google-sheets/incentives-sheet-exporter.test.ts
@@ -10,7 +10,16 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
       { bar: true, baz: 10 },
     ],
   };
-  const output = spreadsheetToGoogleSheet(input, false, 'baz');
+  const output = spreadsheetToGoogleSheet(input, false, 'baz', [
+    {
+      column_aliases: ['bar'],
+      description: 'A property',
+      values: {
+        valA: { value_aliases: ['unused'] },
+        valB: { value_aliases: ['unused'] },
+      },
+    },
+  ]);
 
   const expected = {
     data: [
@@ -144,6 +153,19 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
                   wrapStrategy: 'WRAP',
                   verticalAlignment: 'TOP',
                 },
+                dataValidation: {
+                  strict: true,
+                  showCustomUi: true,
+                  condition: {
+                    type: 'ONE_OF_RANGE',
+                    values: [
+                      {
+                        userEnteredValue:
+                          "='Standardized Enum List Values'!$A$2:$A$3",
+                      },
+                    ],
+                  },
+                },
               },
               {
                 userEnteredFormat: {
@@ -226,6 +248,19 @@ test('Spreadsheet format converts to Google sheet without standard header', tap 
                   verticalAlignment: 'TOP',
                 },
                 userEnteredValue: { boolValue: true },
+                dataValidation: {
+                  strict: true,
+                  showCustomUi: true,
+                  condition: {
+                    type: 'ONE_OF_RANGE',
+                    values: [
+                      {
+                        userEnteredValue:
+                          "='Standardized Enum List Values'!$A$2:$A$3",
+                      },
+                    ],
+                  },
+                },
               },
               {
                 userEnteredFormat: {

--- a/test/scripts/google-sheets/standardized-enums.test.ts
+++ b/test/scripts/google-sheets/standardized-enums.test.ts
@@ -258,7 +258,16 @@ test('Creates correct standardized enums sheet', tap => {
         ],
       },
     ],
-    properties: { title: 'Standardized Enum List Values' },
+    properties: { title: 'Standardized Enum List Values', sheetId: 1 },
+    protectedRanges: [
+      {
+        range: {
+          sheetId: 1,
+        },
+        requestingUserCanEdit: true,
+        warningOnly: true,
+      },
+    ],
   };
 
   tap.strictSame(output, expected);


### PR DESCRIPTION
[Sample output](https://docs.google.com/spreadsheets/d/1lS5htTOE2Nji9Nqy_6HzA50dZuPEYukb_G1tUXe63ys/edit#gid=0)

Notable diff from current approach: I currently have it so that users can edit the protected sheet; it just shows a warning. In my experience, the sheet protection has been more trouble than it's worth - see Slack for lots of examples of people needing sheets unlocked. I think we want the validations to discourage changes but ultimately allow people to make changes if they think the schema needs to be updated.

It's an easy change to switch to actual protection if you prefer, in which case I would make engineering-team@rewiringamerica.org editors.

Not in this PR
- there are other protected ranges in our templates like the example data row or the IDs column, but I think they are also unnecessary, so I'm not inclined to implement them. It's pretty easy to add them, especially since they're hardcoded (row 3 and column 1)