### PR TITLE
Release PA incentives

### DIFF
--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -154,11 +154,9 @@ curl \
 &include_beta_states=true" \
   | jq . > test/fixtures/v1-ny-11557-state-utility-lowincome.json
 
-# TODO: Remove beta states argument when PA is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator?\
 zip=17555\
-&include_beta_states=true\
 &owner_status=homeowner\
 &household_income=20000\
 &tax_filing=joint\

--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -62,13 +62,13 @@ export const BETA_STATES: string[] = [
   'NV',
   'NY',
   'OR',
-  'PA',
   'VT',
   'WI',
 ];
 
 export const LAUNCHED_STATES: string[] = [
   'DC',
+  'PA',
   'RI',
   'VA',
 ];

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -3,8 +3,11 @@
   "is_under_150_ami": true,
   "is_over_150_ami": false,
   "authorities": {
-    "pa-department-of-community-and-economic-development": {
-      "name": "Department of Community and Economic Development"
+    "pa-pennsylvania-department-of-environmental-protection": {
+      "name": "Pennsylvania Department of Environmental Protection"
+    },
+    "pa-pennsylvania-department-of-community-and-economic-development": {
+      "name": "Pennsylvania Department of Community and Economic Development"
     }
   },
   "coverage": {
@@ -23,7 +26,7 @@
         "assistance_program"
       ],
       "authority_type": "state",
-      "authority": "pa-department-of-community-and-economic-development",
+      "authority": "pa-pennsylvania-department-of-community-and-economic-development",
       "program": "Pennsylvania Weatherization Assistance Program",
       "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
       "item": {
@@ -243,6 +246,114 @@
       "ami_qualification": "less_than_150_ami",
       "eligible": true,
       "short_description": "Rebate up to $840 for heat pump dryers. Low-income households: 100% rebate, Moderate-income: 50% rebate."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "pa-pennsylvania-department-of-environmental-protection",
+      "program": "Alternative Fuel Vehicle Rebates",
+      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 3000,
+        "maximum": 3000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-07-01",
+      "end_date": "2024-06-30",
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "Income-qualified rebate for purchase or lease of new electric vehicles. $3,000 for battery EVs; $2,500 for plug-in hybrid EVs."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "pa-pennsylvania-department-of-environmental-protection",
+      "program": "Alternative Fuel Vehicle Rebates",
+      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
+      "item": {
+        "type": "used_electric_vehicle",
+        "name": "Used Electric Vehicle"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 3000,
+        "maximum": 3000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-07-01",
+      "end_date": "2024-06-30",
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "Income-qualified rebate for purchase of eligible used electric vehicles. $3,000 rebate for battery EVs; $2,500 rebate for plug-in hybrid EVs."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "pa-pennsylvania-department-of-environmental-protection",
+      "program": "Alternative Fuel Vehicle Rebates",
+      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
+      "item": {
+        "type": "new_electric_vehicle",
+        "name": "New Electric Vehicle"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000,
+        "maximum": 2000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-07-01",
+      "end_date": "2024-06-30",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "Income-qualified rebate for purchase or lease of new electric vehicles. $2,000 for battery EVs; $1,500 for plug-in hybrid EVs."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "pa-pennsylvania-department-of-environmental-protection",
+      "program": "Alternative Fuel Vehicle Rebates",
+      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
+      "item": {
+        "type": "used_electric_vehicle",
+        "name": "Used Electric Vehicle"
+      },
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000,
+        "maximum": 2000
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-07-01",
+      "end_date": "2024-06-30",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "Income-qualified rebate for purchase of eligible used electric vehicles. $2,000 rebate for battery EVs; $1,500 rebate for plug-in hybrid EVs."
     },
     {
       "payment_methods": [

--- a/test/fixtures/v1-15289-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-80000-joint-4.json
@@ -2,9 +2,13 @@
   "is_under_80_ami": false,
   "is_under_150_ami": true,
   "is_over_150_ami": false,
-  "authorities": {},
+  "authorities": {
+    "pa-department-of-community-and-economic-development": {
+      "name": "Department of Community and Economic Development"
+    }
+  },
   "coverage": {
-    "state": null,
+    "state": "PA",
     "utility": null
   },
   "location": {
@@ -14,6 +18,29 @@
   },
   "data_partners": {},
   "incentives": [
+    {
+      "payment_methods": [
+        "assistance_program"
+      ],
+      "authority_type": "state",
+      "authority": "pa-department-of-community-and-economic-development",
+      "program": "Pennsylvania Weatherization Assistance Program",
+      "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
+      "item": {
+        "type": "weatherization",
+        "name": "Weatherization"
+      },
+      "amount": {
+        "type": "percent",
+        "number": 1
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "Free energy audit and weatherization services for income-qualified residents. Average value per household is $7,669 depending on results."
+    },
     {
       "payment_methods": [
         "pos_rebate"

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -371,8 +371,6 @@ test('PA low income response with state and utility filtering is valid and corre
       tax_filing: 'joint',
       authority_types: ['state', 'utility', 'other'],
       utility: 'pa-met-ed',
-      // TODO: Remove when PA is fully launched.
-      include_beta_states: true,
     },
     './test/fixtures/v1-pa-17555-state-lowincome.json',
   );


### PR DESCRIPTION
Launch 🎉 Moving forward this because:
- We're doing an event in PA on 4/22 and this needs to be ready by then
- PA utilities have started working on integrating the embed into their sites, and to avoid using the `beta_states` flag these need to be live