### PR TITLE
Combine Duquesne weatherization updates

### DIFF
--- a/data/PA/incentives.json
+++ b/data/PA/incentives.json
@@ -220,111 +220,14 @@
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
       "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
+      "number": 2000,
+      "maximum": 2000
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $400 rebate for home air sealing. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
-      "es": "Reembolso de hasta $400 dólares por el sellado hermético de la vivienda. El monto del reembolso se eleva en proporción a la reducción del consumo de kilowatts por hora (kWh)."
-    },
-    "start_date": "2021-06-01",
-    "end_date": "2026-05-31"
-  },
-  {
-    "id": "PA-11",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
-    "payment_methods": [
-      "rebate"
-    ],
-    "item": "weatherization",
-    "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "Up to $400 rebate for duct insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
-      "es": "Reembolso de hasta $400 dólares por aislamiento térmico de ductos. El monto del reembolso se eleva en proporción a la reducción del consumo de kilowatts por hora (kWh)."
-    },
-    "start_date": "2021-06-01",
-    "end_date": "2026-05-31"
-  },
-  {
-    "id": "PA-12",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
-    "payment_methods": [
-      "rebate"
-    ],
-    "item": "weatherization",
-    "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "Up to $400 rebate for attic insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
-      "es": "Reembolso de hasta $400 dólares por aislamiento térmico del desván. El monto del reembolso se eleva en proporción a la reducción del consumo de kilowatts por hora (kWh)."
-    },
-    "start_date": "2021-06-01",
-    "end_date": "2026-05-31"
-  },
-  {
-    "id": "PA-13",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
-    "payment_methods": [
-      "rebate"
-    ],
-    "item": "weatherization",
-    "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "Up to $400 rebate for basement/crawl space wall insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
-      "es": "Reembolso de hasta $400 dólares por aislamiento térmico de muros en sótanos y espacios reducidos. El monto del reembolso se eleva en proporción a la reducción del consumo de kilowatts por hora (kWh)."
-    },
-    "start_date": "2021-06-01",
-    "end_date": "2026-05-31"
-  },
-  {
-    "id": "PA-14",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
-    "payment_methods": [
-      "rebate"
-    ],
-    "item": "weatherization",
-    "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 400,
-      "maximum": 400
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "Up to $400 rebate for knee wall insulation. The rebate value rises in proportion to the reduction in kilowatt-hour (kWh) usage.",
-      "es": "Reembolso de hasta $400 dólares por aislamiento térmico de muros. El monto del reembolso se eleva en proporción a la reducción del consumo de kilowatts por hora (kWh)."
+      "en": "Up to $2,000 rebate for weatherization. Up to $400 each for air sealing, duct, attic, basement/crawl space and knee wall insulation."
     },
     "start_date": "2021-06-01",
     "end_date": "2026-05-31"


### PR DESCRIPTION
We got some last minute feedback from Duquesne that they'd like to combine these 5 weatherization incentives ($400 each) into 1 incentive (Up to $2,000) before the public launch on Monday. They confirmed these rebates can be stacked and that they prefer this representation.

Open to ideas on the wording here for the description - this seems okay to me but the wording is a little weird to make sure it's under the 150 character limit.

Unfortunately this means we'll need to get the Spanish translation redone - I'll make a ticket for that but it may not be done by Monday, which I think is fine