### PR TITLE
Remove item.url from v1

### DIFF
--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -31,9 +31,6 @@ function transformIncentives(
     item: {
       type: incentive.item,
       name: t('items', incentive.item, language),
-      url: incentive.more_info_url
-        ? tr(incentive.more_info_url, language)
-        : t('urls', incentive.item, language),
     },
     program: tr(PROGRAMS[incentive.program as keyof Programs].name, language),
     program_url: tr(

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -54,9 +54,6 @@ export const API_INCENTIVE_SCHEMA = {
         name: {
           type: 'string',
         },
-        url: {
-          type: 'string',
-        },
       },
       required: ['type'],
       additionalProperties: false,

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://dceo.illinois.gov/communityservices/homeweatherization/howtoapply.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -33,8 +33,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -60,8 +59,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -84,8 +82,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -110,8 +107,7 @@
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -135,8 +131,7 @@
       "program_url": "https://drive.ri.gov/ev-programs/drive-plus",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -160,8 +155,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -189,8 +183,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -47,8 +47,7 @@
       "program_url": "https://dhs.ri.gov/programs-and-services/energy-assistance-programs/weatherization-assistance-program-wap",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -72,8 +71,7 @@
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -96,8 +94,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -120,8 +117,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "percent",
@@ -195,8 +191,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -221,8 +216,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -247,8 +241,7 @@
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -275,8 +268,7 @@
       "program_url": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf",
       "item": {
         "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+        "name": "Rooftop Solar Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -302,8 +294,7 @@
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -327,8 +318,7 @@
       "program_url": "https://drive.ri.gov/ev-programs/drive-plus",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -352,8 +342,7 @@
       "program_url": "https://drive.ri.gov/ev-programs/drive-plus",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -377,8 +366,7 @@
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -402,8 +390,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -426,8 +413,7 @@
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -453,8 +439,7 @@
       "program_url": "https://cleanheatri.com/",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -24,8 +24,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -51,8 +50,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "dollar_amount",
@@ -77,8 +75,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "efficiency_rebates",
-        "name": "Efficiency Rebates",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates"
+        "name": "Efficiency Rebates"
       },
       "amount": {
         "type": "dollar_amount",
@@ -103,8 +100,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_wiring",
-        "name": "Electric Wiring",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Electric Wiring"
       },
       "amount": {
         "type": "dollar_amount",
@@ -129,8 +125,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -155,8 +150,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -181,8 +175,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_stove",
-        "name": "Electric/Induction Stove",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Electric/Induction Stove"
       },
       "amount": {
         "type": "dollar_amount",
@@ -208,8 +201,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -235,8 +227,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
       "item": {
         "type": "battery_storage_installation",
-        "name": "Battery Storage Installation",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit"
+        "name": "Battery Storage Installation"
       },
       "amount": {
         "type": "percent",
@@ -262,8 +253,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "percent",
@@ -289,8 +279,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
       "item": {
         "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit"
+        "name": "Rooftop Solar Installation"
       },
       "amount": {
         "type": "percent",
@@ -316,8 +305,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -345,8 +333,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -374,8 +361,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -400,8 +386,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -426,8 +411,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -452,8 +436,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
       "item": {
         "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit"
+        "name": "Electric Vehicle Charger"
       },
       "amount": {
         "type": "dollar_amount",
@@ -479,8 +462,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-80212-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-80212-homeowner-80000-joint-4.json
@@ -24,8 +24,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -51,8 +50,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "efficiency_rebates",
-        "name": "Efficiency Rebates",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates"
+        "name": "Efficiency Rebates"
       },
       "amount": {
         "type": "dollar_amount",
@@ -77,8 +75,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "dollar_amount",
@@ -103,8 +100,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_wiring",
-        "name": "Electric Wiring",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Electric Wiring"
       },
       "amount": {
         "type": "dollar_amount",
@@ -129,8 +125,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -155,8 +150,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -181,8 +175,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "electric_stove",
-        "name": "Electric/Induction Stove",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Electric/Induction Stove"
       },
       "amount": {
         "type": "dollar_amount",
@@ -208,8 +201,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -235,8 +227,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
       "item": {
         "type": "battery_storage_installation",
-        "name": "Battery Storage Installation",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit"
+        "name": "Battery Storage Installation"
       },
       "amount": {
         "type": "percent",
@@ -262,8 +253,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "percent",
@@ -289,8 +279,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
       "item": {
         "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit"
+        "name": "Rooftop Solar Installation"
       },
       "amount": {
         "type": "percent",
@@ -316,8 +305,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -345,8 +333,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -374,8 +361,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -400,8 +386,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -426,8 +411,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -452,8 +436,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
       "item": {
         "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit"
+        "name": "Electric Vehicle Charger"
       },
       "amount": {
         "type": "dollar_amount",
@@ -479,8 +462,7 @@
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -31,8 +31,7 @@
       "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -56,8 +55,7 @@
       "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -81,8 +79,7 @@
       "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -106,8 +103,7 @@
       "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://www.tep.com/weatherization-assistance/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -52,8 +51,7 @@
       "program_url": "https://www.tep.com/efficient-home-water-heating/",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://www.uesaz.com/weatherization-assistance/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -52,8 +51,7 @@
       "program_url": "https://www.uesaz.com/efficient-home-program/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -76,8 +74,7 @@
       "program_url": "https://www.uesaz.com/efficient-home-program/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -41,8 +41,7 @@
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -67,8 +66,7 @@
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -92,8 +90,7 @@
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -117,8 +114,7 @@
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -142,8 +138,7 @@
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -166,8 +161,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -190,8 +184,7 @@
       "program_url": "https://socgov02.my.site.com/ceoweatherization/s/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -215,8 +208,7 @@
       "program_url": "https://energyoffice.colorado.gov/vehicle-exchange-colorado",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -240,8 +232,7 @@
       "program_url": "https://energyoffice.colorado.gov/vehicle-exchange-colorado",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -265,8 +256,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -290,8 +280,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -315,8 +304,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -340,8 +328,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -365,8 +352,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -390,8 +376,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "percent",
@@ -415,8 +400,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "percent",
@@ -440,8 +424,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "percent",
@@ -465,8 +448,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "percent",
@@ -514,8 +496,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_stove",
-        "name": "Electric/Induction Stove",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove"
+        "name": "Electric/Induction Stove"
       },
       "amount": {
         "type": "percent",
@@ -539,8 +520,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -564,8 +544,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -589,8 +568,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -614,8 +592,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -639,8 +616,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -664,8 +640,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "percent",
@@ -689,8 +664,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "percent",
@@ -714,8 +688,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "percent",
@@ -739,8 +712,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "percent",
@@ -788,8 +760,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_stove",
-        "name": "Electric/Induction Stove",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove"
+        "name": "Electric/Induction Stove"
       },
       "amount": {
         "type": "percent",
@@ -813,8 +784,7 @@
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+        "name": "Rooftop Solar Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -864,8 +834,7 @@
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
       "item": {
         "type": "battery_storage_installation",
-        "name": "Battery Storage Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/battery-storage-installation"
+        "name": "Battery Storage Installation"
       },
       "amount": {
         "type": "percent",
@@ -890,8 +859,7 @@
       "program_url": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -916,8 +884,7 @@
       "program_url": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -31,8 +31,7 @@
       "program_url": "https://energizect.com/energy-evaluations/income-eligible-options",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -57,8 +56,7 @@
       "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -82,8 +80,7 @@
       "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -107,8 +104,7 @@
       "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -132,8 +128,7 @@
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -160,8 +155,7 @@
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -188,8 +182,7 @@
       "program_url": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -214,8 +207,7 @@
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollar_amount",
@@ -240,8 +232,7 @@
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -42,8 +42,7 @@
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -69,8 +68,7 @@
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
       "item": {
         "type": "electric_stove",
-        "name": "Electric/Induction Stove",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-stove-induction-stove"
+        "name": "Electric/Induction Stove"
       },
       "amount": {
         "type": "percent",
@@ -96,8 +94,7 @@
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "percent",
@@ -123,8 +120,7 @@
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
       "item": {
         "type": "electric_panel",
-        "name": "Electric Panel",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel"
+        "name": "Electric Panel"
       },
       "amount": {
         "type": "percent",
@@ -150,8 +146,7 @@
       "program_url": "https://doee.dc.gov/service/wap",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -177,8 +172,7 @@
       "program_url": "https://www.dcseu.com/solar-for-all",
       "item": {
         "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+        "name": "Rooftop Solar Installation"
       },
       "amount": {
         "type": "percent",
@@ -204,8 +198,7 @@
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -257,8 +250,7 @@
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -28,8 +28,7 @@
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -55,8 +54,7 @@
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -82,8 +80,7 @@
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -135,8 +132,7 @@
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "percent",
@@ -162,8 +158,7 @@
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "percent",
@@ -189,8 +184,7 @@
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "item": {
         "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger"
+        "name": "Electric Vehicle Charger"
       },
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/electric-vehicle-rebate.html",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -54,8 +53,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -78,8 +76,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -103,8 +100,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollar_amount",
@@ -127,8 +123,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/home-ev-charger-rebate.html",
       "item": {
         "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger"
+        "name": "Electric Vehicle Charger"
       },
       "amount": {
         "type": "dollar_amount",
@@ -152,8 +147,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/washers-dryers.html#tabs-f1a15f985f-item-83a9b1fa23",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -178,8 +172,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -202,8 +195,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -249,8 +241,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -273,8 +264,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -297,8 +287,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -321,8 +310,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -345,8 +333,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -369,8 +356,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -393,8 +379,7 @@
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -37,8 +37,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/qualified-appliance-replacement",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "percent",
@@ -86,8 +85,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -135,8 +133,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -159,8 +156,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -208,8 +204,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -232,8 +227,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -256,8 +250,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -281,8 +274,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -306,8 +298,7 @@
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -34,8 +34,7 @@
       "program_url": "https://homeenergy.pseg.com",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -59,8 +58,7 @@
       "program_url": "https://www.nyserda.ny.gov/All-Programs/Drive-Clean-Rebate-For-Electric-Cars-Program/How-it-Works",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -86,8 +84,7 @@
       "program_url": "https://homeenergy.pseg.com",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -110,8 +107,7 @@
       "program_url": "https://homeenergy.pseg.com",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -135,8 +131,7 @@
       "program_url": "https://homeenergy.pseg.com",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -159,8 +154,7 @@
       "program_url": "https://homeenergy.pseg.com",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -183,8 +177,7 @@
       "program_url": "https://homeenergy.pseg.com",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -207,8 +200,7 @@
       "program_url": "https://www.nyserda.ny.gov/All-Programs/Comfort-Home-Program",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -232,8 +224,7 @@
       "program_url": "https://www.tax.ny.gov/pit/credits/geothermal-energy-system-credit.htm",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-or-97001-state-lowincome.json
+++ b/test/fixtures/v1-or-97001-state-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -99,8 +98,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -124,8 +122,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -149,8 +146,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -174,8 +170,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -199,8 +194,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -224,8 +218,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -249,8 +242,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -274,8 +266,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -299,8 +290,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -324,8 +314,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -349,8 +338,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -374,8 +362,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -399,8 +386,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -424,8 +410,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -449,8 +434,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -474,8 +458,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -499,8 +482,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -524,8 +506,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -549,8 +530,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -574,8 +554,7 @@
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-pa-17555-state-lowincome.json
+++ b/test/fixtures/v1-pa-17555-state-lowincome.json
@@ -31,8 +31,7 @@
       "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -55,8 +54,7 @@
       "program_url": "https://www.firstenergycorp.com/save_energy/save_energy_pennsylvania/met_ed/for_your_home/warm-info.html",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -79,8 +77,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -156,8 +153,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollar_amount",
@@ -182,8 +178,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -209,8 +204,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -260,8 +254,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -286,8 +279,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -313,8 +305,7 @@
       "program_url": "https://rebates.energysavepa.com/",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/income-and-age-qualifying-home-improvements",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -52,8 +51,7 @@
       "program_url": "https://cdn-dominionenergy-prd-001.azureedge.net/-/media/pdfs/virginia/save-energy/residential-water-energy--savings-program-measures.pdf",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -78,8 +76,7 @@
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/ev-charger-rewards",
       "item": {
         "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger"
+        "name": "Electric Vehicle Charger"
       },
       "amount": {
         "type": "dollar_amount",
@@ -102,8 +99,7 @@
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/energy-star-products",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -43,8 +43,7 @@
       "program_url": "https://dcf.vermont.gov/benefits/weatherization",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -67,8 +66,7 @@
       "program_url": "https://www.driveelectricvt.com/incentives/vermont-state-incentives#mileagesmart",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "percent",
@@ -93,8 +91,7 @@
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/ryr/vermont-replace-your-ride-program-guidelines.pdf?refresh",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -122,8 +119,7 @@
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/ryr/vermont-replace-your-ride-program-guidelines.pdf?refresh",
       "item": {
         "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "Used Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -150,8 +146,7 @@
       "program_url": "https://www.driveelectricvt.com/incentives/vermont-state-incentives#new",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -178,8 +173,7 @@
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/ryr/vermont-replace-your-ride-program-guidelines.pdf?refresh",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -209,8 +203,7 @@
       "program_url": "https://www.driveelectricvt.com/incentives/vermont-state-incentives#new",
       "item": {
         "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/electric-vehicles"
+        "name": "New Electric Vehicle"
       },
       "amount": {
         "type": "dollar_amount",
@@ -238,8 +231,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -264,8 +256,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -291,8 +282,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -317,8 +307,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/clothes-dryers",
       "item": {
         "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-clothes-dryer"
+        "name": "Heat Pump Clothes Dryer"
       },
       "amount": {
         "type": "dollar_amount",
@@ -343,8 +332,7 @@
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -370,8 +358,7 @@
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "percent",
@@ -397,8 +384,7 @@
       "program_url": "https://www.burlingtonelectric.com/evchargers#",
       "item": {
         "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/ev-charger"
+        "name": "Electric Vehicle Charger"
       },
       "amount": {
         "type": "percent",
@@ -423,8 +409,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -449,8 +434,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "percent",
@@ -475,8 +459,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/ground-source-heat-pumps",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -502,8 +485,7 @@
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -530,8 +512,7 @@
       "program_url": "https://www.burlingtonelectric.com/gshp",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -556,8 +537,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollars_per_unit",
@@ -583,8 +563,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -608,8 +587,7 @@
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -635,8 +613,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollar_amount",
@@ -661,8 +638,7 @@
       "program_url": "https://www.burlingtonelectric.com/waterheaters",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -688,8 +664,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -715,8 +690,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -742,8 +716,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -769,8 +742,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -794,8 +766,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -819,8 +790,7 @@
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-bonus-verification.pdf",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -845,8 +815,7 @@
       "program_url": "https://www.efficiencyvermont.com/rebates/list/diy-weatherization",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -28,8 +28,7 @@
       "program_url": "https://focusonenergy.com/residential/water-heating",
       "item": {
         "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-water-heater"
+        "name": "Heat Pump Water Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -52,8 +51,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -78,8 +76,7 @@
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -104,8 +101,7 @@
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
       "item": {
         "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/geothermal-heating-installation"
+        "name": "Geothermal Heating Installation"
       },
       "amount": {
         "type": "dollar_amount",
@@ -131,8 +127,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -157,8 +152,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -183,8 +177,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -209,8 +202,7 @@
       "program_url": "https://focusonenergy.com/residential/solar-for-homes",
       "item": {
         "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/rooftop-solar-installation"
+        "name": "Rooftop Solar Installation"
       },
       "amount": {
         "type": "dollar_amount",
@@ -236,8 +228,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -262,8 +253,7 @@
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/heat-pump-air-conditioner-heater"
+        "name": "Heat Pump Air Conditioner/Heater"
       },
       "amount": {
         "type": "dollar_amount",
@@ -288,8 +278,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -314,8 +303,7 @@
       "program_url": "https://focusonenergy.com/residential/diy",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -340,8 +328,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -366,8 +353,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",
@@ -392,8 +378,7 @@
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "item": {
         "type": "weatherization",
-        "name": "Weatherization",
-        "url": "https://www.rewiringamerica.org/app/ira-calculator/information/weatherization"
+        "name": "Weatherization"
       },
       "amount": {
         "type": "dollar_amount",


### PR DESCRIPTION
## Description

This is no longer used by the frontend, and the URLs now get
redirected to incentive-centered pages; I think the whole concept of a
URL for an item is dead.

v0 still uses the URLs, in the `more_info_url` field, so we can't
delete them. We can't even change them to the incentive-centric
`homes.rewiring` URLs, because these URLs are relative, and the host
is assumed to be `www`. So we'll be stuck with this until v0 can be deleted.

## Test Plan

`yarn test`. Make sure the embed frontend does not use this field.
