### PR TITLE
Unlock calculation for territories

### DIFF
--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -52,6 +52,14 @@ export const STATES_PLUS_DC = [
   'DC',
 ] as const;
 
+export const TERRITORIES = [
+  'PR',
+  'GU',
+  'MP',
+  'VI',
+  'AS',
+] as const;
+
 export const BETA_STATES: string[] = [
   'AZ',
   'CT',

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -122,7 +122,7 @@ function calculateFederalIncentivesAndSavings(
     // 5) Add the Rooftop Solar Credit amount
     //
     const amount = { ...incentive.amount };
-    if (item === 'rooftop_solar_installation') {
+    if (item === 'rooftop_solar_installation' && !isNaN(solarSystemCost)) {
       amount.representative = roundCents(solarSystemCost * amount.number!);
     }
 
@@ -238,13 +238,6 @@ export default function calculateIncentives(
     );
   }
 
-  const solarSystemCost = SOLAR_PRICES[state_id]?.system_cost;
-  if (isNaN(solarSystemCost)) {
-    throw new InvalidInputError(
-      'Invalid state id provided. Must be US state code or DC.',
-    );
-  }
-
   // Throw an error if the request specifically asks for utility incentives and
   // doesn't include a utility.
   if (
@@ -291,7 +284,7 @@ export default function calculateIncentives(
   if (!authority_types || authority_types.includes(AuthorityType.Federal)) {
     const federal = calculateFederalIncentivesAndSavings(
       amiAndEvCreditEligibility,
-      solarSystemCost,
+      SOLAR_PRICES[state_id]?.system_cost,
       request,
     );
     incentives.push(...federal.federalIncentives);
@@ -322,6 +315,7 @@ export default function calculateIncentives(
 
   // Get tax owed to determine max potential tax savings
   const tax = estimateFederalTaxAmount(
+    location.state,
     tax_filing as FilingStatus,
     household_income,
   );

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -172,8 +172,8 @@ export default async function (
           incentive => incentive.items[0] === 'rooftop_solar_installation',
         );
 
-        if (solarTaxCredit) {
-          solarTaxCredit.amount.number = solarTaxCredit.amount.representative!;
+        if (solarTaxCredit && solarTaxCredit.amount.representative) {
+          solarTaxCredit.amount.number = solarTaxCredit.amount.representative;
           delete solarTaxCredit.amount.representative;
 
           // 1.2) Re-sort incentives per https://app.asana.com/0/0/1204275945510481/f
@@ -199,7 +199,8 @@ export default async function (
 
           // 2) Add annual savings from pregenerated model
           estimated_annual_savings:
-            IRA_STATE_SAVINGS[location.state].estimated_savings_heat_pump_ev,
+            IRA_STATE_SAVINGS[location.state]?.estimated_savings_heat_pump_ev ??
+            IRA_STATE_SAVINGS['US'].estimated_savings_heat_pump_ev,
 
           // 3) Populate the expected English and Spanish strings
           pos_rebate_incentives: translateIncentives(pos_rebate_incentives),

--- a/test/lib/tax-brackets.test.ts
+++ b/test/lib/tax-brackets.test.ts
@@ -34,57 +34,58 @@ test('defaults to a null state tax obligation for unsupported states', async t =
  */
 
 test('correctly evaluates scenerio: $112,500 hoh', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.HoH, 112500);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.HoH, 112500);
   t.equal(data.taxOwed, 13875);
 });
 
 test('correctly evaluates scenerio: $53,100 single', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Single, 53100);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Single, 53100);
   t.equal(data.taxOwed, 4490);
 });
 
 test('correctly evaluates scenerio: $300,000 hoh', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.HoH, 300000);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.HoH, 300000);
   t.equal(data.taxOwed, 68009);
 });
 
 test('correctly evaluates scenerio: $300,000 single', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Single, 300000);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Single, 300000);
   t.equal(data.taxOwed, 72047);
 });
 
 test('correctly evaluates scenerio: $94,000 joint', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Joint, 94000);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Joint, 94000);
   t.equal(data.taxOwed, 7516);
 });
 
 test('correctly evaluates scenerio: $1,000,000 joint', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Joint, 1000000);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Joint, 1000000);
   t.equal(data.taxOwed, 289665);
 });
 
 test('correctly evaluates scenerio: $8,000 single', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Single, 8000);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Single, 8000);
   t.equal(data.taxOwed, 0);
 });
 
 test('correctly evaluates income at standard deduction', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Joint, 13850);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Joint, 13850);
   t.equal(data.taxOwed, 0);
 });
 
 test('correctly evaluates income below standard deduction', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Joint, 5000);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Joint, 5000);
   t.equal(data.taxOwed, 0);
 });
 
 test('correctly evaluates $0 income', async t => {
-  const data = estimateFederalTaxAmount(FilingStatus.Single, 0);
+  const data = estimateFederalTaxAmount('CA', FilingStatus.Single, 0);
   t.equal(data.taxOwed, 0);
 });
 
 test('correctly evaluates scenario: $500,000 married-separate', async t => {
   const data = estimateFederalTaxAmount(
+    'CA',
     FilingStatus.MarriedFilingSeparately,
     500000,
   );
@@ -93,6 +94,7 @@ test('correctly evaluates scenario: $500,000 married-separate', async t => {
 
 test('correctly evaluates scenario: $53,100 married-separate', async t => {
   const data = estimateFederalTaxAmount(
+    'CA',
     FilingStatus.MarriedFilingSeparately,
     53100,
   );

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -217,14 +217,6 @@ const BAD_QUERIES = [
     tax_filing: 'joint',
     household_size: 9,
   },
-  {
-    // Puerto Rico; no MFI coverage
-    zip: '00907',
-    owner_status: 'homeowner',
-    household_income: 80000,
-    tax_filing: 'joint',
-    household_size: 4,
-  },
 ];
 
 test('bad queries', async t => {


### PR DESCRIPTION
## Description

We can do this now that we have AMI data and 30C eligibility data for
the territories. This further required:

- Making the solar system cost estimation optional

- Making the estimated savings lookup fall back to the `US` value if
  it's not known for the user's state.

## Test Plan

Tested old and new embed frontends against local API server, with zip
00930 (PR).  The old one correctly shows total tax savings of $0 for
low and high incomes. The rooftop solar credit is shown as "30%"
instead of an estimated amount.

The tax credits still show up as eligible, which I think is not ideal,
but is OK -- territory residents are technically eligible for the
credits, and may benefit from them if they have non-territory-sourced
income or some other circumstance that means they do pay nonzero
federal income tax. (And this is the same thing you see for a low
income in the states.)
