### PR TITLE
[WAIT TO MERGE] Launch Colorado

### DIFF
--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -5236,7 +5236,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "non_heat_pump_clothes_dryer",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5259,7 +5259,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_clothes_dryer",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5282,7 +5282,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_water_heater",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5305,7 +5305,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5330,7 +5330,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5355,7 +5355,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "ebike",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5380,7 +5380,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5405,7 +5405,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5430,7 +5430,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5455,7 +5455,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "smart_thermostat",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5480,7 +5480,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "evaporative_cooler",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5503,7 +5503,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "whole_house_fan",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5526,7 +5526,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "battery_storage_installation",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5550,7 +5550,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "battery_storage_installation",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5574,7 +5574,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "weatherization",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5598,7 +5598,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "weatherization",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5622,7 +5622,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "weatherization",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5646,7 +5646,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5670,7 +5670,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5694,7 +5694,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "new_electric_vehicle",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5718,7 +5718,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "used_electric_vehicle",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5742,7 +5742,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_vehicle_charger",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5766,7 +5766,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_vehicle_charger",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5790,7 +5790,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_vehicle_charger",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5814,7 +5814,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_vehicle_charger",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5838,7 +5838,7 @@
     "authority_type": "utility",
     "authority": "co-san-isabel-electric",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "geothermal_heating_installation",
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -6422,7 +6422,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "evaporative_cooler",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6443,7 +6443,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "whole_house_fan",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6464,7 +6464,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "smart_thermostat",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6487,7 +6487,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "battery_storage_installation",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6509,7 +6509,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "battery_storage_installation",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6531,7 +6531,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6553,7 +6553,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6575,7 +6575,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6597,7 +6597,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "battery_storage_installation",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6618,7 +6618,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6640,7 +6640,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "geothermal_heating_installation",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6662,7 +6662,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "geothermal_heating_installation",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6685,7 +6685,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_water_heater",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6706,7 +6706,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "heat_pump_clothes_dryer",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6727,7 +6727,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6750,7 +6750,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6774,7 +6774,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6797,7 +6797,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6820,7 +6820,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6843,7 +6843,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_outdoor_equipment",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
@@ -6866,7 +6866,7 @@
     "authority_type": "utility",
     "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
-      "unknown"
+      "rebate"
     ],
     "item": "electric_vehicle_charger",
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -14,12 +14,12 @@ curl \
 
 curl \
   "http://localhost:3000/api/v1/calculator\
-?zip=80212\
+?zip=84106\
 &owner_status=homeowner\
 &household_income=80000\
 &tax_filing=joint\
 &household_size=4" \
-  | jq . > test/fixtures/v1-80212-homeowner-80000-joint-4.json
+  | jq . > test/fixtures/v1-84106-homeowner-80000-joint-4.json
 
 curl \
   "http://localhost:3000/api/v1/calculator\
@@ -198,7 +198,6 @@ curl \
 curl \
   "http://localhost:3000/api/v1/calculator\
 ?zip=81657\
-&include_beta_states=true\
 &owner_status=homeowner\
 &household_income=100000\
 &tax_filing=joint\
@@ -234,7 +233,6 @@ curl \
 curl \
   "http://localhost:3000/api/v1/calculator\
 ?zip=80517\
-&include_beta_states=true\
 &owner_status=homeowner\
 &household_income=80000\
 &tax_filing=single\
@@ -249,7 +247,6 @@ curl \
 curl \
   "http://localhost:3000/api/v1/calculator\
 ?zip=80517\
-&include_beta_states=true\
 &owner_status=homeowner\
 &household_income=80000\
 &tax_filing=single\

--- a/src/data/programs/co_programs.ts
+++ b/src/data/programs/co_programs.ts
@@ -1,7 +1,7 @@
 export const CO_PROGRAMS = {
   co_blackHillsEnergy_coloradoElectricResidentialRebates: {
     name: {
-      en: 'Colorado Electric Residential Rebates',
+      en: 'Black Hills Energy Residential Rebate Program',
     },
     url: {
       en: 'https://www.blackhillsenergy.com/efficiency-and-savings/residential-rebates/colorado-electric-residential-rebates',
@@ -9,7 +9,7 @@ export const CO_PROGRAMS = {
   },
   co_blackHillsEnergy_electrificationPilotProgram: {
     name: {
-      en: 'Electrification Pilot Program',
+      en: 'Black Hills Energy Electrification Pilot Program',
     },
     url: {
       en: 'https://www.blackhillsenergy.com/efficiency-and-savings/residential-rebates/colorado-electric-residential-rebates',
@@ -17,7 +17,7 @@ export const CO_PROGRAMS = {
   },
   co_blackHillsEnergy_readyEVProgram: {
     name: {
-      en: 'Ready EV Program',
+      en: 'Black Hills Energy Electric Vehicle Rebate Program',
     },
     url: {
       en: 'https://www.blackhillsenergy.com/efficiency-and-savings/residential-rebates/colorado-electric-residential-rebates',
@@ -25,7 +25,7 @@ export const CO_PROGRAMS = {
   },
   co_coloradoSpringsUtilities_residentialEfficiencyRebateProgram: {
     name: {
-      en: 'Residential Efficiency Rebate Program',
+      en: 'Colorado Springs Utilities Residential Rebates & Incentives',
     },
     url: {
       en: 'https://www.csu.org/Pages/ResidentialRebates.aspx',
@@ -59,7 +59,7 @@ export const CO_PROGRAMS = {
   },
   co_fortCollinsUtilities_solarRebates: {
     name: {
-      en: 'Solar Rebates',
+      en: 'Fort Collins Utilities Solar Rebates',
     },
     url: {
       en: 'https://www.fcgov.com/utilities/residential/renewables/solar-rebates',
@@ -67,7 +67,7 @@ export const CO_PROGRAMS = {
   },
   'co_fortCollinsUtilities_solarRebates-ResidentialBatteryStorageProgram': {
     name: {
-      en: 'Solar Rebates-Residential Battery Storage Program',
+      en: 'Fort Collins Utilities Residential Battery Storage Program',
     },
     url: {
       en: 'https://www.fcgov.com/utilities/residential-battery-storage-program',
@@ -107,15 +107,15 @@ export const CO_PROGRAMS = {
   },
   co_empireElectricAssociation_energyEfficiencyProductsProgram: {
     name: {
-      en: 'Energy Efficiency Products Program',
+      en: 'Empire Electric Association Residential Energy Efficiency Program',
     },
     url: {
-      en: 'https://www.eea.coop/energy-efficiency-products-program',
+      en: 'https://www.eea.coop/residential-energy-efficiency-program',
     },
   },
   co_energyOutreachColorado_weatherizationAssistanceProgram: {
     name: {
-      en: 'Weatherization Assistance Program',
+      en: 'Energy Outreach Colorado Weatherization Assistance Program',
     },
     url: {
       en: 'https://socgov02.my.site.com/ceoweatherization/s/',
@@ -123,7 +123,7 @@ export const CO_PROGRAMS = {
   },
   co_gunnisonCountyElectricAssociation_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'Gunnison County Electric Association Rebates',
     },
     url: {
       en: 'https://www.gcea.coop/energy-efficiency/rebates/',
@@ -131,7 +131,7 @@ export const CO_PROGRAMS = {
   },
   co_holyCrossEnergy_residentialRebates: {
     name: {
-      en: 'Residential Rebates',
+      en: 'Holy Cross Energy Residential Rebates',
     },
     url: {
       en: 'https://www.holycross.com/rebates/',
@@ -139,7 +139,7 @@ export const CO_PROGRAMS = {
   },
   co_laPlataElectricAssociation_electrifyAndSave: {
     name: {
-      en: 'Electrify and Save',
+      en: 'La Plata Electric Association - Electrify and Save',
     },
     url: {
       en: 'https://lpea.coop/electrify',
@@ -147,7 +147,7 @@ export const CO_PROGRAMS = {
   },
   'co_morganCountyREA_tri-StateG&T': {
     name: {
-      en: 'Tri-State G&T',
+      en: 'Morgan County REA Energy Efficiency Rebates',
     },
     url: {
       en: 'https://www.mcrea.org/energy-efficiency-rebates',
@@ -155,7 +155,7 @@ export const CO_PROGRAMS = {
   },
   co_mountainViewElectricAssociation_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'Mountain View Electric Association Rebates',
     },
     url: {
       en: 'https://www.mvea.coop/save-energy-money/rebates/',
@@ -163,7 +163,7 @@ export const CO_PROGRAMS = {
   },
   co_poudreValleyREA_rebatesForResidentialCustomers: {
     name: {
-      en: 'Rebates for Residential Customers',
+      en: 'Poudre Valley REA Rebates for Residential Members',
     },
     url: {
       en: 'https://pvrea.coop/for-members/residential-services/rebates/',
@@ -171,7 +171,7 @@ export const CO_PROGRAMS = {
   },
   co_sanIsabelElectric_sanIsabelElectric: {
     name: {
-      en: 'San Isabel Electric',
+      en: 'San Isabel Electric Residential Rebates',
     },
     url: {
       en: 'https://siea.com/rebates/',
@@ -179,7 +179,7 @@ export const CO_PROGRAMS = {
   },
   co_sanMiguelPowerAssociation_residentialAndCommercialRebates: {
     name: {
-      en: 'Residential and Commercial Rebates',
+      en: 'San Miguel Power Association Residential and Commercial Rebates',
     },
     url: {
       en: 'https://www.smpa.com/energy#berebates',
@@ -187,7 +187,7 @@ export const CO_PROGRAMS = {
   },
   'co_southeastColoradoPowerAssociation_tri-StateG&T': {
     name: {
-      en: 'Tri-State G&T',
+      en: 'Southeast Colorado Power Association Rebates',
     },
     url: {
       en: 'https://www.secpa.com/rebates',
@@ -195,7 +195,7 @@ export const CO_PROGRAMS = {
   },
   'co_tri-StateG&T_tri-StateG&T': {
     name: {
-      en: 'Tri-State G&T',
+      en: 'United Power Heat Pump Rebates',
     },
     url: {
       en: 'https://www.unitedpower.com/heat-pumps',
@@ -203,7 +203,7 @@ export const CO_PROGRAMS = {
   },
   'co_unitedPower_tri-StateG&T': {
     name: {
-      en: 'Tri-State G&T',
+      en: 'United Power Rebates & Programs',
     },
     url: {
       en: 'https://www.unitedpower.com/rebates',
@@ -211,7 +211,7 @@ export const CO_PROGRAMS = {
   },
   co_xcelEnergy_heatPumpRebates: {
     name: {
-      en: 'Heat Pump Rebates',
+      en: 'Xcel Energy Heat Pump Rebates',
     },
     url: {
       en: 'https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps',
@@ -219,7 +219,7 @@ export const CO_PROGRAMS = {
   },
   co_xcelEnergy_heatPumpWaterHeaterRebates: {
     name: {
-      en: 'Heat Pump Water Heater Rebates',
+      en: 'Xcel Energy Heat Pump Water Heater Rebates',
     },
     url: {
       en: 'https://co.my.xcelenergy.com/s/residential/home-rebates/water-heaters',
@@ -227,7 +227,7 @@ export const CO_PROGRAMS = {
   },
   co_coloradoEnergyOffice_electricVehicleTaxCredits: {
     name: {
-      en: 'Electric Vehicle Tax Credits',
+      en: 'Colorado Electric Vehicle Tax Credits',
     },
     url: {
       en: 'https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits',
@@ -251,7 +251,7 @@ export const CO_PROGRAMS = {
   },
   co_stateOfColorado_taxCredits: {
     name: {
-      en: 'Tax Credits',
+      en: 'Colorado Tax Credits',
     },
     url: {
       en: 'https://energysmartcolorado.org/tax-credits-incentives/',
@@ -259,7 +259,7 @@ export const CO_PROGRAMS = {
   },
   co_cityOfBoulder_residentialRebates: {
     name: {
-      en: 'Residential Rebates',
+      en: 'City of Boulder Residential Rebates',
     },
     url: {
       en: 'https://energysmartyes.com/rebates-financing/',
@@ -267,7 +267,7 @@ export const CO_PROGRAMS = {
   },
   co_cityOfBoulder_solarTaxRebates: {
     name: {
-      en: 'Solar Tax Rebates',
+      en: 'City of Boulder Solar Tax Rebates',
     },
     url: {
       en: 'https://bouldercolorado.gov/services/solar-tax-rebates',
@@ -275,7 +275,7 @@ export const CO_PROGRAMS = {
   },
   co_boulderCounty_energySmart: {
     name: {
-      en: 'EnergySmart',
+      en: 'Boulder County EnergySmart',
     },
     url: {
       en: 'https://energysmartyes.com/rebates-financing/boco-rebates/',
@@ -283,7 +283,7 @@ export const CO_PROGRAMS = {
   },
   co_boulderCounty_energySmartManufacturedHomesRebates: {
     name: {
-      en: 'EnergySmart Manufactured Homes Rebates',
+      en: 'Boulder County EnergySmart Manufactured Homes Rebates',
     },
     url: {
       en: 'https://assets-partners.bouldercounty.gov/wp-content/uploads/sites/2/2023/08/Manufactured-Homes-Eligible-Measures-List-2023.pdf',
@@ -299,7 +299,7 @@ export const CO_PROGRAMS = {
   },
   co_highlineElectricAssociation_rebateProgram: {
     name: {
-      en: 'Rebate Program',
+      en: 'Highline Electric Association Rebate Program',
     },
     url: {
       en: 'https://www.hea.coop/rebates',
@@ -307,7 +307,7 @@ export const CO_PROGRAMS = {
   },
   co_kCElectricAssociation_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'K.C. Electric Association Rebates',
     },
     url: {
       en: 'https://www.kcelectric.coop/rebates',
@@ -315,7 +315,7 @@ export const CO_PROGRAMS = {
   },
   co_mountainParksElectric_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'Mountain Parks Electric Rebates',
     },
     url: {
       en: 'https://www.mpei.com/rebates',
@@ -323,7 +323,7 @@ export const CO_PROGRAMS = {
   },
   co_sanLuisValleyREC_energyEfficiencyRebateProgram: {
     name: {
-      en: 'Energy Efficiency Rebate Program',
+      en: 'San Luis Valley REC Energy Efficiency Rebate Program',
     },
     url: {
       en: 'https://slvrec.com/rebates',
@@ -331,7 +331,7 @@ export const CO_PROGRAMS = {
   },
   co_sangreDeCristoElectricAssociation_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'Sangre de Cristo Electric Association Rebates',
     },
     url: {
       en: 'https://www.myelectric.coop/energy-efficiency/energy-efficiency-credit-programs/',
@@ -339,7 +339,7 @@ export const CO_PROGRAMS = {
   },
   'co_sangreDeCristoElectricAssociation_saveEnergy&Money': {
     name: {
-      en: 'Save Energy & Money',
+      en: 'Sangre de Cristo Electric Association - Save Energy & Money',
     },
     url: {
       en: 'https://www.myelectric.coop/energy-efficiency/energy-efficiency-credit-programs/',
@@ -347,7 +347,7 @@ export const CO_PROGRAMS = {
   },
   co_townOfAvon_energyEfficiencyProgram: {
     name: {
-      en: 'Energy Efficiency Program',
+      en: 'Town of Avon Energy Efficiency Program',
     },
     url: {
       en: 'https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/',
@@ -355,7 +355,7 @@ export const CO_PROGRAMS = {
   },
   co_townOfEagle_energyEfficiencyProgram: {
     name: {
-      en: 'Energy Efficiency Program',
+      en: 'Town of Eagle Energy Efficiency Program',
     },
     url: {
       en: 'https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/',
@@ -363,7 +363,7 @@ export const CO_PROGRAMS = {
   },
   co_townOfErie_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'Town of Erie Rebates',
     },
     url: {
       en: 'https://www.erieco.gov/2242/Energy-Efficiency-Rebates',
@@ -371,7 +371,7 @@ export const CO_PROGRAMS = {
   },
   co_townOfVail_energyEfficiencyProgram: {
     name: {
-      en: 'Energy Efficiency Program',
+      en: 'Town of Vail Energy Efficiency Program',
     },
     url: {
       en: 'https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/',
@@ -387,7 +387,7 @@ export const CO_PROGRAMS = {
   },
   'co_walkingMountains_low-ModerateIncomeProgram': {
     name: {
-      en: 'Low-Moderate Income Program',
+      en: 'Walking Mountains Low-Moderate Income Program',
     },
     url: {
       en: 'https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/',
@@ -395,7 +395,7 @@ export const CO_PROGRAMS = {
   },
   'co_walkingMountains_rebates&Incentives': {
     name: {
-      en: 'Rebates & Incentives',
+      en: 'Walking Mountains Rebates & Incentives',
     },
     url: {
       en: 'https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/',
@@ -403,7 +403,7 @@ export const CO_PROGRAMS = {
   },
   co_whiteRiverElectricAssociation_rebates: {
     name: {
-      en: 'Rebates',
+      en: 'White River Electric Association Rebates',
     },
     url: {
       en: 'https://www.wrea.org/rebates',
@@ -411,7 +411,7 @@ export const CO_PROGRAMS = {
   },
   'co_y-WElectricAssociation_rebateProgram': {
     name: {
-      en: 'Rebate Program',
+      en: 'Y-W Electric Association Rebate Program',
     },
     url: {
       en: 'https://www.ywelectric.coop/rebate-program-information',

--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -54,7 +54,6 @@ export const STATES_PLUS_DC = [
 
 export const BETA_STATES: string[] = [
   'AZ',
-  'CO',
   'CT',
   'GA',
   'IL',
@@ -67,6 +66,7 @@ export const BETA_STATES: string[] = [
 ];
 
 export const LAUNCHED_STATES: string[] = [
+  'CO',
   'DC',
   'PA',
   'RI',

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -2,6 +2,7 @@ import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from 'fastify';
 import _ from 'lodash';
 import { Database } from 'sqlite';
+import { AuthorityType } from '../data/authorities';
 import { IRA_INCENTIVES, IRAIncentive } from '../data/ira_incentives';
 import { IRA_STATE_SAVINGS } from '../data/ira_state_savings';
 import { PROGRAMS, Programs } from '../data/programs';
@@ -146,6 +147,7 @@ export default async function (
       try {
         const result = calculateIncentives(incomeInfo, {
           ...request.query,
+          authority_types: [AuthorityType.Federal],
         });
 
         const pos_rebate_incentives = result.incentives.filter(

--- a/test/data/cycles.ts
+++ b/test/data/cycles.ts
@@ -1,0 +1,46 @@
+// Helper to check for circular dependencies in the incentive relationships.
+export function checkForCycle(
+  incentiveId: string,
+  seen: Set<string>,
+  finished: Set<string>,
+  edges: Map<string, Set<string>>,
+) {
+  if (finished.has(incentiveId)) {
+    // We've already finished checking this incentive.
+    return false;
+  }
+  if (seen.has(incentiveId)) {
+    // We haven't finished checking this incentive's dependencies but are
+    // visiting it for the second time. This is a cycle.
+    return true;
+  }
+  seen.add(incentiveId);
+  const dependencies = edges.get(incentiveId);
+  if (dependencies !== undefined) {
+    for (const id of dependencies) {
+      if (checkForCycle(id, seen, finished, edges)) {
+        return true;
+      }
+    }
+  }
+  finished.add(incentiveId);
+  return false;
+}
+
+export function incentiveRelationshipsContainCycle(
+  relationshipGraph: Map<string, Set<string>>,
+) {
+  const seen = new Set<string>();
+  const finished = new Set<string>();
+  const toCheck = Array.from(relationshipGraph.keys());
+  let hasCycle = false;
+  if (toCheck !== undefined) {
+    for (const incentiveId of toCheck) {
+      hasCycle = checkForCycle(incentiveId, seen, finished, relationshipGraph);
+      if (hasCycle) {
+        break;
+      }
+    }
+  }
+  return hasCycle;
+}

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -24,7 +24,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Water Heater Rebates",
+      "program": "Xcel Energy Heat Pump Water Heater Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/home-rebates/water-heaters",
       "item": {
         "type": "heat_pump_water_heater",

--- a/test/fixtures/v1-84106-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-84106-homeowner-80000-joint-4.json
@@ -8,9 +8,9 @@
     "utility": null
   },
   "location": {
-    "state": "CO",
-    "city": "Denver",
-    "county": "Denver"
+    "state": "UT",
+    "city": "Salt Lake City",
+    "county": "Salt Lake"
   },
   "data_partners": {},
   "incentives": [
@@ -284,7 +284,7 @@
       "amount": {
         "type": "percent",
         "number": 0.3,
-        "representative": 5130
+        "representative": 4626
       },
       "owner_status": [
         "homeowner"

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -37,7 +37,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Rebates",
+      "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "geothermal_heating_installation",
@@ -62,7 +62,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Rebates",
+      "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -86,7 +86,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Rebates",
+      "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -110,7 +110,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Rebates",
+      "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -134,7 +134,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Rebates",
+      "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -157,7 +157,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Low-Moderate Income Program",
+      "program": "Walking Mountains Low-Moderate Income Program",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "weatherization",
@@ -180,7 +180,7 @@
       ],
       "authority_type": "state",
       "authority": "co-energy-outreach-colorado",
-      "program": "Weatherization Assistance Program",
+      "program": "Energy Outreach Colorado Weatherization Assistance Program",
       "program_url": "https://socgov02.my.site.com/ceoweatherization/s/",
       "item": {
         "type": "weatherization",
@@ -252,7 +252,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "weatherization",
@@ -276,7 +276,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -300,7 +300,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -324,7 +324,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -348,7 +348,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -372,7 +372,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_water_heater",
@@ -396,7 +396,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_clothes_dryer",
@@ -420,7 +420,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
@@ -444,7 +444,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
@@ -468,7 +468,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "smart_thermostat",
@@ -492,7 +492,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_stove",
@@ -516,7 +516,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "weatherization",
@@ -540,7 +540,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -564,7 +564,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -588,7 +588,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -612,7 +612,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -636,7 +636,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_water_heater",
@@ -660,7 +660,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "heat_pump_clothes_dryer",
@@ -684,7 +684,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
@@ -708,7 +708,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_panel",
@@ -732,7 +732,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "smart_thermostat",
@@ -756,7 +756,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "electric_stove",
@@ -780,7 +780,7 @@
       ],
       "authority_type": "other",
       "authority": "co-walking-mountains",
-      "program": "Rebates & Incentives",
+      "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "item": {
         "type": "rooftop_solar_installation",
@@ -805,7 +805,7 @@
       ],
       "authority_type": "utility",
       "authority": "co-xcel-energy",
-      "program": "Heat Pump Water Heater Rebates",
+      "program": "Xcel Energy Heat Pump Water Heater Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/home-rebates/water-heaters",
       "item": {
         "type": "heat_pump_water_heater",
@@ -853,7 +853,7 @@
       ],
       "authority_type": "state",
       "authority": "co-state-of-colorado",
-      "program": "Tax Credits",
+      "program": "Colorado Tax Credits",
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
       "item": {
         "type": "battery_storage_installation",
@@ -878,7 +878,7 @@
       ],
       "authority_type": "state",
       "authority": "co-colorado-energy-office",
-      "program": "Electric Vehicle Tax Credits",
+      "program": "Colorado Electric Vehicle Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits",
       "item": {
         "type": "new_electric_vehicle",
@@ -903,7 +903,7 @@
       ],
       "authority_type": "state",
       "authority": "co-colorado-energy-office",
-      "program": "Electric Vehicle Tax Credits",
+      "program": "Colorado Electric Vehicle Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits",
       "item": {
         "type": "new_electric_vehicle",

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -4,7 +4,7 @@ import { FilingStatus } from '../../src/data/tax_brackets';
 import { OwnerStatus } from '../../src/data/types/owner-status';
 import { buildRelationshipGraph } from '../../src/lib/incentive-relationship-calculation';
 import { calculateStateIncentivesAndSavings } from '../../src/lib/state-incentives-calculation';
-import { incentiveRelationshipsContainCycle } from '../data/schemas.test';
+import { incentiveRelationshipsContainCycle } from '../data/cycles';
 import {
   TEST_INCENTIVE_RELATIONSHIPS,
   TEST_INCENTIVE_RELATIONSHIPS_2,

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -58,26 +58,13 @@ test('response is valid and correct', async t => {
   await validateResponse(
     t,
     {
-      zip: '80212',
+      zip: '84106',
       owner_status: 'homeowner',
       household_income: 80000,
       tax_filing: 'joint',
       household_size: 4,
     },
-    './test/fixtures/v1-80212-homeowner-80000-joint-4.json',
-  );
-
-  // Same request but with location passed differently
-  await validateResponse(
-    t,
-    {
-      zip: '80212',
-      owner_status: 'homeowner',
-      household_income: 80000,
-      tax_filing: 'joint',
-      household_size: 4,
-    },
-    './test/fixtures/v1-80212-homeowner-80000-joint-4.json',
+    './test/fixtures/v1-84106-homeowner-80000-joint-4.json',
   );
 });
 
@@ -181,8 +168,6 @@ test('CO low income response with state and utility filtering is valid and corre
       tax_filing: 'joint',
       authority_types: ['state', 'utility', 'other'],
       utility: 'co-xcel-energy',
-      // TODO: Remove when CO is fully launched.
-      include_beta_states: true,
     },
     './test/fixtures/v1-co-81657-state-utility-lowincome.json',
   );
@@ -202,8 +187,6 @@ test('CO incentive for PRPA shows up as intended', async t => {
       items: ['heat_pump_water_heater'],
       // Not in PRPA; incentives should not show up
       utility: 'co-xcel-energy',
-      // TODO: Remove when CO is fully launched.
-      include_beta_states: true,
     },
     './test/fixtures/v1-80517-xcel.json',
   );
@@ -219,8 +202,6 @@ test('CO incentive for PRPA shows up as intended', async t => {
       items: ['heat_pump_water_heater'],
       // Is in PRPA; incentives should show up
       utility: 'co-estes-park-power-and-communications',
-      // TODO: Remove when CO is fully launched.
-      include_beta_states: true,
     },
     './test/fixtures/v1-80517-estes-park.json',
   );
@@ -606,12 +587,12 @@ const BAD_QUERIES = [
     utility: 'nonexistent-utility',
   },
   {
-    zip: '80212',
+    zip: '84106',
     owner_status: 'homeowner',
     household_income: 80000,
     tax_filing: 'joint',
     household_size: 4,
-    // We don't have coverage in 80212 (Colorado)
+    // We don't have coverage in 84106 (Utah)
     utility: 'ri-rhode-island-energy',
   },
 ];
@@ -719,10 +700,10 @@ const UTILITIES = [
   ],
   ['06360', false, { location: { state: 'CT' }, utilities: {} }],
   [
-    '80212',
+    '84106',
     false,
     {
-      location: { state: 'CO' },
+      location: { state: 'UT' },
       utilities: {},
     },
   ],


### PR DESCRIPTION
## Descriptions

A surprising number of changes here:

- There were a bunch of incentives that still had "unknown" payment
  type. I looked at the utility websites and they're clearly
  advertised as rebates (post-purchase), so I updated the spreadsheet
  and synced that into JSON.

- I updated the program names to be more user-friendly when displayed
  in the incentive cards in the frontend. (This implicates a deeper
  question around how much we should strive to keep frontend concerns
  out of the API design -- this style of program name is pretty
  obviously driven by frontend concerns -- but given the imminent CO
  launch we're punting it for now and following what we've been doing
  in other states.)

  One program URL is updated too, because the old one was broken.

- The v0 endpoint has actually had the potential to pull in
  non-federal incentives from `calculateIncentives` all along, and
  only now did that come into play. (It didn't before because no
  `LAUNCHED` state had `pos_rebate`, `performance_rebate`, or
  `tax_credit` incentives and v0 could never have
  `include_beta_states` be true; it started now because CO has tax
  credits. Explicitly have it calculate federal incentives only.

- `incentives-relationships.test.ts` was importing `schemas.test.ts`,
  which actually caused the tests in `schemas.test.ts` to be run
  twice. Factor out the shared code into a new file, to stop that.

- We've been using 80212, a CO zip, all along as a generic "no state
  coverage" zip code for end-to-end tests. Those days are
  over. Switched it to 84106, a zip in Salt Lake City, UT with a
  similar AMI.

## Test Plan

`yarn test`. View the incentives with the calculator frontend pointed
at local server, to make sure the program names look good.
