### PR TITLE
Addresses a typo in CO incentive data as reported from a partner. 

### DIFF
--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -11786,7 +11786,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de los costos del proyecto para proyectos de climatización, como sellado hermético del aire/ductos, aislamiento térmicos y otros, para hogares con bajos ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11810,7 +11810,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de costos de proyecto de bombas de calor con fuente de aire para climas fríos que reúnan los requisitos necesarios para hogares que cumplan requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11834,7 +11834,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de los costos de proyecto para bombas de calor de aire a agua de clima frío certificadas para hogares que cumplan requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11858,7 +11858,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de los costos de proyecto en bombas de calor geotérmico de clima frío que reúnan los requisitos necesarios para hogares que cumplan con nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11882,7 +11882,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de los costos del proyecto para bombas de calor sin ductos para hogares que cumplan con el nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11906,7 +11906,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualifying households.",
       "es": "Reembolsos hasta el 50% de los costos de proyecto para calentadores de agua con bomba de calor destinados a hogares que cumplan con requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11930,7 +11930,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de los costos del proyecto de secadora de ropa con bomba de calor para hogares que cumplan con nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11954,7 +11954,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualifying households.",
       "es": "Reembolso de hasta el 50% de los costos de proyecto para  proyectos de cableado relacionados con la electrificación de los hogares que cumplen requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -11978,7 +11978,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualifying households.",
       "es": "Un reembolso de hasta el 50% de los costos del proyecto para proyectos de cableado relacionados con la electrificación para hogares que cumplen con requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -12002,7 +12002,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualifying households.",
       "es": "Reembolsos de hasta el 50% de los costos del proyecto por termostatos inteligentes con WiFi o termostatos programables para hogares que cumplen con requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"
@@ -12026,7 +12026,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualitying households.",
+      "en": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualifying households.",
       "es": "Reembolso de hasta el 50% de los costos del proyecto para parrillas de inducción y estufas para hogares que cumplan con requisitos de nivel de ingresos."
     },
     "low_income": "co-walking-mountains"

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -268,7 +268,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -292,7 +292,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -316,7 +316,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -340,7 +340,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -364,7 +364,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -388,7 +388,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -412,7 +412,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -436,7 +436,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -460,7 +460,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -484,7 +484,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualifying households."
     },
     {
       "payment_methods": [
@@ -508,7 +508,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualitying households."
+      "short_description": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualifying households."
     },
     {
       "payment_methods": [


### PR DESCRIPTION
Fixes Walking Mountain incentive typos `qualitying` -> `qualifying`.