### PR TITLE
Add more items to the schema

### DIFF
--- a/src/data/ira_incentives.ts
+++ b/src/data/ira_incentives.ts
@@ -6,7 +6,7 @@ import { PROGRAMS } from './programs';
 import { FilingStatus } from './tax_brackets';
 import { AMOUNT_SCHEMA, Amount } from './types/amount';
 import { PaymentMethod } from './types/incentive-types';
-import { ALL_ITEMS, Item } from './types/items';
+import { IRAItem, IRA_ITEMS } from './types/items';
 import { LocalizableString } from './types/localizable-string';
 import { OwnerStatus } from './types/owner-status';
 
@@ -24,7 +24,7 @@ export interface IRAIncentive {
   authority_type: AuthorityType.Federal;
   end_date: string;
   filing_status?: FilingStatus;
-  item: Item;
+  item: IRAItem;
   owner_status: OwnerStatus[];
   program: string;
   start_date: string;
@@ -64,7 +64,7 @@ export const SCHEMA: JSONSchemaType<IRAIncentive[]> = {
       },
       program: { type: 'string', enum: Object.keys(PROGRAMS) },
       authority_type: { type: 'string', const: AuthorityType.Federal },
-      item: { type: 'string', enum: ALL_ITEMS },
+      item: { type: 'string', enum: IRA_ITEMS },
       amount: AMOUNT_SCHEMA,
       owner_status: {
         type: 'array',

--- a/src/data/locale.ts
+++ b/src/data/locale.ts
@@ -4,7 +4,7 @@ import {
   ALL_ERROR_MESSAGES,
   ERROR_MESSAGES_SCHEMA,
 } from './types/error-message';
-import { ALL_ITEMS, ITEMS_SCHEMA } from './types/items';
+import { IRA_ITEMS, ITEMS_SCHEMA } from './types/items';
 
 export const SCHEMA = {
   type: 'object',
@@ -12,12 +12,13 @@ export const SCHEMA = {
     items: {
       type: 'object',
       properties: ITEMS_SCHEMA,
-      required: ALL_ITEMS,
+      required: IRA_ITEMS,
       additionalProperties: false,
     },
     urls: {
       type: 'object',
       properties: ITEMS_SCHEMA,
+      required: IRA_ITEMS,
       additionalProperties: false,
     },
     errors: {

--- a/src/data/types/items.ts
+++ b/src/data/types/items.ts
@@ -4,7 +4,18 @@
  */
 
 export const ITEMS_SCHEMA = {
+  air_sealing: { type: 'string' },
+  air_to_water_heat_pump: { type: 'string' },
+  attic_or_roof_insulation: { type: 'string' },
+  basement_insulation: { type: 'string' },
   battery_storage_installation: { type: 'string' },
+  central_air_conditioner: { type: 'string' },
+  crawlspace_insulation: { type: 'string' },
+  door_replacement: { type: 'string' },
+  duct_replacement: { type: 'string' },
+  duct_sealing: { type: 'string' },
+  ducted_heat_pump: { type: 'string' },
+  ductless_heat_pump: { type: 'string' },
   ebike: { type: 'string' },
   efficiency_rebates: { type: 'string' },
   electric_outdoor_equipment: { type: 'string' },
@@ -13,22 +24,51 @@ export const ITEMS_SCHEMA = {
   electric_thermal_storage_and_slab: { type: 'string' },
   electric_vehicle_charger: { type: 'string' },
   electric_wiring: { type: 'string' },
+  energy_audit: { type: 'string' },
   evaporative_cooler: { type: 'string' },
+  floor_insulation: { type: 'string' },
   geothermal_heating_installation: { type: 'string' },
-  heat_pump_air_conditioner_heater: { type: 'string' },
+  heat_pump_air_conditioner_heater: { type: 'string' }, // TODO remove
   heat_pump_clothes_dryer: { type: 'string' },
   heat_pump_water_heater: { type: 'string' },
   new_electric_vehicle: { type: 'string' },
+  new_plugin_hybrid_vehicle: { type: 'string' },
   non_heat_pump_clothes_dryer: { type: 'string' },
   non_heat_pump_water_heater: { type: 'string' },
   other: { type: 'string' },
+  other_heat_pump: { type: 'string' },
+  other_insulation: { type: 'string' },
+  other_weatherization: { type: 'string' },
   rooftop_solar_installation: { type: 'string' },
   smart_thermostat: { type: 'string' },
   used_electric_vehicle: { type: 'string' },
-  weatherization: { type: 'string' },
+  used_plugin_hybrid_vehicle: { type: 'string' },
+  wall_insulation: { type: 'string' },
+  weatherization: { type: 'string' }, // TODO remove
   whole_house_fan: { type: 'string' },
+  window_replacement: { type: 'string' },
 } as const;
 
 export type Item = keyof typeof ITEMS_SCHEMA;
+
+/** Only these items appear in the IRA incentives (and thus in API v0). */
+export const IRA_ITEMS = [
+  'battery_storage_installation',
+  'efficiency_rebates',
+  'electric_panel',
+  'electric_stove',
+  'electric_vehicle_charger',
+  'electric_wiring',
+  'geothermal_heating_installation',
+  'heat_pump_air_conditioner_heater',
+  'heat_pump_clothes_dryer',
+  'heat_pump_water_heater',
+  'new_electric_vehicle',
+  'rooftop_solar_installation',
+  'used_electric_vehicle',
+  'weatherization',
+] as const satisfies readonly Item[];
+
+export type IRAItem = (typeof IRA_ITEMS)[number];
 
 export const ALL_ITEMS = Object.keys(ITEMS_SCHEMA) as unknown as Item[];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -4,12 +4,15 @@ import { LocalizableString } from '../data/types/localizable-string';
 // FIXME: if we get tempted to start optimizing this, use a real i18n library
 // looked at fastify-polyglot but it didn't have good docs on switching locale
 
-export function t<TCategory extends keyof Locale>(
+export function t<
+  TCategory extends keyof Locale,
+  TKey extends keyof Locale[TCategory],
+>(
   category: TCategory,
-  key: keyof Locale[TCategory],
+  key: TKey,
   locale: keyof typeof LOCALES = 'en',
-): string {
-  return (LOCALES[locale][category] as { [k: string]: string })[key as string];
+): Locale[TCategory][TKey] {
+  return LOCALES[locale][category][key];
 }
 
 export function tr(


### PR DESCRIPTION
## Description

This does not actually change any of the incentive data; just adds new
granular items to the schema.

I think this will be the best place to discuss the editorial matter of
exactly which items to add. Some of the decisions I made:

- I added `other_heat_pump` as a catchall for heat pump-like devices
  that don't fall under `ducted_heat_pump`, `ductless_heat_pump`,
  `central_air_conditioner`, `air_to_water_heat_pump`, or
  `geothermal_heating_installation`. I don't know if such a thing
  really exists, or if it does whether we care to include it in the API?

  - Note that my plan is to deprecate
    `heat_pump_air_conditioner_heater`, rather than use it as the catchall.

- I also added (a) `other_insulation` and (b) `other_weatherization`.
  Respectively, these are for (a) insulation that isn't covered by one
  of the many granular categories I added; and (b) any weatherization
  measure that is not insulation and is not covered by one of the
  granular non-insulation measures. Similar to above, my plan is to
  deprecate `weatherization` rather than use it as the catchall.

- I added `{new,used}_plugin_hybrid_vehicle`. We've seen several
  incentives for thesespecifically, and I think it's worth splitting
  them out from `{new,used}_electric_vehicle`. The latter will become
  pure-EV only.

On the side, I made it so that human-friendly names and URLs are only
required for the items that appear in the IRA incentives (since
they're only needed in API v0).
