### PR TITLE
Get check-spreadsheet-health passing again

### DIFF
--- a/data/DC/incentives.json
+++ b/data/DC/incentives.json
@@ -93,78 +93,6 @@
     "end_date": "2024-09-30"
   },
   {
-    "id": "DC-29",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
-    "payment_methods": [
-      "rebate"
-    ],
-    "item": "heat_pump_air_conditioner_heater",
-    "program": "dc_dCSustainableEnergyUtility_dCResidentialRebates",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 700,
-      "minimum": 375,
-      "maximum": 700
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "$375-$700 rebate for qualified ducted or ductless heat pump systems."
-    },
-    "start_date": "2023-12-31",
-    "end_date": "2024-09-30"
-  },
-  {
-    "id": "DC-28",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
-    "payment_methods": [
-      "assistance_program"
-    ],
-    "item": "heat_pump_air_conditioner_heater",
-    "program": "dc_dCSustainableEnergyUtility_affordableHomeElectrificationProgram",
-    "amount": {
-      "type": "percent",
-      "number": 1
-    },
-    "owner_status": [
-      "homeowner",
-      "renter"
-    ],
-    "short_description": {
-      "en": "100% of costs covered for switching to qualified ducted or ductless heating systems. Income-qualified residents only."
-    },
-    "start_date": "2023-10-01",
-    "end_date": "2024-09-30",
-    "low_income": "dc-dc-sustainable-energy-utility"
-  },
-  {
-    "id": "DC-27",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
-    "payment_methods": [
-      "assistance_program"
-    ],
-    "item": "electric_stove",
-    "program": "dc_dCSustainableEnergyUtility_affordableHomeElectrificationProgram",
-    "amount": {
-      "type": "percent",
-      "number": 1
-    },
-    "owner_status": [
-      "homeowner",
-      "renter"
-    ],
-    "short_description": {
-      "en": "100% of costs covered for switching to induction cooktops or electric resistance stoves. Income-qualified residents only."
-    },
-    "start_date": "2023-10-01",
-    "end_date": "2024-09-30",
-    "low_income": "dc-dc-sustainable-energy-utility"
-  },
-  {
     "id": "DC-16",
     "authority_type": "city",
     "authority": "dc-dc-sustainable-energy-utility",
@@ -260,5 +188,77 @@
     "start_date": "2024-02-23",
     "end_date": "2024-09-30",
     "low_income": "dc-dc-sustainable-energy-utility"
+  },
+  {
+    "id": "DC-27",
+    "authority_type": "city",
+    "authority": "dc-dc-sustainable-energy-utility",
+    "payment_methods": [
+      "assistance_program"
+    ],
+    "item": "electric_stove",
+    "program": "dc_dCSustainableEnergyUtility_affordableHomeElectrificationProgram",
+    "amount": {
+      "type": "percent",
+      "number": 1
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "100% of costs covered for switching to induction cooktops or electric resistance stoves. Income-qualified residents only."
+    },
+    "start_date": "2023-10-01",
+    "end_date": "2024-09-30",
+    "low_income": "dc-dc-sustainable-energy-utility"
+  },
+  {
+    "id": "DC-28",
+    "authority_type": "city",
+    "authority": "dc-dc-sustainable-energy-utility",
+    "payment_methods": [
+      "assistance_program"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "program": "dc_dCSustainableEnergyUtility_affordableHomeElectrificationProgram",
+    "amount": {
+      "type": "percent",
+      "number": 1
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "100% of costs covered for switching to qualified ducted or ductless heating systems. Income-qualified residents only."
+    },
+    "start_date": "2023-10-01",
+    "end_date": "2024-09-30",
+    "low_income": "dc-dc-sustainable-energy-utility"
+  },
+  {
+    "id": "DC-29",
+    "authority_type": "city",
+    "authority": "dc-dc-sustainable-energy-utility",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "program": "dc_dCSustainableEnergyUtility_dCResidentialRebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 700,
+      "minimum": 375,
+      "maximum": 700
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$375-$700 rebate for qualified ducted or ductless heat pump systems."
+    },
+    "start_date": "2023-12-31",
+    "end_date": "2024-09-30"
   }
 ]

--- a/data/OR/incentives.json
+++ b/data/OR/incentives.json
@@ -10,36 +10,37 @@
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
       "type": "dollar_amount",
-      "number": 500
+      "number": 1000
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "$500 rebate for a ductless heat pump replacing zonal electric resistance as the primary heat source. Primary unit must be in the main living space."
+      "en": "$1,000 rebate for a ductless heat pump replacing zonal electric resistance as the primary heat source. Primary unit must be in the main living space."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-2",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
+    "authority_type": "utility",
+    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "program": "or_energyTrustOfOregon_energyTrustOfOregon",
+    "program": "or_pacificPower_extendedCapacityHeatPumpRegionalPromotion",
     "amount": {
       "type": "dollar_amount",
       "number": 2000
     },
     "owner_status": [
-      "homeowner"
+      "homeowner",
+      "renter"
     ],
     "short_description": {
-      "en": "$2,000 rebate for an extended capacity heat pump. Must be a central ducted system from Energy Trust's list and be the primary heat source."
+      "en": "Pacific Power customers are eligible for a $2,000 rebate for a qualifying extended capacity heat pump installed by a trade ally contractor."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-3",
@@ -58,9 +59,9 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$3,000 rebate for an extended capacity central ducted heat pump. Must replace an electric forced-air furnace as the primary heat source."
+      "en": "PGE and Pacific Power customers are eligible for a $3,000 rebate for an extended capacity heat pump replacing an electric furnace."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-4",
@@ -70,7 +71,7 @@
       "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "program": "or_energyTrustOfOregon_energyTrustOfOregon",
+    "program": "or_energyTrustOfOregon_extendedCapacityHeatPump",
     "amount": {
       "type": "dollar_amount",
       "number": 1000
@@ -81,7 +82,7 @@
     "short_description": {
       "en": "$1,000 rebate for an extended capacity central ducted heat pump. Must be listed on Energy Trust’s list and be the primary heat source."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-5",
@@ -102,7 +103,7 @@
     "short_description": {
       "en": "$3,000 rebate for a heat pump for income-qualified customers. Must replace an electric forced-air furnace as the primary heating source."
     },
-    "start_date": "2023",
+    "start_date": "2023-10-01",
     "low_income": "or-energy-trust-of-oregon"
   },
   {
@@ -124,7 +125,7 @@
     "short_description": {
       "en": "$1,000 rebate for a heat pump. Must replace an electric forced-air furnace as the primary heat source. If back up heat present, must be electric."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-7",
@@ -134,7 +135,7 @@
       "rebate"
     ],
     "item": "heat_pump_air_conditioner_heater",
-    "program": "or_energyTrustOfOregon_energyTrustOfOregon",
+    "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
       "type": "dollar_amount",
       "number": 1800
@@ -145,7 +146,7 @@
     "short_description": {
       "en": "$1,800 rebate for a ductless heat pump for income-qualified customers. Must replace electric resistance as the primary heat source."
     },
-    "start_date": "2023",
+    "start_date": "2023-10-01",
     "low_income": "or-energy-trust-of-oregon"
   },
   {
@@ -167,7 +168,7 @@
     "short_description": {
       "en": "$1,000 rebate for a ductless heat pump. Must replace electric resistance as the primary heat source and primary unit must be in the main living space."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-9",
@@ -186,7 +187,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$400 rebate for Portland General Electric customers. Systems must be installed by an approved Energy Trust solar trade ally contractor."
+      "en": "Earn a $400 rebate for installing solar panels on your home. Systems must be installed by an approved Energy Trust solar trade ally contractor."
     }
   },
   {
@@ -206,7 +207,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$450 rebate for Pacific Power customers. Systems must be installed by an approved Energy Trust solar trade ally contractor."
+      "en": "Earn a $450 rebate for installing solar panels on your home. Systems must be installed by an approved Energy Trust solar trade ally contractor."
     }
   },
   {
@@ -228,7 +229,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$250/kWh for battery storage. $3,000 maximum per home. Systems must be installed by an approved Energy Trust solar trade ally contractor."
+      "en": "Earn $250/kWh up to $3,000 for your battery storage system. Systems must be installed by an approved Energy Trust solar trade ally contractor."
     }
   },
   {
@@ -250,7 +251,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$250/kWh for battery storage. $3,000 maximum per home. Systems must be installed by an approved Energy Trust solar trade ally contractor."
+      "en": "Earn $250/kWh up to $3,000 for your battery storage system. Systems must be installed by an approved Energy Trust solar trade ally contractor."
     }
   },
   {
@@ -272,7 +273,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$0.90/watt for solar. $5,400 maximum per home. For income-qualified households. System must be installed by an approved solar trade ally."
+      "en": "Income-qualified households can earn $0.90/watt up to $5,400 for adding solar panels to your home. An approved solar trade ally must install system."
     },
     "low_income": "or-energy-trust-of-oregon"
   },
@@ -287,7 +288,7 @@
     "program": "or_pacificPower_solarWithinReach",
     "amount": {
       "type": "dollars_per_unit",
-      "number": 0.9,
+      "number": 1,
       "unit": "watt",
       "maximum": 6000
     },
@@ -295,7 +296,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$0.90/watt for solar. $6,000 maximum per home. For income-qualified households. System must be installed by an approved solar trade ally."
+      "en": "Income-qualified households can earn $1.00/watt up to $6,000 for adding solar panels to your home. An approved solar trade ally must install system."
     },
     "low_income": "or-energy-trust-of-oregon"
   },
@@ -318,7 +319,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$750/kWh for battery storage. $10,000 maximum per home. For income-qualified households. System must be installed by an approved solar trade ally."
+      "en": "Income-qualified households can earn $750/kWh up to $10,000 for home solar battery storage. An approved solar trade ally must install the system."
     },
     "low_income": "or-energy-trust-of-oregon"
   },
@@ -341,7 +342,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$750/kWh for battery storage. $10,000 maximum per home. For income-qualified households. System must be installed by an approved solar trade ally."
+      "en": "Income-qualified households can earn $750/kWh up to $10,000 for home solar battery storage. An approved solar trade ally must install the system."
     },
     "low_income": "or-energy-trust-of-oregon"
   },
@@ -362,8 +363,9 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$100 off qualifying Google Nest and ecobee Smart Thermostats."
-    }
+      "en": "Receive $100 off qualifying Google Nest and ecobee Smart Thermostats when you purchase online."
+    },
+    "bonus_available": true
   },
   {
     "id": "OR-18",
@@ -383,7 +385,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$1 per sq ft for high efficiency windows. Windows must replace existing windows, glass doors or skylights. U-value must be between 0.27 – 0.23."
+      "en": "Eligible customers can replace their existing windows with new ones with a U-Value rating between 0.27 and 0.23 and earn $1 per sq ft."
     }
   },
   {
@@ -404,7 +406,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$1.50 per sq ft for higher efficiency windows. Windows must replace existing windows, glass doors or skylights. U-value must be 0.22 or less."
+      "en": "Eligible customers can replace their existing windows with new ones rated U-Value 0.22 or less and earn $1.50 per sq ft."
     }
   },
   {
@@ -425,7 +427,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$0.75 per sq ft for floor insulation of manufactured homes. Income-qualified customers. Must insulate to at least R-22."
+      "en": "Earn $0.75 per sq ft for qualifying floor insulation measures in manufactured homes. Income-qualified customers. Must insulate to at least R-22."
     },
     "low_income": "or-energy-trust-of-oregon"
   },
@@ -447,7 +449,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$0.50 per sq ft for floor insulation of manufactured homes. Must insulate to at least R-22 or fill the accessible floor cavity."
+      "en": "$0.50 per sq ft for qualifying floor insulation measures in manufactured homes. Must insulate to at least R-22 or fill the accessible floor cavity."
     }
   },
   {
@@ -468,7 +470,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$0.50 per sq ft for floor insulation. Existing insulation must be R-11 or less. Must insulate to R-30 or greater or fill the accessible floor cavity."
+      "en": "$0.50 per sq ft for floor insulation measures in qualifying homes. Must insulate to R-30 or greater or fill the accessible floor cavity."
     }
   },
   {
@@ -522,7 +524,7 @@
       "rebate"
     ],
     "item": "weatherization",
-    "program": "or_energyTrustOfOregon_energyTrustOfOregon",
+    "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
       "type": "dollars_per_unit",
       "number": 0.75,
@@ -619,7 +621,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$1.25 per sq ft of attic insulation for manufactured homes. Existing insulation must be R-18 or less. Must insulate to R-30 or greater."
+      "en": "$1.25 per sq ft of attic insulation. Existing insulation must be R-18 or less. Must insulate to R-30 or greater."
     }
   },
   {
@@ -641,7 +643,7 @@
     "short_description": {
       "en": "$500 discount on a ductless heat pump with additional heating source. The heat pump must replace zonal electric as the primary heat source."
     },
-    "start_date": "2023"
+    "start_date": "2023-10-01"
   },
   {
     "id": "OR-33",
@@ -660,7 +662,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$250 discount on qualifying heat pump controls. Must lock electric auxiliary heat out @ 35F or lower and have an outdoor temp sensor / be web-enabled."
+      "en": "$250 discount on qualifying heat pump controls."
     }
   },
   {
@@ -715,15 +717,15 @@
     "item": "electric_vehicle_charger",
     "program": "or_pacificPower_pacificPowerRebates",
     "amount": {
-      "type": "percent",
-      "number": 0.75,
+      "type": "dollar_amount",
+      "number": 1500,
       "maximum": 1500
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $1,500 rebate for qualifying hardwired level 2 chargers for income-qualified customers. Rebate capped at 75% of total costs."
+      "en": "Up to $1,500 rebate for qualifying hardwired level 2 chargers for income-qualified customers."
     },
     "low_income": "or-pacific-power"
   },
@@ -737,15 +739,15 @@
     "item": "electric_vehicle_charger",
     "program": "or_pacificPower_pacificPowerRebates",
     "amount": {
-      "type": "percent",
-      "number": 0.75,
+      "type": "dollar_amount",
+      "number": 500,
       "maximum": 500
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $500 rebate for qualifying 240-volt home EV chargers for income-qualified customers. Rebate capped at 75% of total costs."
+      "en": "Up to $500 rebate for qualifying 240-volt home EV chargers for income-qualified customers."
     },
     "low_income": "or-pacific-power"
   },
@@ -757,7 +759,7 @@
       "rebate"
     ],
     "item": "electric_vehicle_charger",
-    "program": "or_portlandGeneralElectric_pGESmartCharging",
+    "program": "or_portlandGeneralElectric_pGESmartChargingProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 300
@@ -766,7 +768,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $300 rebate for qualifying standard level 2 chargers. Must join the PGE Smart Charging Program."
+      "en": "Up to $300 rebate for qualifying standard level 2 charger installations. Must join the PGE Smart Charging Program."
     }
   },
   {
@@ -777,7 +779,7 @@
       "rebate"
     ],
     "item": "electric_vehicle_charger",
-    "program": "or_portlandGeneralElectric_pGESmartCharging",
+    "program": "or_portlandGeneralElectric_pGESmartChargingProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 1000
@@ -798,7 +800,7 @@
       "rebate"
     ],
     "item": "electric_panel",
-    "program": "or_portlandGeneralElectric_pGESmartCharging",
+    "program": "or_portlandGeneralElectric_pGESmartChargingProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 1000
@@ -809,7 +811,7 @@
     "short_description": {
       "en": "Up to $1,000 rebate for a main breaker panel if required to install a level 2 EV charger. Must be at least 200 amps, 30 slots, and 40 circuits."
     },
-    "start_date": "2022"
+    "start_date": "2022-11-16"
   },
   {
     "id": "OR-41",
@@ -819,7 +821,7 @@
       "rebate"
     ],
     "item": "electric_panel",
-    "program": "or_portlandGeneralElectric_pGESmartCharging",
+    "program": "or_portlandGeneralElectric_pGESmartChargingProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 5000
@@ -830,7 +832,7 @@
     "short_description": {
       "en": "Up to $5,000 rebate for a main breaker panel if required to install a level 2 EV charger. For income-qualified customers."
     },
-    "start_date": "2022",
+    "start_date": "2022-11-16",
     "low_income": "or-portland-general-electric"
   },
   {
@@ -841,7 +843,7 @@
       "rebate"
     ],
     "item": "electric_vehicle_charger",
-    "program": "or_portlandGeneralElectric_pGESmartCharging",
+    "program": "or_portlandGeneralElectric_pGESmartChargingProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 50
@@ -850,7 +852,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$50 rebate for a Tesla Wall Connector or another Level 2 charger that is not on the qualified charger list. Must join the PGE Smart Charging Program."
+      "en": "$50 rebate on a Tesla Wall Connector or another Level 2 charger that is not on the qualified charger list. Must join the PGE Smart Charging Program."
     }
   },
   {
@@ -861,7 +863,7 @@
       "rebate"
     ],
     "item": "electric_vehicle_charger",
-    "program": "or_portlandGeneralElectric_pGESmartCharging",
+    "program": "or_portlandGeneralElectric_pGESmartChargingProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 50
@@ -870,7 +872,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "$50 rebate for a qualifying EV charger installed before it was added to the qualified products list. Must join the PGE Smart Charging Program."
+      "en": "$50 rebate for a qualifying EV charger purchased and installed before it was added to the qualified products list."
     }
   },
   {
@@ -890,7 +892,67 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Earn up to $25 for signing up for the Smart Thermostat Program and save $25 on your PGE bill each summer and winter season."
+      "en": "Earn up to $25 for enrolling in the Smart Thermostat Program and save $25 on your PGE bill each summer and winter season."
+    }
+  },
+  {
+    "id": "OR-45",
+    "authority_type": "utility",
+    "authority": "or-pacific-power",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "program": "or_pacificPower_extendedCapacityHeatPumpRegionalPromotion",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 4000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$4,000 incentive for replacing an electric forced-air furnace with a qualifying central ducted system."
+    }
+  },
+  {
+    "id": "OR-46",
+    "authority_type": "utility",
+    "authority": "or-pacific-power",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "program": "or_pacificPower_heatPumpRegionalPromotion",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 4000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$4,000 incentive for installing a ducted heat pump on your home."
+    }
+  },
+  {
+    "id": "OR-47",
+    "authority_type": "utility",
+    "authority": "or-pacific-power",
+    "payment_methods": [
+      "rebate"
+    ],
+    "item": "heat_pump_air_conditioner_heater",
+    "program": "or_pacificPower_heatPumpRegionalPromotion",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 4000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$4,000 incentive for installing a ducted heat pump on your manufactured home."
     }
   }
 ]

--- a/src/data/programs/or_programs.ts
+++ b/src/data/programs/or_programs.ts
@@ -7,6 +7,14 @@ export const OR_PROGRAMS = {
       en: 'https://www.energytrust.org/residential/incentives',
     },
   },
+  or_energyTrustOfOregon_extendedCapacityHeatPump: {
+    name: {
+      en: 'Extended Capacity Heat Pump',
+    },
+    url: {
+      en: 'https://www.energytrust.org/residential/incentives',
+    },
+  },
   or_energyTrustOfOregon_savingsWithinReach: {
     name: {
       en: 'Savings Within Reach',
@@ -15,36 +23,12 @@ export const OR_PROGRAMS = {
       en: 'https://www.energytrust.org/residential/incentives',
     },
   },
-  or_portlandGeneralElectric_solarForYourHome: {
+  or_pacificPower_extendedCapacityHeatPumpRegionalPromotion: {
     name: {
-      en: 'Solar for your Home',
+      en: 'Extended Capacity Heat Pump Regional Promotion',
     },
     url: {
-      en: 'https://www.energytrust.org/incentives/solar-for-your-home',
-    },
-  },
-  or_portlandGeneralElectric_solarWithinReach: {
-    name: {
-      en: 'Solar Within Reach',
-    },
-    url: {
-      en: 'https://www.energytrust.org/incentives/solar-within-reach',
-    },
-  },
-  or_portlandGeneralElectric_pGESmartCharging: {
-    name: {
-      en: 'PGE Smart Charging',
-    },
-    url: {
-      en: 'https://portlandgeneral.com/energy-choices/electric-vehicles-charging/charging-your-ev/charging-your-ev-at-home',
-    },
-  },
-  or_portlandGeneralElectric_pGESmartThermostatProgram: {
-    name: {
-      en: 'PGE Smart Thermostat Program',
-    },
-    url: {
-      en: 'https://portlandgeneral.com/save-money/save-money-home/smart-thermostat-program',
+      en: 'https://www.energytrust.org/residential/incentives/furnace-and-heat-pump/all',
     },
   },
   or_pacificPower_solarForYourHome: {
@@ -68,7 +52,47 @@ export const OR_PROGRAMS = {
       en: 'Pacific Power Rebates',
     },
     url: {
-      en: 'https://www.pacificpower.net/savings-energy-choices/home.html',
+      en: 'https://www.pacificpower.net/savings-energy-choices/electric-vehicles/home-charger-rebates.html',
+    },
+  },
+  or_pacificPower_heatPumpRegionalPromotion: {
+    name: {
+      en: 'Heat Pump Regional Promotion',
+    },
+    url: {
+      en: 'https://www.energytrust.org/residential/incentives/furnace-and-heat-pump/all',
+    },
+  },
+  or_portlandGeneralElectric_solarForYourHome: {
+    name: {
+      en: 'Solar for your Home',
+    },
+    url: {
+      en: 'https://www.energytrust.org/incentives/solar-for-your-home',
+    },
+  },
+  or_portlandGeneralElectric_solarWithinReach: {
+    name: {
+      en: 'Solar Within Reach',
+    },
+    url: {
+      en: 'https://www.energytrust.org/incentives/solar-within-reach',
+    },
+  },
+  or_portlandGeneralElectric_pGESmartChargingProgram: {
+    name: {
+      en: 'PGE Smart Charging Program',
+    },
+    url: {
+      en: 'https://portlandgeneral.com/energy-choices/electric-vehicles-charging/charging-your-ev/charging-your-ev-at-home',
+    },
+  },
+  or_portlandGeneralElectric_pGESmartThermostatProgram: {
+    name: {
+      en: 'PGE Smart Thermostat Program',
+    },
+    url: {
+      en: 'https://portlandgeneral.com/save-money/save-money-home/smart-thermostat-program',
     },
   },
 } as const;

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -62,64 +62,6 @@
       "program": "Affordable Home Electrification Program",
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
       "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
-      "items": [
-        "heat_pump_air_conditioner_heater"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "100% of costs covered for switching to qualified ducted or ductless heating systems. Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Affordable Home Electrification Program",
-      "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
-      "items": [
-        "electric_stove"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "100% of costs covered for switching to induction cooktops or electric resistance stoves. Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Affordable Home Electrification Program",
-      "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "item": {
         "type": "heat_pump_water_heater",
         "name": "Heat Pump Water Heater"
       },
@@ -226,6 +168,64 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "100% of costs covered for income-qualified homeowners to have solar photovoltaic (PV) systems installed by local contractors."
+    },
+    {
+      "payment_methods": [
+        "assistance_program"
+      ],
+      "authority_type": "city",
+      "authority": "dc-dc-sustainable-energy-utility",
+      "program": "Affordable Home Electrification Program",
+      "program_url": "https://www.dcseu.com/affordable-home-electrification",
+      "item": {
+        "type": "electric_stove",
+        "name": "Electric/Induction Stove"
+      },
+      "items": [
+        "electric_stove"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 1
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-10-01",
+      "end_date": "2024-09-30",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "100% of costs covered for switching to induction cooktops or electric resistance stoves. Income-qualified residents only."
+    },
+    {
+      "payment_methods": [
+        "assistance_program"
+      ],
+      "authority_type": "city",
+      "authority": "dc-dc-sustainable-energy-utility",
+      "program": "Affordable Home Electrification Program",
+      "program_url": "https://www.dcseu.com/affordable-home-electrification",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater"
+      },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 1
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-10-01",
+      "end_date": "2024-09-30",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "100% of costs covered for switching to qualified ducted or ductless heating systems. Income-qualified residents only."
     },
     {
       "payment_methods": [

--- a/test/fixtures/v1-or-97001-state-lowincome.json
+++ b/test/fixtures/v1-or-97001-state-lowincome.json
@@ -39,7 +39,7 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$500 discount on a ductless heat pump with additional heating source. The heat pump must replace zonal electric as the primary heat source."
@@ -68,7 +68,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$250 discount on qualifying heat pump controls. Must lock electric auxiliary heat out @ 35F or lower and have an outdoor temp sensor / be web-enabled."
+      "short_description": "$250 discount on qualifying heat pump controls."
     },
     {
       "payment_methods": [
@@ -94,7 +94,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$100 off qualifying Google Nest and ecobee Smart Thermostats."
+      "short_description": "Receive $100 off qualifying Google Nest and ecobee Smart Thermostats when you purchase online."
     },
     {
       "payment_methods": [
@@ -121,7 +121,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$1.50 per sq ft for higher efficiency windows. Windows must replace existing windows, glass doors or skylights. U-value must be 0.22 or less."
+      "short_description": "Eligible customers can replace their existing windows with new ones rated U-Value 0.22 or less and earn $1.50 per sq ft."
     },
     {
       "payment_methods": [
@@ -229,7 +229,7 @@
       ],
       "ami_qualification": null,
       "eligible": false,
-      "short_description": "$1.25 per sq ft of attic insulation for manufactured homes. Existing insulation must be R-18 or less. Must insulate to R-30 or greater."
+      "short_description": "$1.25 per sq ft of attic insulation. Existing insulation must be R-18 or less. Must insulate to R-30 or greater."
     },
     {
       "payment_methods": [
@@ -256,7 +256,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$1 per sq ft for high efficiency windows. Windows must replace existing windows, glass doors or skylights. U-value must be between 0.27 – 0.23."
+      "short_description": "Eligible customers can replace their existing windows with new ones with a U-Value rating between 0.27 and 0.23 and earn $1 per sq ft."
     },
     {
       "payment_methods": [
@@ -283,7 +283,7 @@
       ],
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$0.75 per sq ft for floor insulation of manufactured homes. Income-qualified customers. Must insulate to at least R-22."
+      "short_description": "Earn $0.75 per sq ft for qualifying floor insulation measures in manufactured homes. Income-qualified customers. Must insulate to at least R-22."
     },
     {
       "payment_methods": [
@@ -318,7 +318,7 @@
       ],
       "authority_type": "state",
       "authority": "or-energy-trust-of-oregon",
-      "program": "Energy Trust of Oregon",
+      "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "weatherization",
@@ -364,7 +364,7 @@
       ],
       "ami_qualification": null,
       "eligible": false,
-      "short_description": "$0.50 per sq ft for floor insulation of manufactured homes. Must insulate to at least R-22 or fill the accessible floor cavity."
+      "short_description": "$0.50 per sq ft for qualifying floor insulation measures in manufactured homes. Must insulate to at least R-22 or fill the accessible floor cavity."
     },
     {
       "payment_methods": [
@@ -391,7 +391,7 @@
       ],
       "ami_qualification": null,
       "eligible": false,
-      "short_description": "$0.50 per sq ft for floor insulation. Existing insulation must be R-11 or less. Must insulate to R-30 or greater or fill the accessible floor cavity."
+      "short_description": "$0.50 per sq ft for floor insulation measures in qualifying homes. Must insulate to R-30 or greater or fill the accessible floor cavity."
     },
     {
       "payment_methods": [
@@ -442,10 +442,10 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "$3,000 rebate for an extended capacity central ducted heat pump. Must replace an electric forced-air furnace as the primary heat source."
+      "short_description": "PGE and Pacific Power customers are eligible for a $3,000 rebate for an extended capacity heat pump replacing an electric furnace."
     },
     {
       "payment_methods": [
@@ -469,7 +469,7 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$3,000 rebate for a heat pump for income-qualified customers. Must replace an electric forced-air furnace as the primary heating source."
@@ -480,34 +480,7 @@
       ],
       "authority_type": "state",
       "authority": "or-energy-trust-of-oregon",
-      "program": "Energy Trust of Oregon",
-      "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
-      "items": [
-        "heat_pump_air_conditioner_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 2000
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2023",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "$2,000 rebate for an extended capacity heat pump. Must be a central ducted system from Energy Trust's list and be the primary heat source."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "or-energy-trust-of-oregon",
-      "program": "Energy Trust of Oregon",
+      "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "item": {
         "type": "heat_pump_air_conditioner_heater",
@@ -523,7 +496,7 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,800 rebate for a ductless heat pump for income-qualified customers. Must replace electric resistance as the primary heat source."
@@ -550,7 +523,34 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$1,000 rebate for a ductless heat pump replacing zonal electric resistance as the primary heat source. Primary unit must be in the main living space."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "or-energy-trust-of-oregon",
+      "program": "Extended Capacity Heat Pump",
+      "program_url": "https://www.energytrust.org/residential/incentives",
+      "item": {
+        "type": "heat_pump_air_conditioner_heater",
+        "name": "Heat Pump Air Conditioner/Heater"
+      },
+      "items": [
+        "heat_pump_air_conditioner_heater"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$1,000 rebate for an extended capacity central ducted heat pump. Must be listed on Energy Trust’s list and be the primary heat source."
@@ -577,7 +577,7 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "$1,000 rebate for a heat pump. Must replace an electric forced-air furnace as the primary heat source. If back up heat present, must be electric."
@@ -604,37 +604,10 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2023",
+      "start_date": "2023-10-01",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "$1,000 rebate for a ductless heat pump. Must replace electric resistance as the primary heat source and primary unit must be in the main living space."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "or-energy-trust-of-oregon",
-      "program": "Energy Trust of Oregon",
-      "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
-      "items": [
-        "heat_pump_air_conditioner_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 500
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2023",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "$500 rebate for a ductless heat pump replacing zonal electric resistance as the primary heat source. Primary unit must be in the main living space."
     }
   ]
 }


### PR DESCRIPTION
## Description

The DC incentives just got reordered for some reason (I diffed old and
new after sorting, and they're identical).

There were some actual changes to the OR incentives; they look
sensible, though I haven't verified them with the primary sources.
Since OR launch is still a ways off, I'll leave that for a full data
refresh later. I also had to update the spreadsheet a bit to fix missing
values in required fields.

## Test Plan

`yarn test`
