### PR TITLE
Identify counties by FIPS code, not by name

### DIFF
--- a/data/CA/authorities.json
+++ b/data/CA/authorities.json
@@ -10,39 +10,39 @@
   "county": {
     "ca-alameda-county": {
       "name": "Alameda County",
-      "county": "Alameda"
+      "county_fips": "06001"
     },
     "ca-contra-costa-county": {
       "name": "Contra Costa County",
-      "county": "Contra Costa"
+      "county_fips": "06013"
     },
     "ca-marin-county": {
       "name": "Marin County",
-      "county": "Marin"
+      "county_fips": "06041"
     },
     "ca-napa-county": {
       "name": "Napa County",
-      "county": "Napa"
+      "county_fips": "06055"
     },
     "ca-san-francisco-county": {
       "name": "San Francisco County",
-      "county": "San Francisco"
+      "county_fips": "06074"
     },
     "ca-san-mateo-county": {
       "name": "San Mateo County",
-      "county": "San Mateo"
+      "county_fips": "06081"
     },
     "ca-santa-clara-county": {
       "name": "Santa Clara County",
-      "county": "Santa Clara"
+      "county_fips": "06085"
     },
     "ca-solano-county": {
       "name": "Solano County",
-      "county": "Solano"
+      "county_fips": "06095"
     },
     "ca-sonoma-county": {
       "name": "Sonoma County",
-      "county": "Sonoma"
+      "county_fips": "06097"
     }
   },
   "other": {

--- a/data/CO/authorities.json
+++ b/data/CO/authorities.json
@@ -3,41 +3,41 @@
     "co-city-of-boulder": {
       "name": "City of Boulder",
       "city": "Boulder",
-      "county": "Boulder"
+      "county_fips": "08013"
     },
     "co-town-of-avon": {
       "name": "Town of Avon",
       "city": "Avon",
-      "county": "Eagle"
+      "county_fips": "08037"
     },
     "co-town-of-eagle": {
       "name": "Town of Eagle",
       "city": "Eagle",
-      "county": "Eagle"
+      "county_fips": "08037"
     },
     "co-town-of-erie": {
       "name": "Town of Erie",
       "city": "Erie",
-      "county": "Weld"
+      "county_fips": "08123"
     },
     "co-town-of-vail": {
       "name": "Town of Vail",
       "city": "Vail",
-      "county": "Eagle"
+      "county_fips": "08037"
     }
   },
   "county": {
     "co-city-and-county-of-denver": {
       "name": "City and County of Denver",
-      "county": "Denver"
+      "county_fips": "08031"
     },
     "co-boulder-county": {
       "name": "Boulder County",
-      "county": "Boulder"
+      "county_fips": "08013"
     },
     "co-unincorporated-eagle-county": {
       "name": "Unincorporated Eagle County",
-      "county": "Eagle"
+      "county_fips": "08037"
     }
   },
   "other": {

--- a/data/DC/authorities.json
+++ b/data/DC/authorities.json
@@ -3,7 +3,7 @@
     "dc-dc-sustainable-energy-utility": {
       "name": "DC Sustainable Energy Utility",
       "city": "Washington",
-      "county": "District of Columbia"
+      "county_fips": "11001"
     }
   },
   "state": {

--- a/data/IL/authorities.json
+++ b/data/IL/authorities.json
@@ -3,7 +3,7 @@
     "il-evanston-development-cooperative": {
       "name": "Evanston Development Cooperative ",
       "city": "Evanston",
-      "county": "Cook"
+      "county_fips": "17031"
     }
   },
   "state": {

--- a/data/NV/authorities.json
+++ b/data/NV/authorities.json
@@ -47,84 +47,84 @@
   "county": {
     "nv-washoe-county": {
       "name": "Washoe County",
-      "county": "Washoe"
+      "county_fips": "32031"
     },
     "nv-churchill-county": {
       "name": "Churchill County",
-      "county": "Churchill"
+      "county_fips": "32001"
     },
     "nv-douglas-county": {
       "name": "Douglas County",
-      "county": "Douglas"
+      "county_fips": "32005"
     },
     "nv-lyon-county": {
       "name": "Lyon County",
-      "county": "Lyon"
+      "county_fips": "32019"
     },
     "nv-storey-county": {
       "name": "Storey County",
-      "county": "Storey"
+      "county_fips": "32029"
     },
     "nv-elko-county": {
       "name": "Elko County",
-      "county": "Elko"
+      "county_fips": "32007"
     },
     "nv-esmeralda-county": {
       "name": "Esmeralda County",
-      "county": "Esmeralda"
+      "county_fips": "32009"
     },
     "nv-eureka-county": {
       "name": "Eureka County",
-      "county": "Eureka"
+      "county_fips": "32011"
     },
     "nv-humboldt-county": {
       "name": "Humboldt County",
-      "county": "Humboldt"
+      "county_fips": "32013"
     },
     "nv-lander-county": {
       "name": "Lander County",
-      "county": "Lander"
+      "county_fips": "32015"
     },
     "nv-lincoln-county": {
       "name": "Lincoln County",
-      "county": "Lincoln"
+      "county_fips": "32017"
     },
     "nv-mineral-county": {
       "name": "Mineral County",
-      "county": "Mineral"
+      "county_fips": "32021"
     },
     "nv-nye-county": {
       "name": "Nye County",
-      "county": "Nye"
+      "county_fips": "32023"
     },
     "nv-pershing-county": {
       "name": "Pershing County",
-      "county": "Pershing"
+      "county_fips": "32027"
     },
     "nv-white-pine-county": {
       "name": "White Pine County",
-      "county": "White Pine"
+      "county_fips": "32033"
     },
     "nv-carson-city-county": {
       "name": "Carson City County",
-      "county": "Carson City"
+      "county_fips": "32510"
     }
   },
   "city": {
     "nv-city-of-las-vegas": {
       "name": "City of Las Vegas",
       "city": "Las Vegas",
-      "county": "Clark"
+      "county_fips": "32003"
     },
     "nv-city-of-henderson": {
       "name": "City of Henderson",
       "city": "Henderson",
-      "county": "Clark"
+      "county_fips": "32003"
     },
     "nv-city-of-north-las-vegas": {
       "name": "City of North Las Vegas",
       "city": "North Las Vegas",
-      "county": "Clark"
+      "county_fips": "32003"
     }
   },
   "other": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,33 +36,35 @@ Filling out an entry for `incentive-spreadsheet-registry.ts` consists of creatin
 - Optionally declaring the header row number, if not the top row of the spreadsheet, in `headerRowNumber`
 - Optionally naming a filepath where _collected_ incentives will be written in `collectedFilepath`. We recommend using `data/<state_id>/collected.json`. This is experimental and also requires some setup to authenticate with the Google API. See [JSON To Spreadsheet](#json-to-spreadsheet) for more details before proceeding.
 
-First, look at the `authorities.json` in your state's subdirectory of `data/`. The state's utilities are populated there, by the script `generate-utility-data.ts`. Follow the [instructions below](#utility-data) to vet the utility data, and update/rerun the script to clean up the utility data as appropriate.
+1. First, look at the `authorities.json` in your state's subdirectory of `data/`. The state's utilities are populated there, by the script `generate-utility-data.ts`. Follow the [instructions below](#utility-data) to vet the utility data, and update/rerun the script to clean up the utility data as appropriate.
 
-[`generate-misc-state-data.ts`](generate-misc-state-data.ts) adds values to ancillary files to reflect the programs and authorities that will be needed for the JSON. This needs to happen first because our data schemas actually require an incentive's program/authority to be one of the listed members, and if that's not the case, the incentive will fail validation.
+2. [`generate-misc-state-data.ts`](generate-misc-state-data.ts) adds values to ancillary files to reflect the programs and authorities that will be needed for the JSON. This needs to happen first because our data schemas actually require an incentive's program/authority to be one of the listed members, and if that's not the case, the incentive will fail validation.
 
-This script covers:
+   This script covers:
 
-- data/authorities.json
-- src/data/programs.ts
+   - `data/<state>/authorities.json`
+   - `src/data/programs.ts`
 
-Usage:
-`node build/scripts/generate-misc-state-data.js <state_id>`
+   Usage:
+   `node build/scripts/generate-misc-state-data.js <state_id>`
 
-It's recommended to also define low-income thresholds in `data/low_income_thresholds.json` and geo groups in `data/geo_groups.json` for your state to save time in the next step.
+   If the state has city- or county-level incentives, you will need to add `city` and `county_fips` keys (respectively) to the entries that get generated in the state's `authorities.json`. This is what lets the runtime code know which authority applies to the user's actual location. `city` values have to match `zips.city` in the SQLite database. `county_fips` must be a county FIPS code ([list here](https://transition.fcc.gov/oet/info/maps/census/fips/fips.txt)).
 
-1. [`incentive-spreadsheet-to-json.ts`](incentive-spreadsheet-to-json.ts) reads the spreadsheet and tries to convert it to JSON. This can be a messy process – spreadsheets may not have the correct column names or values. The script tries to handle small string discrepancies itself because making edits to Google sheets has a 5-minute delay before changes are reflected, but ultimately even with the script's help, this may be a painstaking process.
+   It's recommended to also define low-income thresholds in `data/low_income_thresholds.json` and geo groups in `data/geo_groups.json` for your state to save time in the next step.
 
-Usage:
-`node build/scripts/incentive-spreadsheet-to-json.js --strict CO`
+3. [`incentive-spreadsheet-to-json.ts`](incentive-spreadsheet-to-json.ts) reads the spreadsheet and tries to convert it to JSON. This can be a messy process – spreadsheets may not have the correct column names or values. The script tries to handle small string discrepancies itself because making edits to Google sheets has a 5-minute delay before changes are reflected, but ultimately even with the script's help, this may be a painstaking process.
 
-`--strict` is recommended since it will throw an error for any misnamed columns. You can correct these or errors in cell values by remapping them: use the [spreadsheet-mappings](lib/spreadsheet-mappings.ts) file.
+   Usage:
+   `node build/scripts/incentive-spreadsheet-to-json.js --strict CO`
 
-All valid records according to our schema will be written to the location you specified in the [incentive-spreadsheet-registry.ts](incentive-spreadsheet-registry.ts). Invalid records will be in an adjacent file with the suffix `_invalid.json`. There should be a rationale for the invalidation in the `errors` key to help you fix it. It may require multiple passes to get all JSON records produced.
+   `--strict` is recommended since it will throw an error for any misnamed columns. You can correct these or errors in cell values by remapping them: use the [spreadsheet-mappings](lib/spreadsheet-mappings.ts) file.
 
-Note that even after running these, there are still files you must edit manually to get the JSON in. Follow a recent CL example.
-Eg: https://github.com/rewiringamerica/api.rewiringamerica.org/pull/209/files
+   All valid records according to our schema will be written to the location you specified in the [incentive-spreadsheet-registry.ts](incentive-spreadsheet-registry.ts). Invalid records will be in an adjacent file with the suffix `_invalid.json`. There should be a rationale for the invalidation in the `errors` key to help you fix it. It may require multiple passes to get all JSON records produced.
 
-To encode relationships between incentives, see the [`relationships-README`](https://github.com/rewiringamerica/api.rewiringamerica.org/blob/main/docs/relationships-README.md).
+   Note that even after running these, there are still files you must edit manually to get the JSON in. Follow a recent CL example.
+   Eg: https://github.com/rewiringamerica/api.rewiringamerica.org/pull/209/files
+
+   To encode relationships between incentives, see the [`relationships-README`](https://github.com/rewiringamerica/api.rewiringamerica.org/blob/main/docs/relationships-README.md).
 
 ## JSON to Spreadsheet
 

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -32,7 +32,7 @@ export const API_AUTHORITY_SCHEMA = {
     name: { type: 'string' },
     logo: API_IMAGE_SCHEMA,
     city: { type: 'string' },
-    county: { type: 'string' },
+    county_fips: { type: 'string' },
   },
   required: ['name'],
   additionalProperties: false,

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -344,8 +344,13 @@ export default function calculateIncentives(
   if (stateAuthorities) {
     incentives.forEach(i => {
       if ('authority' in i && i.authority && i.authority_type !== 'federal') {
-        authorities[i.authority] =
-          stateAuthorities[i.authority_type]![i.authority];
+        // Just return the name and logo; omit stuff that specifies location
+        // since it's not part of the public API.
+        authorities[i.authority] = _.pick(
+          stateAuthorities[i.authority_type]![i.authority],
+          'name',
+          'logo',
+        );
       }
     });
   }
@@ -365,7 +370,6 @@ export default function calculateIncentives(
     location: {
       state: state_id,
       city: location.city,
-      county: location.county,
     },
     savings,
     incentives: sortedIncentives,

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -273,11 +273,11 @@ function skipBasedOnRequestParams(
   // tracks long-term work in this space.
   if (item.authority_type === AuthorityType.County) {
     // Skip if we didn't get location data.
-    if (location.county === undefined) return true;
+    if (location.countyFips === undefined) return true;
 
     // We have tests to ensure county authorities are registered.
     const authorityDetails = stateAuthorities.county![item.authority];
-    if (authorityDetails.county !== location.county) {
+    if (authorityDetails.county_fips !== location.countyFips) {
       return true;
     }
   }
@@ -287,7 +287,7 @@ function skipBasedOnRequestParams(
     // municipalities can have the same name within the same state.
 
     // Skip if we didn't get location data.
-    if (location.city === undefined || location.county === undefined) {
+    if (location.city === undefined || location.countyFips === undefined) {
       return true;
     }
 
@@ -296,7 +296,7 @@ function skipBasedOnRequestParams(
 
     if (
       authorityDetails.city !== location.city ||
-      authorityDetails.county !== location.county
+      authorityDetails.county_fips !== location.countyFips
     ) {
       return true;
     }
@@ -311,10 +311,10 @@ function skipBasedOnRequestParams(
       (group.utilities &&
         (!request.utility || !group.utilities.includes(request.utility))) ||
       (group.counties &&
-        (!location.county ||
+        (!location.countyFips ||
           !group.counties
-            .map(id => stateAuthorities.county[id].county)
-            .includes(location.county))) ||
+            .map(id => stateAuthorities.county[id].county_fips)
+            .includes(location.countyFips))) ||
       (group.cities &&
         (!location.city ||
           !group.cities

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -199,15 +199,15 @@ test('state incentives JSON files match schemas', async tap => {
       if (incentive.authority_type === AuthorityType.County) {
         tap.hasProp(
           authorities[incentive.authority_type]![incentive.authority],
-          'county',
-          `must define county attribute on corresponding authority ${incentive.authority} for incentives with county authority type`,
+          'county_fips',
+          `must define county_fips attribute on corresponding authority ${incentive.authority} for incentives with county authority type`,
         );
       }
       if (incentive.authority_type === AuthorityType.City) {
         tap.hasProp(
           authorities[incentive.authority_type]![incentive.authority],
-          'county',
-          `must define county attribute on corresponding authority ${incentive.authority} for incentives with city authority type (county is used for matching)`,
+          'county_fips',
+          `must define county_fips attribute on corresponding authority ${incentive.authority} for incentives with city authority type (county is used for matching)`,
         );
         tap.hasProp(
           authorities[incentive.authority_type]![incentive.authority],

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -16,8 +16,7 @@
   },
   "location": {
     "state": "IL",
-    "city": "Oak Park",
-    "county": "Cook"
+    "city": "Oak Park"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -18,8 +18,7 @@
   },
   "location": {
     "state": "RI",
-    "city": "Block Island",
-    "county": "Washington"
+    "city": "Block Island"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -32,8 +32,7 @@
   },
   "location": {
     "state": "RI",
-    "city": "Providence",
-    "county": "Providence"
+    "city": "Providence"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-15289-homeowner-85000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-85000-joint-4.json
@@ -16,8 +16,7 @@
   },
   "location": {
     "state": "PA",
-    "city": "Pittsburgh",
-    "county": "Allegheny"
+    "city": "Pittsburgh"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -16,8 +16,7 @@
   },
   "location": {
     "state": "CO",
-    "city": "Estes Park",
-    "county": "Larimer"
+    "city": "Estes Park"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "CO",
-    "city": "Estes Park",
-    "county": "Larimer"
+    "city": "Estes Park"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-84106-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-84106-homeowner-80000-joint-4.json
@@ -9,8 +9,7 @@
   },
   "location": {
     "state": "UT",
-    "city": "Salt Lake City",
-    "county": "Salt Lake"
+    "city": "Salt Lake City"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "AZ",
-    "city": "Tucson",
-    "county": "Pima"
+    "city": "Tucson"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "AZ",
-    "city": "Tucson",
-    "county": "Pima"
+    "city": "Tucson"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -25,8 +25,7 @@
   },
   "location": {
     "state": "CO",
-    "city": "Vail",
-    "county": "Eagle"
+    "city": "Vail"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -16,8 +16,7 @@
   },
   "location": {
     "state": "CT",
-    "city": "Bloomfield",
-    "county": "Hartford"
+    "city": "Bloomfield"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -4,9 +4,7 @@
   "is_over_150_ami": false,
   "authorities": {
     "dc-dc-sustainable-energy-utility": {
-      "name": "DC Sustainable Energy Utility",
-      "city": "Washington",
-      "county": "District of Columbia"
+      "name": "DC Sustainable Energy Utility"
     },
     "dc-dc-department-of-energy-and-environment": {
       "name": "DC Department of Energy and Environment"
@@ -18,8 +16,7 @@
   },
   "location": {
     "state": "DC",
-    "city": "Washington",
-    "county": "District of Columbia"
+    "city": "Washington"
   },
   "data_partners": {
     "dc-electrify-dc": {

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "GA",
-    "city": "Decatur",
-    "county": "DeKalb"
+    "city": "Decatur"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-il-60202-city-lowincome.json
+++ b/test/fixtures/v1-il-60202-city-lowincome.json
@@ -4,9 +4,7 @@
   "is_over_150_ami": false,
   "authorities": {
     "il-evanston-development-cooperative": {
-      "name": "Evanston Development Cooperative ",
-      "city": "Evanston",
-      "county": "Cook"
+      "name": "Evanston Development Cooperative "
     }
   },
   "coverage": {
@@ -15,8 +13,7 @@
   },
   "location": {
     "state": "IL",
-    "city": "Evanston",
-    "county": "Cook"
+    "city": "Evanston"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "MI",
-    "city": "Ann Arbor",
-    "county": "Washtenaw"
+    "city": "Ann Arbor"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-mi-48825-city-lowincome.json
+++ b/test/fixtures/v1-mi-48825-city-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "MI",
-    "city": "East Lansing",
-    "county": "Ingham"
+    "city": "East Lansing"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "NV",
-    "city": "Las Vegas",
-    "county": "Clark"
+    "city": "Las Vegas"
   },
   "data_partners": {
     "nv-nevada-clean-energy-fund": {

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -19,8 +19,7 @@
   },
   "location": {
     "state": "NY",
-    "city": "Hewlett",
-    "county": "Nassau"
+    "city": "Hewlett"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-or-97001-state-lowincome.json
+++ b/test/fixtures/v1-or-97001-state-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "OR",
-    "city": "Antelope",
-    "county": "Wasco"
+    "city": "Antelope"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-pa-17555-state-lowincome.json
+++ b/test/fixtures/v1-pa-17555-state-lowincome.json
@@ -19,8 +19,7 @@
   },
   "location": {
     "state": "PA",
-    "city": "Narvon",
-    "county": "Lancaster"
+    "city": "Narvon"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "VA",
-    "city": "Fairfax",
-    "county": "Fairfax"
+    "city": "Fairfax"
   },
   "data_partners": {},
   "incentives": [

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -19,8 +19,7 @@
   },
   "location": {
     "state": "VT",
-    "city": "Burlington",
-    "county": "Chittenden"
+    "city": "Burlington"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/fixtures/v1-vt-05845-vec-ev-low-income.json
+++ b/test/fixtures/v1-vt-05845-vec-ev-low-income.json
@@ -16,8 +16,7 @@
   },
   "location": {
     "state": "VT",
-    "city": "Irasburg",
-    "county": "Orleans"
+    "city": "Irasburg"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -13,8 +13,7 @@
   },
   "location": {
     "state": "WI",
-    "city": "Madison",
-    "county": "Dane"
+    "city": "Madison"
   },
   "data_partners": {},
   "incentives": [

--- a/test/lib/ami-evcredit-calculation.test.ts
+++ b/test/lib/ami-evcredit-calculation.test.ts
@@ -23,28 +23,28 @@ const AS_LOCATION: ResolvedLocation = {
   zcta: '96799',
   state: 'AS',
   city: 'Pago Pago',
-  county: 'Western',
+  countyFips: '60010',
   tractGeoid: '60010950600',
 };
 const GU_LOCATION: ResolvedLocation = {
   zcta: '96913',
   state: 'GU',
   city: 'Barrigada',
-  county: 'Guam',
+  countyFips: '66010',
   tractGeoid: '66010951100',
 };
 const MP_LOCATION: ResolvedLocation = {
   zcta: '96950',
   state: 'MP',
   city: 'Saipan',
-  county: 'Saipan',
+  countyFips: '69110',
   tractGeoid: '69110001700',
 };
 const VI_LOCATION: ResolvedLocation = {
   zcta: '00840',
   state: 'VI',
   city: 'Frederiksted',
-  county: 'St. Croix',
+  countyFips: '78010',
   tractGeoid: '78010971000',
 };
 
@@ -75,7 +75,7 @@ test('territories other than PR', async t => {
 const NY_TRACT = '36099950200';
 const NY_LOCATION: ResolvedLocation = {
   city: 'Seneca Falls',
-  county: 'Seneca',
+  countyFips: '36099',
   state: 'NY',
   zcta: '13148',
 };
@@ -83,7 +83,7 @@ const NY_LOCATION: ResolvedLocation = {
 const DC_TRACT = '11001010700';
 const DC_LOCATION: ResolvedLocation = {
   city: 'Washington',
-  county: 'District of Columbia',
+  countyFips: '11001',
   state: 'DC',
   zcta: '20036',
 };
@@ -91,7 +91,7 @@ const DC_LOCATION: ResolvedLocation = {
 const PR_TRACT = '72127002100';
 const PR_LOCATION: ResolvedLocation = {
   city: 'San Juan',
-  county: 'San Juan',
+  countyFips: '72127',
   state: 'PR',
   zcta: '00907',
 };
@@ -166,7 +166,7 @@ test('EV charger eligibility', async t => {
     zcta: '11211',
     state: 'NY',
     city: 'Brooklyn',
-    county: 'Kings',
+    countyFips: '36047',
   };
   t.notOk(
     (await computeAMIAndEVCreditEligibility(db, brooklyn, 4))!.evCreditEligible,

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -19,7 +19,7 @@ const LOCATION: ResolvedLocation = {
   state: 'RI',
   zcta: '02903',
   city: 'Providence',
-  county: 'Providence County',
+  countyFips: '44007',
 };
 
 // This is a basic test to set up supplying test data to the calculator logic.

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -14,7 +14,7 @@ import { calculateStateIncentivesAndSavings } from '../../src/lib/state-incentiv
 
 const LOCATION_AND_AMIS = {
   '11211': [
-    { zcta: '11211', city: 'Brooklyn', state: 'NY', county: 'Kings' },
+    { zcta: '11211', city: 'Brooklyn', state: 'NY', countyFips: '36047' },
     { computedAMI80: 87080, computedAMI150: 163065, evCreditEligible: false },
   ],
   '94117': [
@@ -22,20 +22,20 @@ const LOCATION_AND_AMIS = {
       zcta: '94117',
       city: 'San Francisco',
       state: 'CA',
-      county: 'San Francisco',
+      countyFips: '06075',
     },
     { computedAMI80: 156650, computedAMI150: 293700, evCreditEligible: false },
   ],
   '39503': [
-    { zcta: '39503', city: 'Gulfport', state: 'MS', county: 'Harrison' },
+    { zcta: '39503', city: 'Gulfport', state: 'MS', countyFips: '28047' },
     { computedAMI80: 80256, computedAMI150: 150480, evCreditEligible: false },
   ],
   '02861': [
-    { zcta: '02861', city: 'Pawtucket', state: 'RI', county: 'Providence' },
+    { zcta: '02861', city: 'Pawtucket', state: 'RI', countyFips: '44007' },
     { computedAMI80: 62930, computedAMI150: 118020, evCreditEligible: false },
   ],
   '06002': [
-    { zcta: '06002', city: 'Bloomfield', state: 'CT', county: 'Hartford' },
+    { zcta: '06002', city: 'Bloomfield', state: 'CT', countyFips: '09003' },
     { computedAMI80: 68215, computedAMI150: 127890, evCreditEligible: false },
   ],
 } as const;
@@ -528,7 +528,7 @@ test('correct filtering of county incentives', async t => {
     county: {
       'mock-county-authority': {
         name: 'The Mock Authority Company',
-        county: 'Cook',
+        county_fips: '99999',
       },
     },
   };
@@ -542,7 +542,7 @@ test('correct filtering of county incentives', async t => {
     include_beta_states: true,
   };
   const shouldFind = calculateStateIncentivesAndSavings(
-    { state: 'CO', county: 'Cook', city: 'Asdf', zcta: '00000' },
+    { state: 'CO', countyFips: '99999', city: 'Asdf', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -552,7 +552,7 @@ test('correct filtering of county incentives', async t => {
   t.equal(shouldFind.stateIncentives.length, 1);
 
   const shouldNotFind = calculateStateIncentivesAndSavings(
-    { state: 'CO', county: 'Nomatch', city: 'Asdf', zcta: '00000' },
+    { state: 'CO', countyFips: '11111', city: 'Asdf', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -591,7 +591,7 @@ test('correct filtering of city incentives', async t => {
       'mock-city-authority': {
         name: 'The Mock Authority Company',
         city: 'New York',
-        county: 'Cook',
+        county_fips: '99999',
       },
     },
   };
@@ -605,7 +605,7 @@ test('correct filtering of city incentives', async t => {
     include_beta_states: true,
   };
   const shouldFind = calculateStateIncentivesAndSavings(
-    { state: 'CO', city: 'New York', county: 'Cook', zcta: '00000' },
+    { state: 'CO', city: 'New York', countyFips: '99999', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -615,7 +615,7 @@ test('correct filtering of city incentives', async t => {
   t.equal(shouldFind.stateIncentives.length, 1);
 
   const shouldNotFindWithPartialMatch = calculateStateIncentivesAndSavings(
-    { state: 'CO', city: 'New York', county: 'NoMatch', zcta: '00000' },
+    { state: 'CO', city: 'New York', countyFips: '11111', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -654,7 +654,7 @@ test('correctly evaluates savings when state tax liability is lower than max sav
       'mock-state-authority': {
         name: 'Colorado Mock Department of Energy',
         city: 'Colorado Springs',
-        county: 'El Paso County',
+        county_fips: '11111',
       },
     },
   };
@@ -672,7 +672,7 @@ test('correctly evaluates savings when state tax liability is lower than max sav
     {
       state: 'CO',
       city: 'Colorado Springs',
-      county: 'El Paso County',
+      countyFips: '11111',
       zcta: '80903',
     },
     request,


### PR DESCRIPTION
## Description

Our zips data identifies counties just by their name, e.g. `Suffolk`.
Geocodio identifies them like `Suffolk County`. This would cause
problems for county-level incentives, which need the location's county
to match the county name in `authorities.json`.

It's not trivial to adapt one format into the other (the second word
isn't always "County"; you can't just chop off the last word of the
Geocodio value; etc.) so instead, let's identify counties using a
consistent non-human-friendly identifier.

One other little advantage of the FIPS code is that the first five
digits of a tract ID are the county's FIPS code. We're not making use
of this fact yet, but it may come in handy.

Two concurrent minor changes:

- I removed the county name from the `location` object returned in the
  API, since we're not passing the county name around anymore. We
  could add it back in, but neither the embed nor PEP uses it anyway,
  so I'm thinking that can wait until it's needed.

- I made it so that the `authorities` object in the API response only
  contains names and logos, not the other bits that specify the
  authority's geographic scope. Those aren't part of the public API,
  and I'd rather not let them become so. (Embed and PEP are not using
  them.)

I used this document to manually convert existing county names (it
doesn't have territories, but I just got those from the tract IDs):
https://transition.fcc.gov/oet/info/maps/census/fips/fips.txt

## Test Plan

`yarn test`
