### PR TITLE
Add CORS plugin for Fastify, in non-production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,6 @@ COPY data data
 COPY locales locales
 
 # go!
+ENV NODE_ENV=production
 ENV PORT=8080
 CMD yarn start

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ You can run the API server as a Docker container, without setting up a developme
 - The container listens for HTTP requests on port 8080.
 - If you have a [Geocodio](https://geocod.io) API key, put it in the environment variable `GEOCODIO_API_KEY` to enable the API server to accept addresses as well as ZIP codes.
 
-- The server does not deal with access control (e.g. API keys), CORS support, or rate limiting. Rewiring America's public API instance uses [Zuplo](https://zuplo.com) to handle those concerns.
+- The server does not deal with access control (e.g. API keys) or rate limiting. Rewiring America's public API instance uses [Zuplo](https://zuplo.com) to handle those concerns.
 
-  If you run your own API server and want to hit it directly from code in a browser, you'll want to add the [Fastify CORS plugin](https://github.com/fastify/fastify-cors).
+  There is also a Fastify plugin to handle CORS, but it's enabled only when `NODE_ENV !== 'production'`, because RA's public API instance also uses Zuplo to handle CORS.
 
 ## API versions
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fastify/autoload": "^5.7.1",
+    "@fastify/cors": "^8.3.0",
     "@fastify/sensible": "^5.2.0",
     "@fastify/swagger": "^8.12.0",
     "@types/cheerio": "^0.22.35",

--- a/src/plugins/cors.ts
+++ b/src/plugins/cors.ts
@@ -1,0 +1,10 @@
+import FastifyCors from '@fastify/cors';
+import fp from 'fastify-plugin';
+
+export default fp(async function (fastify) {
+  if (process.env.NODE_ENV !== 'production') {
+    await fastify.register(FastifyCors, {
+      origin: true,
+    });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,14 @@
   dependencies:
     pkg-up "^3.1.0"
 
+"@fastify/cors@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@fastify/cors/-/cors-8.3.0.tgz#f03d745731b770793a1a15344da7220ca0d19619"
+  integrity sha512-oj9xkka2Tg0MrwuKhsSUumcAkfp2YCnKxmFEusi01pjk1YrdDsuSYTHXEelWNW+ilSy/ApZq0c2SvhKrLX0H1g==
+  dependencies:
+    fastify-plugin "^4.0.0"
+    mnemonist "0.39.5"
+
 "@fastify/deepmerge@^1.0.0", "@fastify/deepmerge@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@fastify/deepmerge/-/deepmerge-1.3.0.tgz#8116858108f0c7d9fd460d05a7d637a13fe3239a"
@@ -3285,6 +3293,13 @@ mkdirp@^3.0.0, mkdirp@^3.0.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
   integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
+mnemonist@0.39.5:
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.39.5.tgz#5850d9b30d1b2bc57cc8787e5caa40f6c3420477"
+  integrity sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==
+  dependencies:
+    obliterator "^2.0.1"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -3496,6 +3511,11 @@ object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
+
+obliterator@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-2.0.4.tgz#fa650e019b2d075d745e44f1effeb13a2adbe816"
+  integrity sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==
 
 on-exit-leak-free@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Description

I keep having to apply this locally when testing the embed frontend
against local API changes, I figure it'll probably be generally
useful.

The plugin is disabled by means of `NODE_ENV` in the Docker build,
because for now the Docker image is only used in prod, and in prod we
have Zuplo handling CORS for us.

## Test Plan

Run `yarn dev` and run the embed frontend with the API host set to
`http://localhost:3000`; make sure calculations succeed, and the CORS
requests are visible in web inspector and in the server log.

Build and run the Docker image; run the embed frontend against it and
make sure the CORS preflight requests fail.
