### PR TITLE
Update CO EO incentive - remove erroneous space

### DIFF
--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -7584,7 +7584,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "At least  $999.90 discount for ENERGY STAR & AHRI certified system. Available through registered contractors.",
+      "en": "At least $999.90 discount for ENERGY STAR & AHRI certified system. Available through registered contractors.",
       "es": "Al menos $999.90 de descuento para sistemas certificados por ENERGY STAR y AHRI. Disponible a través de contratistas registrados."
     },
     "start_date": "2024-01-01",
@@ -7607,7 +7607,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "At least  $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors.",
+      "en": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors.",
       "es": "Al menos $166.65 de descuento para sistemas certificados por ENERGY STAR y AHRI. Disponible a través de contratistas registrados."
     },
     "start_date": "2024-01-01",

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -49,7 +49,7 @@
       "end_date": "2024-12-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "At least  $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
+      "short_description": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
       "payment_methods": [

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -46,7 +46,7 @@
       "end_date": "2024-12-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "At least  $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
+      "short_description": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
       "payment_methods": [

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -298,7 +298,7 @@
       "end_date": "2024-12-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "At least  $999.90 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
+      "short_description": "At least $999.90 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
       "payment_methods": [
@@ -354,7 +354,7 @@
       "end_date": "2024-12-31",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "At least  $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
+      "short_description": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
       "payment_methods": [


### PR DESCRIPTION
Update CO EO incentive - remove erroneous space
I recently merged in https://github.com/rewiringamerica/api.rewiringamerica.org/pull/452, which contained an extra space. This fixes the issue. 
