### PR TITLE
Let /v1/utilities serve utilities for all states

### DIFF
--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -1,6 +1,5 @@
 import { Database } from 'sqlite';
 import { AUTHORITIES_BY_STATE, Authority } from '../data/authorities';
-import { isStateIncluded } from '../data/types/states';
 import { GeoInfo } from './income-info';
 
 /** Models the zip_to_utility table in sqlite. */
@@ -22,13 +21,12 @@ type ZipToUtility = {
 export async function getUtilitiesForLocation(
   db: Database,
   location: GeoInfo,
-  includeBeta: boolean,
 ): Promise<{
   [id: string]: Authority;
 }> {
   const stateUtilities = AUTHORITIES_BY_STATE[location.state_id]?.utility;
 
-  if (!stateUtilities || !isStateIncluded(location.state_id, includeBeta)) {
+  if (!stateUtilities) {
     return {};
   }
 

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -153,11 +153,7 @@ export default async function (
           .type('application/json')
           .send({
             location: { state: location.state_id },
-            utilities: await getUtilitiesForLocation(
-              fastify.sqlite,
-              location,
-              request.query.include_beta_states ?? false,
-            ),
+            utilities: await getUtilitiesForLocation(fastify.sqlite, location),
           });
       } catch (error) {
         if (error instanceof InvalidInputError) {

--- a/test/data/utilities.test.ts
+++ b/test/data/utilities.test.ts
@@ -15,13 +15,17 @@ test('all authorities.json utilities are in DB', async t => {
     .map(Object.keys)
     .flat();
 
+  const query = await database.all<{ utility_id: string; ct: number }[]>(
+    'SELECT utility_id, COUNT(1) AS ct FROM zip_to_utility GROUP BY utility_id',
+  );
+  const utilityCounts = Object.fromEntries(
+    query!.map(({ utility_id, ct }) => [utility_id, ct]),
+  );
+
   for (const id of allUtilityIds) {
-    const dbCount = (
-      await database.get(
-        'SELECT count(1) AS ct FROM zip_to_utility WHERE utility_id = ?',
-        id,
-      )
-    )['ct'];
-    t.ok(dbCount > 0, `utility ${id} does not appear in zip_to_utility`);
+    t.ok(
+      utilityCounts[id] > 0,
+      `utility ${id} does not appear in zip_to_utility`,
+    );
   }
 });

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -653,7 +653,6 @@ test('non-existent zips', async t => {
 const UTILITIES = [
   [
     '02807',
-    false,
     {
       location: { state: 'RI' },
       utilities: {
@@ -663,7 +662,6 @@ const UTILITIES = [
   ],
   [
     '02814',
-    false,
     {
       location: { state: 'RI' },
       utilities: {
@@ -674,7 +672,6 @@ const UTILITIES = [
   ],
   [
     '02905',
-    false,
     {
       location: { state: 'RI' },
       utilities: { 'ri-rhode-island-energy': { name: 'Rhode Island Energy' } },
@@ -682,7 +679,6 @@ const UTILITIES = [
   ],
   [
     '06360',
-    true,
     {
       location: { state: 'CT' },
       utilities: {
@@ -698,16 +694,18 @@ const UTILITIES = [
       },
     },
   ],
-  ['06360', false, { location: { state: 'CT' }, utilities: {} }],
   [
     '84106',
-    false,
     {
       location: { state: 'UT' },
-      utilities: {},
+      utilities: {
+        'ut-rocky-mountain-power': {
+          name: 'Rocky Mountain Power',
+        },
+      },
     },
   ],
-];
+] as const;
 
 test('/utilities', async t => {
   const app = await build(t);
@@ -720,11 +718,8 @@ test('/utilities', async t => {
   });
   const validator = ajv.getSchema('APIUtilitiesResponse')!;
 
-  for (const [zip, beta, expectedResponse] of UTILITIES) {
-    const searchParams = qs.stringify(
-      { zip, include_beta_states: beta },
-      { encodeValuesOnly: true },
-    );
+  for (const [zip, expectedResponse] of UTILITIES) {
+    const searchParams = qs.stringify({ zip }, { encodeValuesOnly: true });
     const res = await app.inject({ url: `/api/v1/utilities?${searchParams}` });
     t.equal(res.statusCode, 200);
 


### PR DESCRIPTION
## Description

We want to show real utility options to all users, not just in
launched/beta states. We now have the data, so we can remove the check.

https://app.asana.com/0/1206661332626418/1206843501113809

## Test Plan

`yarn test` and updated tests/fixtures. Run queries for some states
that we haven't touched yet.