### PR TITLE
Remove the singular item field from v1

### DIFF
--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -29,11 +29,6 @@ function transformIncentives(
     ...incentive,
 
     // Localize localizable fields
-    // TODO remove this field once all clients use "items" exclusively
-    item: {
-      type: incentive.items[0],
-      name: t('items', incentive.items[0], language),
-    },
     program: tr(PROGRAMS[incentive.program as keyof Programs].name, language),
     program_url: tr(
       PROGRAMS[incentive.program as keyof Programs].url,

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -15,7 +15,6 @@ export const API_INCENTIVE_SCHEMA = {
     'authority_type',
     'program',
     'program_url',
-    'item',
     'items',
     'amount',
     'owner_status',
@@ -44,20 +43,6 @@ export const API_INCENTIVE_SCHEMA = {
     },
     more_info_url: {
       type: 'string',
-    },
-    item: {
-      type: 'object',
-      properties: {
-        type: {
-          type: 'string',
-          enum: ALL_ITEMS,
-        },
-        name: {
-          type: 'string',
-        },
-      },
-      required: ['type'],
-      additionalProperties: false,
     },
     items: {
       type: 'array',

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -28,10 +28,6 @@
       "authority": "il-illinois-solar-for-all",
       "program": "ILSFA Residential Solar Program",
       "program_url": "https://www.illinoissfa.com/programs/for-homeowners-and-building-owners/",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -56,10 +52,6 @@
       "authority": "il-state-of-illinois",
       "program": "Illinois Home Weatherization",
       "program_url": "https://dceo.illinois.gov/communityservices/homeweatherization/howtoapply.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -84,10 +76,6 @@
       "authority": "il-state-of-illinois",
       "program": "Illinois Electric Vehicle Rebate Program",
       "program_url": "https://epa.illinois.gov/topics/ceja/electric-vehicle-rebates.html",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -30,10 +30,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -59,10 +55,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -85,10 +77,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -113,10 +101,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE EV",
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -140,10 +124,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE+",
       "program_url": "https://drive.ri.gov/ev-programs/drive-plus",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -167,10 +147,6 @@
       "program": "Federal Clean Vehicle Credit (30D)",
       "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -198,10 +174,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -44,10 +44,6 @@
       "authority": "ri-dhs",
       "program": "RI Department of Human Services Weatherization Assistance Program",
       "program_url": "https://dhs.ri.gov/programs-and-services/energy-assistance-programs/weatherization-assistance-program-wap",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -71,10 +67,6 @@
       "authority": "ri-rhode-island-energy",
       "program": "Rhode Island Energy Income-Eligible Energy Savings Program",
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -97,10 +89,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -123,10 +111,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -150,10 +134,6 @@
       "authority": "ri-oer",
       "program": "Erika Niedowski Memorial Electric Bicycle Rebate Program",
       "program_url": "https://drive.ri.gov/erika-niedowski-memorial-electric-bicycle-rebate-program",
-      "item": {
-        "type": "ebike",
-        "name": "E-Bike"
-      },
       "items": [
         "ebike"
       ],
@@ -178,10 +158,6 @@
       "authority": "ri-oer",
       "program": "Erika Niedowski Memorial Electric Bicycle Rebate Program",
       "program_url": "https://drive.ri.gov/erika-niedowski-memorial-electric-bicycle-rebate-program",
-      "item": {
-        "type": "ebike",
-        "name": "E-Bike"
-      },
       "items": [
         "ebike"
       ],
@@ -206,10 +182,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -234,10 +206,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -262,10 +230,6 @@
       "authority": "ri-rhode-island-energy",
       "program": "Rhode Island Energy residential electric heating and cooling rebates",
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -292,10 +256,6 @@
       "authority": "ri-commerce-corp",
       "program": "Rhode Island Commerce Corp. Small-Scale Solar Program",
       "program_url": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -321,10 +281,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE EV",
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -348,10 +304,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE+",
       "program_url": "https://drive.ri.gov/ev-programs/drive-plus",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -375,10 +327,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE+",
       "program_url": "https://drive.ri.gov/ev-programs/drive-plus",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -402,10 +350,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE EV",
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -429,10 +373,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -455,10 +395,6 @@
       "authority": "ri-rhode-island-energy",
       "program": "Rhode Island Energy residential heat pump water heater rebates",
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -484,10 +420,6 @@
       "authority": "ri-oer",
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],

--- a/test/fixtures/v1-15289-homeowner-85000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-85000-joint-4.json
@@ -28,10 +28,6 @@
       "authority": "pa-pennsylvania-department-of-community-and-economic-development",
       "program": "Pennsylvania Weatherization Assistance Program",
       "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -54,10 +50,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -83,10 +75,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -111,10 +99,6 @@
       "program": "Federal Home Efficiency Rebates (HER)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "item": {
-        "type": "efficiency_rebates",
-        "name": "Efficiency Rebates"
-      },
       "items": [
         "efficiency_rebates"
       ],
@@ -139,10 +123,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "electric_wiring",
-        "name": "Electric Wiring"
-      },
       "items": [
         "electric_wiring"
       ],
@@ -167,10 +147,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -195,10 +171,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -223,10 +195,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -252,10 +220,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -281,10 +245,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -311,10 +271,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -341,10 +297,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -371,10 +323,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -401,10 +349,6 @@
       "program": "Federal Residential Clean Energy Credit (25D)",
       "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
-      "item": {
-        "type": "battery_storage_installation",
-        "name": "Battery Storage Installation"
-      },
       "items": [
         "battery_storage_installation"
       ],
@@ -430,10 +374,6 @@
       "program": "Federal Residential Clean Energy Credit (25D)",
       "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -459,10 +399,6 @@
       "program": "Federal Residential Clean Energy Credit (25D)",
       "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -488,10 +424,6 @@
       "program": "Federal Clean Vehicle Credit (30D)",
       "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -519,10 +451,6 @@
       "program": "Federal Credit for Previously-Owned Clean Vehicles (25E)",
       "program_url": "https://www.irs.gov/credits-deductions/used-clean-vehicle-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -550,10 +478,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -578,10 +502,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -606,10 +526,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -634,10 +550,6 @@
       "program": "Federal Alternative Fuel Vehicle Refueling Property Credit (30C)",
       "program_url": "https://www.irs.gov/credits-deductions/alternative-fuel-vehicle-refueling-property-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -663,10 +575,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -28,10 +28,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Heat Pump Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/hptc",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -56,10 +52,6 @@
       "authority": "co-platte-river-power-authority",
       "program": "Efficiency Works",
       "program_url": "https://efficiencyworks.org/homes/rebates/#secrebates",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -28,10 +28,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Heat Pump Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/hptc",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -56,10 +52,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Water Heater Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/home-rebates/water-heaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],

--- a/test/fixtures/v1-84106-homeowner-80000-joint-4.json
+++ b/test/fixtures/v1-84106-homeowner-80000-joint-4.json
@@ -21,10 +21,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -50,10 +46,6 @@
       "program": "Federal Home Efficiency Rebates (HER)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "item": {
-        "type": "efficiency_rebates",
-        "name": "Efficiency Rebates"
-      },
       "items": [
         "efficiency_rebates"
       ],
@@ -78,10 +70,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -106,10 +94,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "electric_wiring",
-        "name": "Electric Wiring"
-      },
       "items": [
         "electric_wiring"
       ],
@@ -134,10 +118,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -162,10 +142,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -190,10 +166,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -219,10 +191,6 @@
       "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
       "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -248,10 +216,6 @@
       "program": "Federal Residential Clean Energy Credit (25D)",
       "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-battery-storage-tax-credit",
-      "item": {
-        "type": "battery_storage_installation",
-        "name": "Battery Storage Installation"
-      },
       "items": [
         "battery_storage_installation"
       ],
@@ -277,10 +241,6 @@
       "program": "Federal Residential Clean Energy Credit (25D)",
       "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-geothermal-heating-and-cooling-tax-credit",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -306,10 +266,6 @@
       "program": "Federal Residential Clean Energy Credit (25D)",
       "program_url": "https://www.irs.gov/credits-deductions/residential-clean-energy-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25d-rooftop-solar-tax-credit",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -335,10 +291,6 @@
       "program": "Federal Clean Vehicle Credit (30D)",
       "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -366,10 +318,6 @@
       "program": "Federal Credit for Previously-Owned Clean Vehicles (25E)",
       "program_url": "https://www.irs.gov/credits-deductions/used-clean-vehicle-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -397,10 +345,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -425,10 +369,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -453,10 +393,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -481,10 +417,6 @@
       "program": "Federal Alternative Fuel Vehicle Refueling Property Credit (30C)",
       "program_url": "https://www.irs.gov/credits-deductions/alternative-fuel-vehicle-refueling-property-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30c-ev-charger-tax-credit",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -510,10 +442,6 @@
       "program": "Federal Energy Efficient Home Improvement Credit (25C)",
       "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "az-tucson-electric-power",
       "program": "Weatherization assistance",
       "program_url": "https://www.tep.com/weatherization-assistance/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -51,10 +47,6 @@
       "authority": "az-tucson-electric-power",
       "program": "Efficient Home Water Heating",
       "program_url": "https://www.tep.com/efficient-home-water-heating/",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "az-uni-source-energy-services",
       "program": "Weatherization assistance",
       "program_url": "https://www.uesaz.com/weatherization-assistance/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -51,10 +47,6 @@
       "authority": "az-uni-source-energy-services",
       "program": "Efficient Home Program",
       "program_url": "https://www.uesaz.com/efficient-home-program/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -77,10 +69,6 @@
       "authority": "az-uni-source-energy-services",
       "program": "Efficient Home Program",
       "program_url": "https://www.uesaz.com/efficient-home-program/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -38,10 +38,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -66,10 +62,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -93,10 +85,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -120,10 +108,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -147,10 +131,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -173,10 +153,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Low-Moderate Income Program",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -199,10 +175,6 @@
       "authority": "co-energy-outreach-colorado",
       "program": "Energy Outreach Colorado Weatherization Assistance Program",
       "program_url": "https://socgov02.my.site.com/ceoweatherization/s/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -226,10 +198,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Vehicle Exchange Colorado (VXC) Program",
       "program_url": "https://energyoffice.colorado.gov/vehicle-exchange-colorado",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -253,10 +221,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Vehicle Exchange Colorado (VXC) Program",
       "program_url": "https://energyoffice.colorado.gov/vehicle-exchange-colorado",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -280,10 +244,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Heat Pump Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/hptc",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -308,10 +268,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Heat Pump Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/hptc",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -336,10 +292,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Heat Pump Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/hptc",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -364,10 +316,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -391,10 +339,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -418,10 +362,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -445,10 +385,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -472,10 +408,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -499,10 +431,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -526,10 +454,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -553,10 +477,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -580,10 +500,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -607,10 +523,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -634,10 +546,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -661,10 +569,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -688,10 +592,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -715,10 +615,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -742,10 +638,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -769,10 +661,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -796,10 +684,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -823,10 +707,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -850,10 +730,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -877,10 +753,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -904,10 +776,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -931,10 +799,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -958,10 +822,6 @@
       "authority": "co-walking-mountains",
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -986,10 +846,6 @@
       "authority": "co-xcel-energy",
       "program": "Xcel Energy Heat Pump Water Heater Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/home-rebates/water-heaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -1012,10 +868,6 @@
       "authority": "co-state-of-colorado",
       "program": "Colorado Heat Pump Incentives",
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -1040,10 +892,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Electric Vehicle Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -1068,10 +916,6 @@
       "authority": "co-colorado-energy-office",
       "program": "Colorado Electric Vehicle Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -28,10 +28,6 @@
       "authority": "ct-eversource",
       "program": "Energize CT Home Energy Solutions",
       "program_url": "https://energizect.com/energy-evaluations/income-eligible-options",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -56,10 +52,6 @@
       "authority": "ct-deep",
       "program": "Connecticut Hydrogen and Electric Automobile Purchase Rebate",
       "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -83,10 +75,6 @@
       "authority": "ct-deep",
       "program": "Connecticut Hydrogen and Electric Automobile Purchase Rebate",
       "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -110,10 +98,6 @@
       "authority": "ct-deep",
       "program": "Connecticut Hydrogen and Electric Automobile Purchase Rebate",
       "program_url": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -137,10 +121,6 @@
       "authority": "ct-eversource",
       "program": "Energize CT Residential Ground Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -167,10 +147,6 @@
       "authority": "ct-eversource",
       "program": "Energize CT Residential Air Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -197,10 +173,6 @@
       "authority": "ct-eversource",
       "program": "Energize CT Residential Heat Pump Water Heater Incentive",
       "program_url": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -225,10 +197,6 @@
       "authority": "ct-eversource",
       "program": "Energize CT Residential Ground Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -253,10 +221,6 @@
       "authority": "ct-eversource",
       "program": "Energize CT Residential Air Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -61,10 +61,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "Affordable Home Electrification Program",
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -90,10 +86,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "Affordable Home Electrification Program",
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -119,10 +111,6 @@
       "authority": "dc-dc-department-of-energy-and-environment",
       "program": "Weatherization Assistance Program",
       "program_url": "https://doee.dc.gov/service/wap",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -148,10 +136,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "Solar for All Single- Family Program",
       "program_url": "https://www.dcseu.com/solar-for-all",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -177,10 +161,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "Affordable Home Electrification Program",
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -206,10 +186,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "Affordable Home Electrification Program",
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -235,10 +211,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -264,10 +236,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "item": {
-        "type": "electric_outdoor_equipment",
-        "name": "Electric Outdoor Equipment"
-      },
       "items": [
         "electric_outdoor_equipment"
       ],
@@ -293,10 +261,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -322,10 +286,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "item": {
-        "type": "electric_outdoor_equipment",
-        "name": "Electric Outdoor Equipment"
-      },
       "items": [
         "electric_outdoor_equipment"
       ],
@@ -351,10 +311,6 @@
       "authority": "dc-dc-sustainable-energy-utility",
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -25,10 +25,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -54,10 +50,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -83,10 +75,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -112,10 +100,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -141,10 +125,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -170,10 +150,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -199,10 +175,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -228,10 +200,6 @@
       "authority": "ga-georgia-power",
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],

--- a/test/fixtures/v1-il-60202-city-lowincome.json
+++ b/test/fixtures/v1-il-60202-city-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "il-evanston-development-cooperative",
       "program": "Evanston Green Homes Pilot Program",
       "program_url": "https://greenhomes.cnt.org/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -51,10 +47,6 @@
       "authority": "il-evanston-development-cooperative",
       "program": "Evanston Green Homes Pilot Program",
       "program_url": "https://greenhomes.cnt.org/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -77,10 +69,6 @@
       "authority": "il-evanston-development-cooperative",
       "program": "Evanston Green Homes Pilot Program",
       "program_url": "https://greenhomes.cnt.org/",
-      "item": {
-        "type": "electric_panel",
-        "name": "Electric Panel"
-      },
       "items": [
         "electric_panel"
       ],
@@ -103,10 +91,6 @@
       "authority": "il-evanston-development-cooperative",
       "program": "Evanston Green Homes Pilot Program",
       "program_url": "https://greenhomes.cnt.org/",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "mi-dte",
       "program": "Electric Vehicle Rebate",
       "program_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/electric-vehicle-rebate.html",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -53,10 +49,6 @@
       "authority": "mi-dte",
       "program": "Air Conditioners",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -79,10 +71,6 @@
       "authority": "mi-dte",
       "program": "Air Conditioners",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -106,10 +94,6 @@
       "authority": "mi-dte",
       "program": "Air Conditioners",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -132,10 +116,6 @@
       "authority": "mi-dte",
       "program": "Home EV Charger Rebate",
       "program_url": "https://www.dteenergy.com/us/en/residential/service-request/pev/home-ev-charger-rebate.html",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -159,10 +139,6 @@
       "authority": "mi-dte",
       "program": "Washers & Dryers",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/washers-dryers.html#tabs-f1a15f985f-item-83a9b1fa23",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -187,10 +163,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -213,10 +185,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -239,10 +207,6 @@
       "authority": "mi-dte",
       "program": "Wi-Fi Enabled Thermostats",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/wi-fi-enabled-thermostats.html",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -265,10 +229,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -291,10 +251,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -317,10 +273,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -343,10 +295,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -369,10 +317,6 @@
       "authority": "mi-dte",
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],

--- a/test/fixtures/v1-mi-48825-city-lowincome.json
+++ b/test/fixtures/v1-mi-48825-city-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Electrification Programs",
       "program_url": "https://www.lbwl.com/customers/save-money-energy/electrification-programs",
-      "item": {
-        "type": "ebike",
-        "name": "E-Bike"
-      },
       "items": [
         "ebike"
       ],
@@ -53,10 +49,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Electrification Programs",
       "program_url": "https://www.lbwl.com/customers/save-money-energy/electrification-programs",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -80,10 +72,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Plug-in Electric Vehicle Rebates",
       "program_url": "https://www.lbwl.com/customers/save-money-energy/plug-electric-vehicles-pev",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -107,10 +95,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Heating and Cooling Rebates",
       "program_url": "https://www.lbwl.com/hvac",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -134,10 +118,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Electrification Programs",
       "program_url": "https://www.lbwl.com/customers/save-money-energy/electrification-programs",
-      "item": {
-        "type": "ebike",
-        "name": "E-Bike"
-      },
       "items": [
         "ebike"
       ],
@@ -162,10 +142,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Heating and Cooling Rebates",
       "program_url": "https://www.lbwl.com/hvac",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -189,10 +165,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Electrification Programs",
       "program_url": "https://www.lbwl.com/customers/save-money-energy/electrification-programs",
-      "item": {
-        "type": "electric_outdoor_equipment",
-        "name": "Electric Outdoor Equipment"
-      },
       "items": [
         "electric_outdoor_equipment"
       ],
@@ -217,10 +189,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL ENERGY STAR Appliance Rebates",
       "program_url": "https://www.lbwl.com/appliances",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -244,10 +212,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Heating and Cooling Rebates",
       "program_url": "https://www.lbwl.com/hvac",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -270,10 +234,6 @@
       "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL ENERGY STAR Appliance Rebates",
       "program_url": "https://www.lbwl.com/appliances",
-      "item": {
-        "type": "non_heat_pump_water_heater",
-        "name": "Electric Resistance Water Heater"
-      },
       "items": [
         "non_heat_pump_water_heater"
       ],

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -34,10 +34,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Qualified Appliance Replacement program",
       "program_url": "https://www.nvenergy.com/save-with-powershift/qualified-appliance-replacement",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -61,10 +57,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Smart Thermostat Program",
       "program_url": "https://www.nvenergy.com/save-with-powershift/smart-thermostat",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -88,10 +80,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -115,10 +103,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -142,10 +126,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -168,10 +148,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -195,10 +171,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -222,10 +194,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -248,10 +216,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Heat Pump Water Heating",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/water-heating",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -274,10 +238,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Appliances and Products",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/retail-appliances-and-products",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -301,10 +261,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Residential Appliances and Products",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/retail-appliances-and-products",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -328,10 +284,6 @@
       "authority": "nv-nv-energy",
       "program": "NV Energy Home Improvements",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/home-improvements",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -31,10 +31,6 @@
       "authority": "ny-pseg-long-island",
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -58,10 +54,6 @@
       "authority": "ny-state-of-ny",
       "program": "NY State Drive Clean Program",
       "program_url": "https://www.nyserda.ny.gov/All-Programs/Drive-Clean-Rebate-For-Electric-Cars-Program/How-it-Works",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -87,10 +79,6 @@
       "authority": "ny-pseg-long-island",
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -113,10 +101,6 @@
       "authority": "ny-pseg-long-island",
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -140,10 +124,6 @@
       "authority": "ny-pseg-long-island",
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -166,10 +146,6 @@
       "authority": "ny-pseg-long-island",
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -192,10 +168,6 @@
       "authority": "ny-pseg-long-island",
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -218,10 +190,6 @@
       "authority": "ny-nyserda",
       "program": "New York State Comfort Home Program",
       "program_url": "https://www.nyserda.ny.gov/All-Programs/Comfort-Home-Program",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -245,10 +213,6 @@
       "authority": "ny-state-of-ny",
       "program": "NY State Residential Tax Credit",
       "program_url": "https://www.tax.ny.gov/pit/credits/geothermal-energy-system-credit.htm",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],

--- a/test/fixtures/v1-or-97001-state-lowincome.json
+++ b/test/fixtures/v1-or-97001-state-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -52,10 +48,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -78,10 +70,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -104,10 +92,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -131,10 +115,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -158,10 +138,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -185,10 +161,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -212,10 +184,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -239,10 +207,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -266,10 +230,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -293,10 +253,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -320,10 +276,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -347,10 +299,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -374,10 +322,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -401,10 +345,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -428,10 +368,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -455,10 +391,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -482,10 +414,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -509,10 +437,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -536,10 +460,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Extended Capacity Heat Pump",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -563,10 +483,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -590,10 +506,6 @@
       "authority": "or-energy-trust-of-oregon",
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],

--- a/test/fixtures/v1-pa-17555-state-lowincome.json
+++ b/test/fixtures/v1-pa-17555-state-lowincome.json
@@ -31,10 +31,6 @@
       "authority": "pa-pennsylvania-department-of-community-and-economic-development",
       "program": "Pennsylvania Weatherization Assistance Program",
       "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -57,10 +53,6 @@
       "authority": "pa-first-energy",
       "program": "First Energy WARM Program",
       "program_url": "https://www.firstenergycorp.com/save_energy/save_energy_pennsylvania/met_ed/for_your_home/warm-info.html",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -83,10 +75,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -111,10 +99,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -140,10 +124,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -168,10 +148,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -198,10 +174,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -228,10 +200,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -258,10 +226,6 @@
       "authority": "pa-pennsylvania-department-of-environmental-protection",
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -288,10 +252,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -316,10 +276,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -345,10 +301,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -373,10 +325,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -401,10 +349,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -429,10 +373,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -458,10 +398,6 @@
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "va-dominion-energy",
       "program": "Income and Age Qualifying Energy Efficiency Program",
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/income-and-age-qualifying-home-improvements",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -51,10 +47,6 @@
       "authority": "va-dominion-energy",
       "program": "Water Energy Savings Program",
       "program_url": "https://cdn-dominionenergy-prd-001.azureedge.net/-/media/pdfs/virginia/save-energy/residential-water-energy--savings-program-measures.pdf",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -79,10 +71,6 @@
       "authority": "va-dominion-energy",
       "program": "EV Charger Rewards",
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/ev-charger-rewards",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -105,10 +93,6 @@
       "authority": "va-dominion-energy",
       "program": "Energy Star Rebates",
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/energy-star-products",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -40,10 +40,6 @@
       "authority": "vt-state-of-vermont",
       "program": "Income based Weatherization Assistance Program",
       "program_url": "https://dcf.vermont.gov/benefits/weatherization",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -66,10 +62,6 @@
       "authority": "vt-state-of-vermont",
       "program": "MileageSmart Used High Efficiency Vehicle Incentive Program",
       "program_url": "https://www.driveelectricvt.com/incentives/vermont-state-incentives#mileagesmart",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -94,10 +86,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -124,10 +112,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -154,10 +138,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -184,10 +164,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -214,10 +190,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -245,10 +217,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -276,10 +244,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -307,10 +271,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -338,10 +298,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Ducted Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -366,10 +322,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Ductless Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -394,10 +346,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Wood & Pellet Stove Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/wood-stoves",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -422,10 +370,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Dehumidifier Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/dehumidifiers",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -450,10 +394,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - High-Performance Circulator Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/high-performance-circulator-pumps",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -478,10 +418,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -505,10 +441,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -533,10 +465,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Ductless Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Mini-Split%20Heat%20Pump",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -562,10 +490,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Residential EV Charger Rebate",
       "program_url": "https://www.burlingtonelectric.com/evchargers#",
-      "item": {
-        "type": "electric_vehicle_charger",
-        "name": "Electric Vehicle Charger"
-      },
       "items": [
         "electric_vehicle_charger"
       ],
@@ -590,10 +514,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Home performance with ENERGY STAR",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -618,10 +538,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Home performance with ENERGY STAR",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -646,10 +562,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Lawn Care - Residential Rebate",
       "program_url": "https://www.burlingtonelectric.com/lawnmowers",
-      "item": {
-        "type": "electric_outdoor_equipment",
-        "name": "Electric Outdoor Equipment"
-      },
       "items": [
         "electric_outdoor_equipment"
       ],
@@ -675,10 +587,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Ground Source Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-ground-source-heat-pump-rebate-form.pdf",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -703,10 +611,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Air-to-Water Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -733,10 +637,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Ground Source Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/gshp",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -761,10 +661,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Air to Water Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -790,10 +686,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Ducted Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/heatpumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -819,10 +711,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Central Wood Pellet Boiler Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/central-wood-pellet-furnaces-boilers-business",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -847,10 +735,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department Electric Vehicle Rebates",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -875,10 +759,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department Electric Vehicle Rebates",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -902,10 +782,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Ductless Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -929,10 +805,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Heat Pump Water Heater",
       "program_url": "https://www.burlingtonelectric.com/waterheaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -958,10 +830,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department Electric Vehicle Rebate Income Bonus",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -986,10 +854,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Residential Energy Efficiency Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/integrated-controls",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -1014,10 +878,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -1041,10 +901,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Air to Water Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -1068,10 +924,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Ground Source Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/ground-source-heat-pumps",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -1096,10 +948,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Air-to-Water Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -1125,10 +973,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Clothes Dryer Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/clothes-dryers",
-      "item": {
-        "type": "heat_pump_clothes_dryer",
-        "name": "Heat Pump Clothes Dryer"
-      },
       "items": [
         "heat_pump_clothes_dryer"
       ],
@@ -1153,10 +997,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Ducted Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/heatpumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -1182,10 +1022,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Ductless Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Mini-Split%20Heat%20Pump",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -1211,10 +1047,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Washer & Dryer Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/washer-dryer",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -1239,10 +1071,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont Ducted Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -1265,10 +1093,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Heat Pump Rebates - Income Bonus",
       "program_url": "https://www.burlingtonelectric.com/waterheaters",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -1294,10 +1118,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Rebate for Induction Cooktop",
       "program_url": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Induction%20Cooktop",
-      "item": {
-        "type": "electric_stove",
-        "name": "Electric/Induction Stove"
-      },
       "items": [
         "electric_stove"
       ],
@@ -1323,10 +1143,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department Electric Vehicle Rebate Income Bonus",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -1350,10 +1166,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Residential Energy Efficiency Rebate Program (DIY Weatherization)",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-residential-diy-weatherization-rebate-form.pdf",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -1378,10 +1190,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Smart Thermostats",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-smart-therm-rebate-form.pdf, https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-smart-therm-rebate-form.pdf",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],
@@ -1406,10 +1214,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - LEDs for Indoor Growing",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/led-indoor-growing",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -1434,10 +1238,6 @@
       "authority": "vt-efficiency-vermont",
       "program": "Efficiency Vermont - Window Air Conditioner Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/window-air-conditioners",
-      "item": {
-        "type": "other",
-        "name": "Other"
-      },
       "items": [
         "other"
       ],
@@ -1462,10 +1262,6 @@
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department - Lawn Care - Residential Rebate",
       "program_url": "https://www.burlingtonelectric.com/lawnmowers",
-      "item": {
-        "type": "electric_outdoor_equipment",
-        "name": "Electric Outdoor Equipment"
-      },
       "items": [
         "electric_outdoor_equipment"
       ],

--- a/test/fixtures/v1-vt-05845-vec-ev-low-income.json
+++ b/test/fixtures/v1-vt-05845-vec-ev-low-income.json
@@ -37,10 +37,6 @@
       "authority": "vt-state-of-vermont",
       "program": "MileageSmart Used High Efficiency Vehicle Incentive Program",
       "program_url": "https://www.driveelectricvt.com/incentives/vermont-state-incentives#mileagesmart",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -65,10 +61,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -95,10 +87,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -125,10 +113,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -155,10 +139,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -185,10 +165,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -216,10 +192,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -247,10 +219,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -278,10 +246,6 @@
       "authority": "vt-state-of-vermont",
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -309,10 +273,6 @@
       "authority": "vt-vermont-electric-cooperative",
       "program": "Vermont Electric Co-op Energy Transformation Incentives",
       "program_url": "https://vermontelectric.coop/energy-transformation-programs",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -338,10 +298,6 @@
       "authority": "vt-vermont-electric-cooperative",
       "program": "Vermont Electric Co-op Energy Transformation Incentives",
       "program_url": "https://vermontelectric.coop/energy-transformation-programs",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],
@@ -367,10 +323,6 @@
       "authority": "vt-vermont-electric-cooperative",
       "program": "Vermont Electric Co-op Energy Transformation Incentives",
       "program_url": "https://vermontelectric.coop/energy-transformation-programs",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -395,10 +347,6 @@
       "program": "Federal Clean Vehicle Credit (30D)",
       "program_url": "https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
-      "item": {
-        "type": "new_electric_vehicle",
-        "name": "New Electric Vehicle"
-      },
       "items": [
         "new_electric_vehicle"
       ],
@@ -426,10 +374,6 @@
       "program": "Federal Credit for Previously-Owned Clean Vehicles (25E)",
       "program_url": "https://www.irs.gov/credits-deductions/used-clean-vehicle-credit",
       "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25e-used-ev-tax-incentive",
-      "item": {
-        "type": "used_electric_vehicle",
-        "name": "Used Electric Vehicle"
-      },
       "items": [
         "used_electric_vehicle"
       ],

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -25,10 +25,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Water Heating Rebates",
       "program_url": "https://focusonenergy.com/residential/water-heating",
-      "item": {
-        "type": "heat_pump_water_heater",
-        "name": "Heat Pump Water Heater"
-      },
       "items": [
         "heat_pump_water_heater"
       ],
@@ -51,10 +47,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -79,10 +71,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Heating & Cooling Rebates",
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -107,10 +95,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Heating & Cooling Rebates",
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "item": {
-        "type": "geothermal_heating_installation",
-        "name": "Geothermal Heating Installation"
-      },
       "items": [
         "geothermal_heating_installation"
       ],
@@ -136,10 +120,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -164,10 +144,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -192,10 +168,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -220,10 +192,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Solar for Homes",
       "program_url": "https://focusonenergy.com/residential/solar-for-homes",
-      "item": {
-        "type": "rooftop_solar_installation",
-        "name": "Rooftop Solar Installation"
-      },
       "items": [
         "rooftop_solar_installation"
       ],
@@ -249,10 +217,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -277,10 +241,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Heating & Cooling Rebates",
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "item": {
-        "type": "heat_pump_air_conditioner_heater",
-        "name": "Heat Pump Air Conditioner/Heater"
-      },
       "items": [
         "heat_pump_air_conditioner_heater"
       ],
@@ -305,10 +265,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -333,10 +289,6 @@
       "authority": "wi-focus-on-energy",
       "program": "DIY Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/diy",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -361,10 +313,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -389,10 +337,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "item": {
-        "type": "weatherization",
-        "name": "Weatherization"
-      },
       "items": [
         "weatherization"
       ],
@@ -418,10 +362,6 @@
       "authority": "wi-focus-on-energy",
       "program": "Smart Thermostats Rebates",
       "program_url": "https://focusonenergy.com/residential/smart-thermostats",
-      "item": {
-        "type": "smart_thermostat",
-        "name": "Smart Thermostat"
-      },
       "items": [
         "smart_thermostat"
       ],


### PR DESCRIPTION
## Description

This is the last piece to unlock updating the incentives to have
multiple items.

Embed frontend is already updated to not read this field.

Don't merge until rewiringamerica/consumer#1138 is deployed.

## Test Plan

`yarn test`.
