### PR TITLE
Add multi-valued "items" field

### DIFF
--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -112,6 +112,16 @@ zip=60304\
 &authority=il-state-of-illinois" \
  | jq . > test/fixtures/il-60304-state-utility-lowincome.json
 
+ curl \
+  "http://localhost:3000/api/v1/calculator?\
+zip=60202\
+&owner_status=homeowner\
+&household_income=10000\
+&tax_filing=single\
+&household_size=2\
+&authority_types=city" \
+ | jq . > test/fixtures/v1-il-60202-city-lowincome.json
+
 # TODO: Remove beta states argument when MI is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\
@@ -124,6 +134,19 @@ curl \
 &authority_types=utility\
 &utility=mi-dte" \
   | jq . > test/fixtures/v1-mi-48103-state-utility-lowincome.json
+
+# TODO: Remove beta states argument when MI is fully launched.
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?zip=48825\
+&include_beta_states=true\
+&owner_status=homeowner\
+&household_income=10000\
+&tax_filing=single\
+&household_size=2\
+&authority_types=utility\
+&utility=mi-lansing-board-of-water-and-light" \
+  | jq . > test/fixtures/v1-mi-48825-city-lowincome.json
 
 curl \
   "http://localhost:3000/api/v1/calculator\

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -26,6 +26,9 @@ function transformIncentives(
   return incentives.map(incentive => ({
     ...incentive,
 
+    // Synthesize multi-valued items field
+    items: [incentive.item],
+
     // Localize localizable fields
     item: {
       type: incentive.item,

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -16,6 +16,7 @@ export const API_INCENTIVE_SCHEMA = {
     'program',
     'program_url',
     'item',
+    'items',
     'amount',
     'owner_status',
   ],
@@ -57,6 +58,13 @@ export const API_INCENTIVE_SCHEMA = {
       },
       required: ['type'],
       additionalProperties: false,
+    },
+    items: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: ALL_ITEMS,
+      },
     },
     amount: {
       type: 'object',

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -33,6 +33,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -58,6 +61,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 18500,
@@ -83,6 +89,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000,

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -35,6 +35,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 8000
@@ -61,6 +64,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -84,6 +90,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1000,
@@ -109,6 +118,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -133,6 +145,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -157,6 +172,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 7500
@@ -185,6 +203,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -49,6 +49,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -73,6 +76,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -96,6 +102,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -119,6 +128,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1,
@@ -143,6 +155,9 @@
         "type": "ebike",
         "name": "E-Bike"
       },
+      "items": [
+        "ebike"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.75,
@@ -168,6 +183,9 @@
         "type": "ebike",
         "name": "E-Bike"
       },
+      "items": [
+        "ebike"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -193,6 +211,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1250,
@@ -218,6 +239,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1000,
@@ -243,6 +267,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 350,
@@ -270,6 +297,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.65,
@@ -296,6 +326,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -320,6 +353,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -344,6 +380,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -368,6 +407,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -392,6 +434,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 750
@@ -415,6 +460,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600,
@@ -441,6 +489,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500

--- a/test/fixtures/v1-15289-homeowner-85000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-85000-joint-4.json
@@ -33,6 +33,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -56,6 +59,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 8000
@@ -82,6 +88,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000
@@ -107,6 +116,9 @@
         "type": "efficiency_rebates",
         "name": "Efficiency Rebates"
       },
+      "items": [
+        "efficiency_rebates"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000
@@ -132,6 +144,9 @@
         "type": "electric_wiring",
         "name": "Electric Wiring"
       },
+      "items": [
+        "electric_wiring"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500
@@ -157,6 +172,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1750
@@ -182,6 +200,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1600
@@ -207,6 +228,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 840
@@ -233,6 +257,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 840
@@ -259,6 +286,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000,
@@ -286,6 +316,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000,
@@ -313,6 +346,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000,
@@ -340,6 +376,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000,
@@ -367,6 +406,9 @@
         "type": "battery_storage_installation",
         "name": "Battery Storage Installation"
       },
+      "items": [
+        "battery_storage_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -393,6 +435,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -419,6 +464,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -445,6 +493,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 7500
@@ -473,6 +524,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000
@@ -501,6 +555,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000
@@ -526,6 +583,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000
@@ -551,6 +611,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1200
@@ -576,6 +639,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -602,6 +668,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -33,6 +33,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 900,
@@ -59,6 +62,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 900,

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -30,6 +30,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 800

--- a/test/fixtures/v1-84106-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-84106-homeowner-80000-joint-4.json
@@ -26,6 +26,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 8000
@@ -52,6 +55,9 @@
         "type": "efficiency_rebates",
         "name": "Efficiency Rebates"
       },
+      "items": [
+        "efficiency_rebates"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 8000
@@ -77,6 +83,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000
@@ -102,6 +111,9 @@
         "type": "electric_wiring",
         "name": "Electric Wiring"
       },
+      "items": [
+        "electric_wiring"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500
@@ -127,6 +139,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1750
@@ -152,6 +167,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1600
@@ -177,6 +195,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 840
@@ -203,6 +224,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 840
@@ -229,6 +253,9 @@
         "type": "battery_storage_installation",
         "name": "Battery Storage Installation"
       },
+      "items": [
+        "battery_storage_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -255,6 +282,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -281,6 +311,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.3,
@@ -307,6 +340,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 7500
@@ -335,6 +371,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000
@@ -363,6 +402,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000
@@ -388,6 +430,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000
@@ -413,6 +458,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1200
@@ -438,6 +486,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -464,6 +515,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -30,6 +30,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -53,6 +56,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -30,6 +30,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -53,6 +56,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 900
@@ -76,6 +82,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 650

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -43,6 +43,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 600,
@@ -68,6 +71,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2200
@@ -92,6 +98,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2200
@@ -116,6 +125,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1700
@@ -140,6 +152,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1700
@@ -163,6 +178,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -186,6 +204,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -210,6 +231,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 6000
@@ -234,6 +258,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000
@@ -258,6 +285,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -282,6 +312,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -306,6 +339,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -330,6 +366,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -354,6 +393,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -378,6 +420,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -402,6 +447,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -426,6 +474,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -450,6 +501,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -474,6 +528,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -498,6 +555,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -522,6 +582,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -546,6 +609,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -570,6 +636,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -594,6 +663,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -618,6 +690,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -642,6 +717,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -666,6 +744,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -690,6 +771,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -714,6 +798,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -738,6 +825,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -762,6 +852,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -786,6 +879,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 100,
@@ -811,6 +907,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 800
@@ -834,6 +933,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.129
@@ -859,6 +961,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000
@@ -884,6 +989,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -33,6 +33,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -58,6 +61,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000
@@ -82,6 +88,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2250
@@ -106,6 +115,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000
@@ -130,6 +142,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1500,
@@ -157,6 +172,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 750,
@@ -184,6 +202,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 650
@@ -209,6 +230,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500
@@ -234,6 +258,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -68,6 +68,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -94,6 +97,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -120,6 +126,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -146,6 +155,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -172,6 +184,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -198,6 +213,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -224,6 +242,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 700,
@@ -250,6 +271,9 @@
         "type": "electric_outdoor_equipment",
         "name": "Electric Outdoor Equipment"
       },
+      "items": [
+        "electric_outdoor_equipment"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500
@@ -276,6 +300,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200,
@@ -302,6 +329,9 @@
         "type": "electric_outdoor_equipment",
         "name": "Electric Outdoor Equipment"
       },
+      "items": [
+        "electric_outdoor_equipment"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 75
@@ -328,6 +358,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -30,6 +30,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -56,6 +59,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -82,6 +88,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -108,6 +117,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -134,6 +146,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -160,6 +175,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -186,6 +204,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -212,6 +233,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,

--- a/test/fixtures/v1-il-60202-city-lowincome.json
+++ b/test/fixtures/v1-il-60202-city-lowincome.json
@@ -32,6 +32,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -55,6 +58,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -78,6 +84,9 @@
         "type": "electric_panel",
         "name": "Electric Panel"
       },
+      "items": [
+        "electric_panel"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -101,6 +110,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 1

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -30,6 +30,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500
@@ -55,6 +58,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -78,6 +84,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 850,
@@ -102,6 +111,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 800
@@ -125,6 +137,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500
@@ -149,6 +164,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 250,
@@ -174,6 +192,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 125
@@ -197,6 +218,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 125
@@ -220,6 +244,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -243,6 +270,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -266,6 +296,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -289,6 +322,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -312,6 +348,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -335,6 +374,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 25

--- a/test/fixtures/v1-mi-48825-city-lowincome.json
+++ b/test/fixtures/v1-mi-48825-city-lowincome.json
@@ -30,6 +30,9 @@
         "type": "ebike",
         "name": "E-Bike"
       },
+      "items": [
+        "ebike"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1500,
@@ -55,6 +58,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -79,6 +85,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000,
@@ -103,6 +112,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600,
@@ -127,6 +139,9 @@
         "type": "ebike",
         "name": "E-Bike"
       },
+      "items": [
+        "ebike"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -152,6 +167,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -176,6 +194,9 @@
         "type": "electric_outdoor_equipment",
         "name": "Electric Outdoor Equipment"
       },
+      "items": [
+        "electric_outdoor_equipment"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 150,
@@ -201,6 +222,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100
@@ -225,6 +249,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -248,6 +275,9 @@
         "type": "non_heat_pump_water_heater",
         "name": "Electric Resistance Water Heater"
       },
+      "items": [
+        "non_heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 25

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -39,6 +39,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -63,6 +66,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "percent",
         "number": 1,
@@ -87,6 +93,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3400,
@@ -111,6 +120,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3060,
@@ -135,6 +147,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2720
@@ -158,6 +173,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2040,
@@ -182,6 +200,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1360,
@@ -206,6 +227,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1360
@@ -229,6 +253,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400
@@ -252,6 +279,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200
@@ -276,6 +306,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -300,6 +333,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -36,6 +36,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1,
@@ -60,6 +63,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000,
@@ -86,6 +92,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -109,6 +118,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600,
@@ -133,6 +145,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600
@@ -156,6 +171,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600
@@ -179,6 +197,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 240
@@ -202,6 +223,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000,
@@ -226,6 +250,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,

--- a/test/fixtures/v1-or-97001-state-lowincome.json
+++ b/test/fixtures/v1-or-97001-state-lowincome.json
@@ -30,6 +30,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500
@@ -54,6 +57,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 250
@@ -77,6 +83,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100
@@ -100,6 +109,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1.5,
@@ -124,6 +136,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1.5,
@@ -148,6 +163,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1.5,
@@ -172,6 +190,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1.25,
@@ -196,6 +217,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1.25,
@@ -220,6 +244,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1,
@@ -244,6 +271,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.75,
@@ -268,6 +298,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.75,
@@ -292,6 +325,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.75,
@@ -316,6 +352,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.5,
@@ -340,6 +379,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.5,
@@ -364,6 +406,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 0.5,
@@ -388,6 +433,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000
@@ -412,6 +460,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000
@@ -436,6 +487,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000
@@ -460,6 +514,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1800
@@ -484,6 +541,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -508,6 +568,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -532,6 +595,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -556,6 +622,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500

--- a/test/fixtures/v1-pa-17555-state-lowincome.json
+++ b/test/fixtures/v1-pa-17555-state-lowincome.json
@@ -36,6 +36,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -59,6 +62,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -82,6 +88,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500
@@ -107,6 +116,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 75,
@@ -133,6 +145,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50
@@ -158,6 +173,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000,
@@ -185,6 +203,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 3000,
@@ -212,6 +233,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000,
@@ -239,6 +263,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000,
@@ -266,6 +293,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 650
@@ -291,6 +321,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -317,6 +350,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400
@@ -342,6 +378,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200
@@ -367,6 +406,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200
@@ -392,6 +434,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 75,
@@ -418,6 +463,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50,

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -30,6 +30,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -53,6 +56,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -78,6 +84,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 125
@@ -101,6 +110,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -45,6 +45,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 1
@@ -68,6 +71,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -93,6 +99,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -120,6 +129,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -147,6 +159,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -174,6 +189,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -201,6 +219,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -229,6 +250,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -257,6 +281,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -285,6 +312,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -313,6 +343,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2000,
@@ -338,6 +371,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 450,
@@ -363,6 +399,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -388,6 +427,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 40,
@@ -413,6 +455,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 15,
@@ -438,6 +483,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1,
@@ -462,6 +510,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 1,
@@ -487,6 +538,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.75,
@@ -513,6 +567,9 @@
         "type": "electric_vehicle_charger",
         "name": "Electric Vehicle Charger"
       },
+      "items": [
+        "electric_vehicle_charger"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.75,
@@ -538,6 +595,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.75,
@@ -563,6 +623,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.75,
@@ -588,6 +651,9 @@
         "type": "electric_outdoor_equipment",
         "name": "Electric Outdoor Equipment"
       },
+      "items": [
+        "electric_outdoor_equipment"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.5,
@@ -614,6 +680,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 2100,
@@ -639,6 +708,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 2000,
@@ -666,6 +738,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1500,
@@ -691,6 +766,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1000,
@@ -717,6 +795,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 6250,
@@ -743,6 +824,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 6000,
@@ -768,6 +852,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2300,
@@ -793,6 +880,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1300
@@ -817,6 +907,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000,
@@ -841,6 +934,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 800,
@@ -867,6 +963,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 700,
@@ -892,6 +991,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600,
@@ -917,6 +1019,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 600
@@ -941,6 +1046,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -965,6 +1073,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -990,6 +1101,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -1016,6 +1130,9 @@
         "type": "heat_pump_clothes_dryer",
         "name": "Heat Pump Clothes Dryer"
       },
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -1041,6 +1158,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -1067,6 +1187,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -1093,6 +1216,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400,
@@ -1118,6 +1244,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200
@@ -1141,6 +1270,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200,
@@ -1167,6 +1299,9 @@
         "type": "electric_stove",
         "name": "Electric/Induction Stove"
       },
+      "items": [
+        "electric_stove"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200,
@@ -1193,6 +1328,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200
@@ -1217,6 +1355,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100,
@@ -1242,6 +1383,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100,
@@ -1267,6 +1411,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100,
@@ -1292,6 +1439,9 @@
         "type": "other",
         "name": "Other"
       },
+      "items": [
+        "other"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 100,
@@ -1317,6 +1467,9 @@
         "type": "electric_outdoor_equipment",
         "name": "Electric Outdoor Equipment"
       },
+      "items": [
+        "electric_outdoor_equipment"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 40

--- a/test/fixtures/v1-vt-05845-vec-ev-low-income.json
+++ b/test/fixtures/v1-vt-05845-vec-ev-low-income.json
@@ -42,6 +42,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "percent",
         "number": 0.25,
@@ -67,6 +70,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -94,6 +100,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -121,6 +130,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -148,6 +160,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 5000,
@@ -175,6 +190,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -203,6 +221,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -231,6 +252,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -259,6 +283,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 2500,
@@ -287,6 +314,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -313,6 +343,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -339,6 +372,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500
@@ -364,6 +400,9 @@
         "type": "new_electric_vehicle",
         "name": "New Electric Vehicle"
       },
+      "items": [
+        "new_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 7500
@@ -392,6 +431,9 @@
         "type": "used_electric_vehicle",
         "name": "Used Electric Vehicle"
       },
+      "items": [
+        "used_electric_vehicle"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 4000

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -30,6 +30,9 @@
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
+      "items": [
+        "heat_pump_water_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 300
@@ -53,6 +56,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1125
@@ -78,6 +84,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000
@@ -103,6 +112,9 @@
         "type": "geothermal_heating_installation",
         "name": "Geothermal Heating Installation"
       },
+      "items": [
+        "geothermal_heating_installation"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 1000,
@@ -129,6 +141,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 675
@@ -154,6 +169,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 675
@@ -179,6 +197,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 525
@@ -204,6 +225,9 @@
         "type": "rooftop_solar_installation",
         "name": "Rooftop Solar Installation"
       },
+      "items": [
+        "rooftop_solar_installation"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 500,
@@ -230,6 +254,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 450
@@ -255,6 +282,9 @@
         "type": "heat_pump_air_conditioner_heater",
         "name": "Heat Pump Air Conditioner/Heater"
       },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 400
@@ -280,6 +310,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 225
@@ -305,6 +338,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 200
@@ -330,6 +366,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 150
@@ -355,6 +394,9 @@
         "type": "weatherization",
         "name": "Weatherization"
       },
+      "items": [
+        "weatherization"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 75
@@ -381,6 +423,9 @@
         "type": "smart_thermostat",
         "name": "Smart Thermostat"
       },
+      "items": [
+        "smart_thermostat"
+      ],
       "amount": {
         "type": "dollar_amount",
         "number": 50


### PR DESCRIPTION
## Description

This is the beginning of the process of adding more granular item
types for heat pumps and weatherization. Individual incentives will
now pertain to multiple `Item`s.

The process will be:

1. Land and deploy this
2. Land and deploy rewiringamerica/embed.rewiringamerica.org#156
3. Land and deploy a PEP PR which is yet to come, similar to the embed one above (read from new field if available; fall back to existing one if not)
4. Update the backend to stop including the old single-valued field in responses.
5. Remove the support for the old field from the embed and PEP code
6. Start updating the underlying data, this getting rid of the "synthesize `items`" bit from this PR.

I decided to ditch the human-friendly `name`. It was a holdover from
v0, in which it was used to populate the table UIs of the old IRA and
embed calculators. It's too frontend-coupled to make total sense in
v1, and neither PEP nor the new embed calculator use it, so it's gone.

Throughout this I don't expect to proactively inform any external API
clients of the changes, and certainly not to block on them. I believe
anyone we've given v1 to has been warned that v1 will break without
notice.

## Test Plan

`yarn test` with updated fixtures. Tested the embed frontend from the
above PR against this state running locally.
