### PR TITLE
add additional DC partner credits

### DIFF
--- a/data/data_partners.json
+++ b/data/data_partners.json
@@ -17,6 +17,22 @@
         "width": 300,
         "height": 200
       }
+    },
+    "dc-mayor": {
+      "name": "Government of the District of Columbia, Muriel Bowser, Mayor",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-mayor.png",
+        "width": 473,
+        "height": 100
+      }
+    },
+    "dc-doee": {
+      "name": "Department of Energy & Environment",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-doee.png",
+        "width": 343,
+        "height": 100
+      }
     }
   },
   "IA": {

--- a/data/data_partners.json
+++ b/data/data_partners.json
@@ -33,6 +33,14 @@
         "width": 343,
         "height": 100
       }
+    },
+    "dc-seu": {
+      "name": "DC Sustainable Energy Utility",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-seu.png",
+        "width": 332,
+        "height": 100
+      }
     }
   },
   "IA": {

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -29,6 +29,30 @@
         "width": 300,
         "height": 200
       }
+    },
+    "dc-mayor": {
+      "name": "Government of the District of Columbia, Muriel Bowser, Mayor",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-mayor.png",
+        "width": 473,
+        "height": 100
+      }
+    },
+    "dc-doee": {
+      "name": "Department of Energy & Environment",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-doee.png",
+        "width": 343,
+        "height": 100
+      }
+    },
+    "dc-seu": {
+      "name": "DC Sustainable Energy Utility",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/dc-seu.png",
+        "width": 332,
+        "height": 100
+      }
     }
   },
   "incentives": [


### PR DESCRIPTION
Linking images to confirm they are uploaded correctly:

https://storage.googleapis.com/rewiring-america-incentives-assets/dc-mayor.png
https://storage.googleapis.com/rewiring-america-incentives-assets/dc-doee.png
https://storage.googleapis.com/rewiring-america-incentives-assets/dc-seu.png

I resized to 100 height, which is consistent with the authority logos but smaller than the other partner logos. Feedback/correction welcome!