### PR TITLE
Update Spanish URLs for IRA incentives

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -25,7 +25,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/instalacion-de-baterias"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25d-battery-storage-tax-credit"
     }
   },
   {
@@ -54,7 +54,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/instalacion-de-calefaccion-geotermica"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit"
     }
   },
   {
@@ -82,7 +82,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25c-electrical-panel-tax-credits"
     }
   },
   {
@@ -110,7 +110,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -138,7 +138,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -167,7 +167,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/estufa-electrica"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -196,7 +196,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/estufa-electrica"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -224,7 +224,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -252,7 +252,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -281,7 +281,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/ve-cargador"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/30c-ev-charger-tax-credit"
     }
   },
   {
@@ -312,7 +312,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/30d-new-ev-tax-incentive"
     }
   },
   {
@@ -343,7 +343,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/30d-new-ev-tax-incentive"
     }
   },
   {
@@ -374,7 +374,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/30d-new-ev-tax-incentive"
     }
   },
   {
@@ -405,7 +405,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/30d-new-ev-tax-incentive"
     }
   },
   {
@@ -436,7 +436,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25e-used-ev-tax-incentive"
     }
   },
   {
@@ -467,7 +467,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25e-used-ev-tax-incentive"
     }
   },
   {
@@ -498,7 +498,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25e-used-ev-tax-incentive"
     }
   },
   {
@@ -529,7 +529,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/vehiculo-electrico"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25e-used-ev-tax-incentive"
     }
   },
   {
@@ -557,7 +557,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-aire-acondicionado-calentador"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25c-heat-pump-tax-credits"
     }
   },
   {
@@ -585,7 +585,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-calentador-de-agua"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25c-heat-pump-water-heater-tax-credits"
     }
   },
   {
@@ -613,7 +613,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-calentador-de-agua"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -642,7 +642,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-aire-acondicionado-calentador"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -671,7 +671,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-secadora-de-ropa"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -699,7 +699,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-calentador-de-agua"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -728,7 +728,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-aire-acondicionado-calentador"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -757,7 +757,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/bomba-de-calor-secadora-de-ropa"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates"
     }
   },
   {
@@ -785,7 +785,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/instalacion-solar-en-el-techo"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25d-rooftop-solar-tax-credit"
     }
   },
   {
@@ -813,7 +813,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/climatizacion"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-efficiency-rebates"
     }
   },
   {
@@ -841,7 +841,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/climatizacion"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/25c-weatherization-tax-credits"
     }
   },
   {
@@ -869,7 +869,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/climatizacion"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-efficiency-rebates"
     }
   },
   {
@@ -897,7 +897,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/reduccion-de-energia-en-toda-la-casa"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-efficiency-rebates"
     }
   },
   {
@@ -925,7 +925,7 @@
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "es": "https://www.rewiringamerica.org/app/ira-calculator/information/reduccion-de-energia-en-toda-la-casa"
+      "es": "https://homes.rewiringamerica.org/es/federal-incentives/home-efficiency-rebates"
     }
   }
 ]


### PR DESCRIPTION
## Description

We didn't update these upon launching the new consumer site content
because it wasn't in Spanish yet. Now it is.

Note that this affects v1 / the new calculator only. v0 and the old
embed still have to link to the `www` equipment pages (URLs in
`locales/{en,es}.json`) because those URLs are relative.

## Test Plan

`yarn test`. Visit each URL to make sure it works.
