### PR TITLE
Script and data updates for split items

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -30,7 +30,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "az_mohaveElectricCooperative_mohaveHeatPumpRebate",
     "amount": {
@@ -55,7 +55,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "az_mohaveElectricCooperative_mohaveHeatPumpRebate",
     "amount": {
@@ -129,7 +129,7 @@
       "pos_rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "az_saltRiverProject_insulationRebate",
     "amount": {
@@ -245,7 +245,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "az_sulphurSpringsValleyElectricCooperative_heatPumpRebates",
     "amount": {
@@ -268,7 +268,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "az_tucsonElectricPower_weatherizationAssistance",
     "amount": {
@@ -317,7 +317,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "az_uniSourceEnergyServices_weatherizationAssistance",
     "amount": {
@@ -341,7 +341,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "az_uniSourceEnergyServices_efficientHomeProgram",
     "amount": {
@@ -364,7 +365,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "az_uniSourceEnergyServices_efficientHomeProgram",
     "amount": {

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -33,7 +33,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -60,7 +60,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -87,7 +87,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -114,7 +114,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "basement_insulation"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -141,7 +141,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -168,7 +168,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -194,7 +194,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "duct_sealing"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -246,7 +246,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -273,7 +274,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -300,7 +302,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -327,7 +330,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -354,7 +358,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -381,7 +386,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -408,7 +414,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_coloradoElectricResidentialRebates",
     "amount": {
@@ -434,7 +440,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_electrificationPilotProgram",
     "amount": {
@@ -461,7 +468,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_electrificationPilotProgram",
     "amount": {
@@ -488,7 +496,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_electrificationPilotProgram",
     "amount": {
@@ -515,7 +524,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_blackHillsEnergy_electrificationPilotProgram",
     "amount": {
@@ -702,7 +711,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "co_coloradoSpringsUtilities_residentialEfficiencyRebateProgram",
     "amount": {
@@ -728,7 +737,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_coloradoSpringsUtilities_residentialEfficiencyRebateProgram",
     "amount": {
@@ -754,7 +764,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_coloradoSpringsUtilities_residentialEfficiencyRebateProgram",
     "amount": {
@@ -832,7 +843,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-HomeEnergyRebates",
     "amount": {
@@ -857,7 +869,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-HomeEnergyRebates",
     "amount": {
@@ -907,7 +920,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-HomeEnergyRebates",
     "amount": {
@@ -932,7 +945,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-HomeEnergyRebates",
     "amount": {
@@ -1285,7 +1298,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_platteRiverPowerAuthority_efficiencyWorks",
     "amount": {
@@ -1339,7 +1353,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_platteRiverPowerAuthority_efficiencyWorks",
     "amount": {
@@ -1422,7 +1436,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "co_platteRiverPowerAuthority_efficiencyWorks",
     "amount": {
@@ -1449,7 +1463,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "co_platteRiverPowerAuthority_efficiencyWorks",
     "amount": {
@@ -1477,7 +1491,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "door_replacement",
+      "window_replacement"
     ],
     "program": "co_platteRiverPowerAuthority_efficiencyWorks",
     "amount": {
@@ -1803,7 +1818,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_empireElectricAssociation_energyEfficiencyProductsProgram",
     "amount": {
@@ -1828,7 +1844,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_empireElectricAssociation_energyEfficiencyProductsProgram",
     "amount": {
@@ -1878,7 +1895,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "energy_audit"
     ],
     "program": "co_energyOutreachColorado_weatherizationAssistanceProgram",
     "amount": {
@@ -2263,7 +2280,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_gunnisonCountyElectricAssociation_rebates",
     "amount": {
@@ -2288,7 +2306,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_gunnisonCountyElectricAssociation_rebates",
     "amount": {
@@ -2313,7 +2332,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_gunnisonCountyElectricAssociation_rebates",
     "amount": {
@@ -2338,7 +2358,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_gunnisonCountyElectricAssociation_rebates",
     "amount": {
@@ -2363,7 +2384,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_gunnisonCountyElectricAssociation_rebates",
     "amount": {
@@ -2802,7 +2824,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_holyCrossEnergy_residentialRebates",
     "amount": {
@@ -2825,7 +2847,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_holyCrossEnergy_residentialRebates",
     "amount": {
@@ -2848,7 +2870,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "co_holyCrossEnergy_residentialRebates",
     "amount": {
@@ -2871,7 +2893,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "crawlspace_insulation",
+      "wall_insulation"
     ],
     "program": "co_holyCrossEnergy_residentialRebates",
     "amount": {
@@ -3059,7 +3083,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_laPlataElectricAssociation_electrifyAndSave",
     "amount": {
@@ -3084,7 +3109,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_laPlataElectricAssociation_electrifyAndSave",
     "amount": {
@@ -3157,7 +3183,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_laPlataElectricAssociation_electrifyAndSave",
     "amount": {
@@ -3466,7 +3492,10 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation",
+      "door_replacement",
+      "window_replacement",
+      "air_sealing"
     ],
     "program": "co_morganCountyREA_tri-StateG&T",
     "amount": {
@@ -3537,7 +3566,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_morganCountyREA_tri-StateG&T",
     "amount": {
@@ -3561,7 +3591,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_morganCountyREA_tri-StateG&T",
     "amount": {
@@ -3586,7 +3617,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_morganCountyREA_tri-StateG&T",
     "amount": {
@@ -4006,7 +4038,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_mountainViewElectricAssociation_rebates",
     "amount": {
@@ -4031,7 +4064,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_mountainViewElectricAssociation_rebates",
     "amount": {
@@ -4057,7 +4091,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_mountainViewElectricAssociation_rebates",
     "amount": {
@@ -4315,7 +4350,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_poudreValleyREA_rebatesForResidentialCustomers",
     "amount": {
@@ -4339,7 +4375,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_poudreValleyREA_rebatesForResidentialCustomers",
     "amount": {
@@ -5331,7 +5368,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "co_sanIsabelElectric_sanIsabelElectric",
     "amount": {
@@ -5357,7 +5394,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "co_sanIsabelElectric_sanIsabelElectric",
     "amount": {
@@ -5383,7 +5420,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "co_sanIsabelElectric_sanIsabelElectric",
     "amount": {
@@ -5409,7 +5446,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_sanIsabelElectric_sanIsabelElectric",
     "amount": {
@@ -5435,7 +5473,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_sanIsabelElectric_sanIsabelElectric",
     "amount": {
@@ -5461,32 +5500,7 @@
       "rebate"
     ],
     "items": [
-      "new_electric_vehicle"
-    ],
-    "program": "co_sanIsabelElectric_sanIsabelElectric",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 500
-    },
-    "owner_status": [
-      "homeowner",
-      "renter"
-    ],
-    "short_description": {
-      "en": "$500 off for qualifying plug-in electric vehicle.",
-      "es": "Un descuento de $500 dólares por vehículo eléctrico enchufable que cumpla los requisitos."
-    },
-    "start_date": "2023-01-01",
-    "end_date": "2023-12-31"
-  },
-  {
-    "id": "CO-249",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
-    "payment_methods": [
-      "rebate"
-    ],
-    "items": [
+      "new_electric_vehicle",
       "used_electric_vehicle"
     ],
     "program": "co_sanIsabelElectric_sanIsabelElectric",
@@ -5644,7 +5658,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_sanMiguelPowerAssociation_residentialAndCommercialRebates",
     "amount": {
@@ -5670,7 +5685,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_sanMiguelPowerAssociation_residentialAndCommercialRebates",
     "amount": {
@@ -5833,7 +5848,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "energy_audit"
     ],
     "program": "co_sanMiguelPowerAssociation_residentialAndCommercialRebates",
     "amount": {
@@ -6106,7 +6121,7 @@
       "account_credit"
     ],
     "items": [
-      "new_electric_vehicle"
+      "new_plugin_hybrid_vehicle"
     ],
     "program": "co_sanMiguelPowerAssociation_residentialAndCommercialRebates",
     "amount": {
@@ -6131,7 +6146,7 @@
       "account_credit"
     ],
     "items": [
-      "used_electric_vehicle"
+      "used_plugin_hybrid_vehicle"
     ],
     "program": "co_sanMiguelPowerAssociation_residentialAndCommercialRebates",
     "amount": {
@@ -6398,7 +6413,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
     "amount": {
@@ -6422,7 +6438,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
     "amount": {
@@ -6446,7 +6463,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
     "amount": {
@@ -6493,7 +6510,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_southeastColoradoPowerAssociation_tri-StateG&T",
     "amount": {
@@ -6813,7 +6831,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_tri-StateG&T_tri-StateG&T",
     "amount": {
@@ -6838,7 +6857,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_tri-StateG&T_tri-StateG&T",
     "amount": {
@@ -6863,7 +6883,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_tri-StateG&T_tri-StateG&T",
     "amount": {
@@ -6910,7 +6931,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_unitedPower_tri-StateG&T",
     "amount": {
@@ -6933,7 +6955,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_unitedPower_tri-StateG&T",
     "amount": {
@@ -7026,7 +7049,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_xcelEnergy_heatPumpRebates",
     "amount": {
@@ -7051,7 +7075,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_xcelEnergy_heatPumpRebates",
     "amount": {
@@ -7102,7 +7127,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_xcelEnergy_heatPumpRebates",
     "amount": {
@@ -7127,7 +7152,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_xcelEnergy_heatPumpRebates",
     "amount": {
@@ -7252,7 +7277,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_coloradoEnergyOffice_coloradoHeatPumpTaxCredits",
     "amount": {
@@ -7327,7 +7353,9 @@
       "tax_credit"
     ],
     "items": [
-      "other"
+      "ducted_heat_pump",
+      "ductless_heat_pump",
+      "heat_pump_water_heater"
     ],
     "program": "co_stateOfColorado_coloradoHeatPumpIncentives",
     "amount": {
@@ -7378,7 +7406,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7403,7 +7432,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7453,7 +7483,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7478,7 +7509,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7528,7 +7560,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7553,7 +7585,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7578,7 +7610,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "crawlspace_insulation",
+      "basement_insulation",
+      "air_sealing"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7603,7 +7637,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7628,7 +7662,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "duct_sealing"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7653,7 +7688,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "duct_sealing"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7703,7 +7738,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7729,7 +7765,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_cityOfBoulder_residentialRebates",
     "amount": {
@@ -7829,7 +7866,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -7856,7 +7893,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -7910,7 +7947,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -7937,7 +7974,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -7964,7 +8001,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "air_sealing"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -7991,7 +8029,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -8018,7 +8056,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "crawlspace_insulation",
+      "basement_insulation",
+      "air_sealing"
     ],
     "program": "co_boulderCounty_energySmart",
     "amount": {
@@ -8098,7 +8138,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8125,7 +8165,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8178,7 +8218,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8205,7 +8245,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8232,7 +8272,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8258,7 +8298,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8284,7 +8324,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8391,7 +8431,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "window_replacement"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8444,7 +8484,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "co_boulderCounty_energySmartManufacturedHomesRebates",
     "amount": {
@@ -8522,7 +8562,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "energy_audit"
     ],
     "program": "co_glenwoodSpringsElectric_sustainabilityProgram2023ElectricRebates",
     "amount": {
@@ -8546,7 +8586,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "co_glenwoodSpringsElectric_sustainabilityProgram2023ElectricRebates",
     "amount": {
@@ -8570,7 +8610,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "co_glenwoodSpringsElectric_sustainabilityProgram2023ElectricRebates",
     "amount": {
@@ -8595,7 +8635,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_glenwoodSpringsElectric_sustainabilityProgram2023ElectricRebates",
     "amount": {
@@ -8620,7 +8661,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_glenwoodSpringsElectric_sustainabilityProgram2023ElectricRebates",
     "amount": {
@@ -9157,7 +9198,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_highlineElectricAssociation_rebateProgram",
     "amount": {
@@ -9184,7 +9226,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_highlineElectricAssociation_rebateProgram",
     "amount": {
@@ -9386,7 +9429,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_kCElectricAssociation_rebates",
     "amount": {
@@ -9410,7 +9454,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_kCElectricAssociation_rebates",
     "amount": {
@@ -9434,7 +9479,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_kCElectricAssociation_rebates",
     "amount": {
@@ -9458,7 +9504,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_kCElectricAssociation_rebates",
     "amount": {
@@ -9482,7 +9529,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_kCElectricAssociation_rebates",
     "amount": {
@@ -9888,7 +9936,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_mountainParksElectric_rebates",
     "amount": {
@@ -9912,7 +9961,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_mountainParksElectric_rebates",
     "amount": {
@@ -9936,7 +9986,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_mountainParksElectric_rebates",
     "amount": {
@@ -10148,7 +10199,10 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation",
+      "window_replacement",
+      "door_replacement",
+      "air_sealing"
     ],
     "program": "co_sanLuisValleyREC_energyEfficiencyRebateProgram",
     "amount": {
@@ -10219,7 +10273,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_sanLuisValleyREC_energyEfficiencyRebateProgram",
     "amount": {
@@ -10243,7 +10298,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_sanLuisValleyREC_energyEfficiencyRebateProgram",
     "amount": {
@@ -10268,7 +10324,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_sanLuisValleyREC_energyEfficiencyRebateProgram",
     "amount": {
@@ -10630,7 +10687,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -10653,7 +10710,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -10676,7 +10733,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -10700,7 +10757,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -10724,7 +10781,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -10748,7 +10805,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -10772,7 +10829,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_sangreDeCristoElectricAssociation_rebates",
     "amount": {
@@ -11064,7 +11121,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "other_insulation"
     ],
     "program": "co_townOfAvon_energyEfficiencyProgram",
     "amount": {
@@ -11087,7 +11145,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_townOfAvon_energyEfficiencyProgram",
     "amount": {
@@ -11110,7 +11168,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "other_insulation"
     ],
     "program": "co_townOfEagle_energyEfficiencyProgram",
     "amount": {
@@ -11133,7 +11192,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_townOfEagle_energyEfficiencyProgram",
     "amount": {
@@ -11179,7 +11239,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_townOfErie_rebates",
     "amount": {
@@ -11202,7 +11263,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_townOfErie_rebates",
     "amount": {
@@ -11225,7 +11286,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_townOfErie_rebates",
     "amount": {
@@ -11248,7 +11310,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_townOfErie_rebates",
     "amount": {
@@ -11455,7 +11517,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "other_insulation"
     ],
     "program": "co_townOfVail_energyEfficiencyProgram",
     "amount": {
@@ -11478,7 +11541,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_townOfVail_energyEfficiencyProgram",
     "amount": {
@@ -11623,7 +11687,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "energy_audit"
     ],
     "program": "co_walkingMountains_low-ModerateIncomeProgram",
     "amount": {
@@ -11648,7 +11712,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "duct_sealing",
+      "other_insulation"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11673,7 +11739,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11698,7 +11765,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11723,7 +11790,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11748,7 +11815,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11923,7 +11990,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "duct_sealing",
+      "other_insulation"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11949,7 +12018,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -11975,7 +12045,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -12001,7 +12071,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -12027,7 +12097,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_walkingMountains_rebates&Incentives",
     "amount": {
@@ -12455,7 +12525,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_whiteRiverElectricAssociation_rebates",
     "amount": {
@@ -12478,7 +12549,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_whiteRiverElectricAssociation_rebates",
     "amount": {
@@ -12501,7 +12573,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_whiteRiverElectricAssociation_rebates",
     "amount": {
@@ -12524,7 +12597,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_whiteRiverElectricAssociation_rebates",
     "amount": {
@@ -12547,7 +12621,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "co_whiteRiverElectricAssociation_rebates",
     "amount": {
@@ -12618,7 +12692,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_y-WElectricAssociation_rebateProgram",
     "amount": {
@@ -12643,7 +12718,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "co_y-WElectricAssociation_rebateProgram",
     "amount": {
@@ -12765,7 +12841,12 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation",
+      "floor_insulation",
+      "air_sealing",
+      "duct_sealing",
+      "window_replacement",
+      "door_replacement"
     ],
     "program": "co_sangreDeCristoElectricAssociation_saveEnergy&Money",
     "amount": {

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -7354,8 +7354,7 @@
     ],
     "items": [
       "ducted_heat_pump",
-      "ductless_heat_pump",
-      "heat_pump_water_heater"
+      "ductless_heat_pump"
     ],
     "program": "co_stateOfColorado_coloradoHeatPumpIncentives",
     "amount": {
@@ -7367,8 +7366,8 @@
       "renter"
     ],
     "short_description": {
-      "en": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption.",
-      "es": "Un descuento del 12.9% sobre el precio del equipamiento de bombas de calor y calentadores de agua con bomba de calor, gracias a una condonación fiscal del estado de Colorado y una bonificación del impuesto sobre las ventas."
+      "en": "12.9% discount on the equipment price of heat pumps, through Colorado State tax credit and sales tax exemption.",
+      "es": "Un descuento del 12.9% sobre el precio del equipamiento de bombas de calor, gracias a una condonación fiscal del estado de Colorado y una bonificación del impuesto sobre las ventas."
     },
     "start_date": "2023-01-01",
     "bonus_available": true
@@ -12883,5 +12882,31 @@
     "short_description": {
       "en": "$800 off qualifying new heat pump water heaters for Xcel customers. Must be installed by registered contractor and may not exceed 80 gallons."
     }
+  },
+  {
+    "id": "CO-548",
+    "authority_type": "state",
+    "authority": "co-state-of-colorado",
+    "payment_methods": [
+      "tax_credit"
+    ],
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "co_stateOfColorado_coloradoHeatPumpIncentives",
+    "amount": {
+      "type": "percent",
+      "number": 0.129
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption.",
+      "es": "Un descuento del 12.9% sobre el precio del equipamiento de calentadores de agua con bomba de calor, gracias a una condonación fiscal del estado de Colorado y una bonificación del impuesto sobre las ventas."
+    },
+    "start_date": "2023-01-01",
+    "bonus_available": true
   }
 ]

--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -6,7 +6,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_weatherization"],
     "program": "ct_energizeCtHomeEnergySolutions",
     "amount": {
       "type": "percent",
@@ -77,7 +77,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_weatherization"],
     "program": "ct_energizeCtHomeEnergySolutions",
     "amount": {
       "type": "percent",
@@ -100,7 +100,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["attic_or_roof_insulation"],
     "program": "ct_atticInsulationRebate",
     "amount": {
       "type": "dollars_per_unit",
@@ -149,7 +149,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["energy_audit"],
     "program": "ct_residentialHomeEnergySavingsProgram",
     "amount": {
       "type": "percent",
@@ -193,7 +193,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["wall_insulation"],
     "program": "ct_wallOrAtticInsulationProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -218,7 +218,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["attic_or_roof_insulation"],
     "program": "ct_wallOrAtticInsulationProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -243,7 +243,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ct_coolChoiceProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -268,7 +268,11 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump",
+      "ductless_heat_pump",
+      "geothermal_heating_installation"
+    ],
     "program": "ct_coolingAndHeatingIncentivePilotProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -316,7 +320,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ct_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollars_per_unit",
@@ -389,7 +393,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ct_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollars_per_unit",
@@ -406,31 +410,6 @@
     },
     "start_date": "2023",
     "end_date": "2024"
-  },
-  {
-    "id": "CT-24",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
-    "payment_methods": [
-      "rebate"
-    ],
-    "items": ["geothermal_heating_installation"],
-    "program": "ct_coolingAndHeatingIncentivePilotProgram",
-    "amount": {
-      "type": "dollars_per_unit",
-      "unit": "ton",
-      "number": 1200,
-      "maximum": 20000
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "Size dependent rebate off qualifying ground source heat pumps, up to $20,000.",
-      "es": "Un reembolso de hasta $20,000 dólares en bombas de calor geotérmicas que cumplan los requisitos, y según su tamaño."
-    },
-    "start_date": "2023",
-    "end_date": "2023"
   },
   {
     "id": "CT-25",
@@ -462,7 +441,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ct_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollar_amount",
@@ -485,7 +464,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ct_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollar_amount",

--- a/data/DC/incentives.json
+++ b/data/DC/incentives.json
@@ -160,7 +160,11 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "attic_or_roof_insulation",
+      "wall_insulation",
+      "other_insulation",
+      "crawlspace_insulation"
     ],
     "program": "dc_dCDepartmentOfEnergyAndEnvironment_weatherizationAssistanceProgram",
     "amount": {
@@ -239,7 +243,7 @@
       "assistance_program"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "dc_dCSustainableEnergyUtility_affordableHomeElectrificationProgram",
     "amount": {
@@ -265,7 +269,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "dc_dCSustainableEnergyUtility_dCResidentialRebates",
     "amount": {

--- a/data/GA/incentives.json
+++ b/data/GA/incentives.json
@@ -7,7 +7,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "ga_georgiaPower_homeEnergyImprovementProgram",
     "amount": {
@@ -33,7 +33,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "ga_georgiaPower_homeEnergyImprovementProgram",
     "amount": {
@@ -59,7 +59,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "duct_sealing"
     ],
     "program": "ga_georgiaPower_homeEnergyImprovementProgram",
     "amount": {
@@ -189,7 +189,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "ga_jeffersonEnergyCooperative_heatPumpRebateProgram",
     "amount": {
@@ -214,7 +215,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "ga_georgiaPower_homeEnergyImprovementProgram",
     "amount": {

--- a/data/IL/incentives.json
+++ b/data/IL/incentives.json
@@ -104,7 +104,7 @@
       "pos_rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "il_commonwealthEdison_comEdApplianceRebates",
     "amount": {
@@ -128,7 +128,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "energy_audit"
     ],
     "program": "il_commonwealthEdison_comEdSingleFamilyHomeEnergySavings",
     "amount": {
@@ -221,7 +221,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "il_cornBeltEnergy_cornBeltEnergyRebateProgram",
     "amount": {
@@ -246,7 +247,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "il_cornBeltEnergy_cornBeltEnergyRebateProgram",
     "amount": {
@@ -271,7 +273,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "il_cornBeltEnergy_cornBeltEnergyRebateProgram",
     "amount": {
@@ -344,7 +346,8 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_insulation",
+      "other_weatherization"
     ],
     "program": "il_stateOfIllinois_illinoisHomeWeatherization",
     "amount": {
@@ -370,7 +373,8 @@
       "rebate"
     ],
     "items": [
-      "new_electric_vehicle"
+      "new_electric_vehicle",
+      "used_electric_vehicle"
     ],
     "program": "il_stateOfIllinois_illinoisElectricVehicleRebateProgram",
     "amount": {
@@ -420,7 +424,7 @@
       "account_credit"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives",
     "amount": {
@@ -446,7 +450,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives",
     "amount": {
@@ -472,7 +477,7 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives",
     "amount": {
@@ -498,7 +503,8 @@
       "account_credit"
     ],
     "items": [
-      "weatherization"
+      "other_insulation",
+      "air_sealing"
     ],
     "program": "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives",
     "amount": {
@@ -551,7 +557,7 @@
       "account_credit"
     ],
     "items": [
-      "weatherization"
+      "energy_audit"
     ],
     "program": "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives",
     "amount": {
@@ -631,7 +637,7 @@
       "account_credit"
     ],
     "items": [
-      "weatherization"
+      "energy_audit"
     ],
     "program": "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives",
     "amount": {
@@ -658,7 +664,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "il_midAmericanEnergy_midAmericanEnergyResidentialInstantRebates",
     "amount": {
@@ -684,7 +691,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "il_midAmericanEnergy_midAmericanEnergyResidentialInstantRebates",
     "amount": {
@@ -903,7 +910,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "il_amerenIllinois_amerenInstantIncentives",
     "amount": {
@@ -925,7 +932,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "il_amerenIllinois_amerenInstantIncentives",
     "amount": {
@@ -947,7 +954,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "il_evanstonDevelopmentCooperative_evanstonGreenHomesPilotProgram",
     "amount": {

--- a/data/MI/incentives.json
+++ b/data/MI/incentives.json
@@ -53,7 +53,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "mi_dTE_airConditioners",
     "amount": {
@@ -99,7 +100,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "mi_dTE_airConditioners",
     "amount": {
@@ -143,7 +144,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -165,7 +166,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -187,7 +188,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -209,7 +210,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -231,7 +232,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "basement_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -253,7 +254,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "crawlspace_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -275,7 +276,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "mi_dTE_insulation&Windows",
     "amount": {
@@ -567,7 +568,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "mi_greatLakesEnergyCooperative_energyWise",
     "amount": {
@@ -591,7 +592,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "mi_greatLakesEnergyCooperative_energyWise",
     "amount": {
@@ -617,7 +618,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "mi_greatLakesEnergyCooperative_energyWise",
     "amount": {
@@ -811,7 +812,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "central_air_conditioner"
     ],
     "program": "mi_consumersEnergy_heatingAndCoolingRebates",
     "amount": {
@@ -883,7 +884,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "mi_upperPeninsulaPowerCompany_uPPCOHeatPumpRebates",
     "amount": {
@@ -1121,7 +1123,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "mi_lansingBoardOfWaterAndLight_lansingBWLHeatingAndCoolingRebates",
     "amount": {
@@ -1145,7 +1147,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "mi_lansingBoardOfWaterAndLight_lansingBWLHeatingAndCoolingRebates",
     "amount": {

--- a/data/NV/incentives.json
+++ b/data/NV/incentives.json
@@ -152,7 +152,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "window_replacement"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -178,7 +178,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "door_replacement"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -204,7 +204,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "door_replacement"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -227,7 +227,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -252,7 +252,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -277,7 +277,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -302,7 +302,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -327,7 +327,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -377,7 +377,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -400,7 +400,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_wellsRuralElectric_saveEnergy,SaveMoney",
     "amount": {
@@ -450,7 +451,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_nVEnergy_nVEnergyResidentialAirConditioning",
     "amount": {
@@ -475,7 +477,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_nVEnergy_nVEnergyResidentialAirConditioning",
     "amount": {
@@ -524,7 +526,8 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_nVEnergy_nVEnergyResidentialAirConditioning",
     "amount": {
@@ -550,7 +553,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_nVEnergy_nVEnergyResidentialAirConditioning",
     "amount": {
@@ -598,7 +601,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_lincolnCountyPowerDistrictNo1_residentialAndCommercialHighEfficiencyAirConditioningAndHeatPumpRebate",
     "amount": {
@@ -621,7 +625,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_lincolnCountyPowerDistrictNo1_residentialAndCommercialHighEfficiencyAirConditioningAndHeatPumpRebate",
     "amount": {
@@ -644,7 +649,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_lincolnCountyPowerDistrictNo1_residentialAndCommercialHighEfficiencyAirConditioningAndHeatPumpRebate",
     "amount": {
@@ -667,7 +672,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_lincolnCountyPowerDistrictNo1_residentialAndCommercialHighEfficiencyAirConditioningAndHeatPumpRebate",
     "amount": {
@@ -690,7 +695,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "floor_insulation",
+      "wall_insulation"
     ],
     "program": "nv_mtWheelerPower_windowsAndInsulationRebates",
     "amount": {
@@ -716,7 +723,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "floor_insulation",
+      "wall_insulation"
     ],
     "program": "nv_mtWheelerPower_windowsAndInsulationRebates",
     "amount": {
@@ -894,7 +903,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_mtWheelerPower_airAndHeatRebates",
     "amount": {
@@ -921,7 +931,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_mtWheelerPower_airAndHeatRebates",
     "amount": {
@@ -948,7 +959,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_mtWheelerPower_airAndHeatRebates",
     "amount": {
@@ -1026,7 +1038,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_cityOfBoulderCity_utilityRebateProgram",
     "amount": {
@@ -1051,7 +1064,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_cityOfBoulderCity_utilityRebateProgram",
     "amount": {
@@ -1076,7 +1089,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "central_air_conditioner"
     ],
     "program": "nv_cityOfBoulderCity_utilityRebateProgram",
     "amount": {
@@ -1249,7 +1262,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "door_replacement"
     ],
     "program": "nv_raftRuralElectricCooperative_energyEfficiencyRebate",
     "amount": {
@@ -1321,7 +1334,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "window_replacement"
     ],
     "program": "nv_raftRuralElectricCooperative_energyEfficiencyRebate",
     "amount": {
@@ -1580,7 +1593,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "window_replacement"
     ],
     "program": "nv_plumas-SierraRuralElectricCooperative_rebates",
     "amount": {
@@ -1605,7 +1618,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "nv_plumas-SierraRuralElectricCooperative_rebates",
     "amount": {
@@ -1631,7 +1644,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "central_air_conditioner"
     ],
     "program": "nv_plumas-SierraRuralElectricCooperative_rebates",
     "amount": {
@@ -1657,7 +1670,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "nv_plumas-SierraRuralElectricCooperative_rebates",
     "amount": {
@@ -1683,7 +1697,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "nv_plumas-SierraRuralElectricCooperative_rebates",
     "amount": {
@@ -1736,7 +1750,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "nv_cSAReno_weatherizationAssistanceProgram",
     "amount": {
@@ -1762,7 +1776,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "nv_ruralNevadaDevelopmentCorporation_weatherizationAssistanceProgram",
     "amount": {
@@ -1788,7 +1802,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "nv_nevadaRuralHousing_weatherizationAssistanceProgram",
     "amount": {
@@ -1814,7 +1828,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "nv_hELPOfSouthernNevada_weatherizationAssistanceProgram",
     "amount": {
@@ -1839,7 +1853,9 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization",
+      "duct_sealing",
+      "other_insulation"
     ],
     "program": "nv_nVEnergy_nVEnergyHomeImprovements",
     "amount": {
@@ -1866,7 +1882,7 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "nv_nevadaRuralHousing_weatherizationAssistanceProgram",
     "amount": {

--- a/data/NY/incentives.json
+++ b/data/NY/incentives.json
@@ -50,7 +50,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ny_cleanHeatIncentives",
     "amount": {
       "type": "dollars_per_unit",
@@ -93,7 +93,7 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ny_consolidatedEdisonRebates",
     "amount": {
       "type": "dollar_amount",
@@ -137,7 +137,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_weatherization"],
     "program": "ny_consolidatedEdisonRebates",
     "amount": {
       "type": "percent",
@@ -179,7 +179,7 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump", "ductless_heat_pump"],
     "program": "ny_allElectricHomesProgram",
     "amount": {
       "type": "dollar_amount",
@@ -201,7 +201,7 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ductless_heat_pump"],
     "program": "ny_allElectricHomesProgram",
     "amount": {
       "type": "dollar_amount",
@@ -241,7 +241,7 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ducted_heat_pump"],
     "program": "ny_allElectricHomesProgram",
     "amount": {
       "type": "dollar_amount",
@@ -261,7 +261,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_weatherization"],
     "program": "ny_allElectricHomesProgram",
     "amount": {
       "type": "percent",
@@ -491,7 +491,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["air_sealing", "other_insulation"],
     "program": "ny_comfortHomeProgram",
     "amount": {
       "type": "dollar_amount",

--- a/data/OR/incentives.json
+++ b/data/OR/incentives.json
@@ -7,7 +7,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -30,7 +30,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "or_pacificPower_extendedCapacityHeatPumpRegionalPromotion",
     "amount": {
@@ -54,7 +54,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -77,7 +77,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_extendedCapacityHeatPump",
     "amount": {
@@ -100,7 +100,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -124,7 +125,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -147,7 +149,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -171,7 +173,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -409,7 +411,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "window_replacement"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -432,7 +434,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "window_replacement"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -455,7 +457,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -479,7 +481,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -502,7 +504,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -525,7 +527,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "floor_insulation"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -549,7 +551,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -572,7 +574,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -596,7 +598,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -620,7 +622,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -643,7 +645,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "or_energyTrustOfOregon_savingsWithinReach",
     "amount": {
@@ -667,7 +669,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -690,7 +692,7 @@
       "pos_rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "or_energyTrustOfOregon_energyTrustOfOregon",
     "amount": {
@@ -987,7 +989,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "or_pacificPower_extendedCapacityHeatPumpRegionalPromotion",
     "amount": {
@@ -1009,7 +1011,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "or_pacificPower_heatPumpRegionalPromotion",
     "amount": {
@@ -1031,7 +1033,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "or_pacificPower_heatPumpRegionalPromotion",
     "amount": {

--- a/data/PA/incentives.json
+++ b/data/PA/incentives.json
@@ -7,7 +7,8 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "energy_audit",
+      "other_weatherization"
     ],
     "program": "pa_pennsylvaniaDepartmentOfCommunityAndEconomicDevelopment_pennsylvaniaWeatherizationAssistanceProgram",
     "amount": {
@@ -31,7 +32,8 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "energy_audit",
+      "other_weatherization"
     ],
     "program": "pa_duquesneLightCompany_duquesneHomeWeatherization",
     "amount": {
@@ -55,7 +57,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
@@ -82,7 +85,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
@@ -107,7 +111,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
@@ -133,7 +137,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
@@ -208,7 +212,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "central_air_conditioner"
     ],
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
@@ -235,7 +239,11 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing",
+      "duct_sealing",
+      "attic_or_roof_insulation",
+      "basement_insulation",
+      "crawlspace_insulation"
     ],
     "program": "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram",
     "amount": {
@@ -261,7 +269,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "ductless_heat_pump"
     ],
     "program": "pa_firstEnergy_residentialProductsRebateProgram",
     "amount": {
@@ -287,7 +295,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "pa_firstEnergy_residentialProductsRebateProgram",
     "amount": {
@@ -339,7 +347,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "air_to_water_heat_pump"
     ],
     "program": "pa_firstEnergy_residentialProductsRebateProgram",
     "amount": {
@@ -365,7 +373,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "pa_firstEnergy_residentialProductsRebateProgram",
     "amount": {
@@ -527,7 +536,8 @@
       "assistance_program"
     ],
     "items": [
-      "weatherization"
+      "energy_audit",
+      "other_weatherization"
     ],
     "program": "pa_firstEnergy_firstEnergyWARMProgram",
     "amount": {
@@ -551,7 +561,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "energy_audit"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -574,7 +584,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "central_air_conditioner"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -598,7 +608,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "basement_insulation"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -623,7 +634,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "basement_insulation"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -648,7 +660,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -720,7 +732,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -745,7 +758,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "pa_pPLElectricUtilitiesCorp_products&Rebates",
     "amount": {
@@ -869,7 +882,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "pa_pECO_heating&CoolingRebates",
     "amount": {
@@ -895,7 +909,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "pa_pECO_heating&CoolingRebates",
     "amount": {
@@ -921,7 +935,8 @@
       "rebate"
     ],
     "items": [
-      "new_electric_vehicle"
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
     ],
     "program": "pa_duquesneLightCompany_dLCEVRegistrationIncentive",
     "amount": {
@@ -946,7 +961,8 @@
       "rebate"
     ],
     "items": [
-      "used_electric_vehicle"
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
     ],
     "program": "pa_duquesneLightCompany_dLCEVRegistrationIncentive",
     "amount": {
@@ -971,7 +987,8 @@
       "rebate"
     ],
     "items": [
-      "new_electric_vehicle"
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
     ],
     "program": "pa_pennsylvaniaDepartmentOfEnvironmentalProtection_alternativeFuelVehicleRebates",
     "amount": {
@@ -1000,7 +1017,8 @@
       "rebate"
     ],
     "items": [
-      "used_electric_vehicle"
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
     ],
     "program": "pa_pennsylvaniaDepartmentOfEnvironmentalProtection_alternativeFuelVehicleRebates",
     "amount": {
@@ -1029,7 +1047,8 @@
       "rebate"
     ],
     "items": [
-      "new_electric_vehicle"
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
     ],
     "program": "pa_pennsylvaniaDepartmentOfEnvironmentalProtection_alternativeFuelVehicleRebates",
     "amount": {
@@ -1057,7 +1076,8 @@
       "rebate"
     ],
     "items": [
-      "used_electric_vehicle"
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
     ],
     "program": "pa_pennsylvaniaDepartmentOfEnvironmentalProtection_alternativeFuelVehicleRebates",
     "amount": {
@@ -1085,7 +1105,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "pa_uGIUtilities_equipmentRebateProgram",
     "amount": {

--- a/data/RI/incentive_relationships.json
+++ b/data/RI/incentive_relationships.json
@@ -5,6 +5,9 @@
     ]
   },
   "prerequesites": {
+    "RI-32": {
+      "anyOf": ["RI-30", "RI-31", "RI-33"]
+    },
     "RI-41": "RI-4"
   }
 }

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -6,12 +6,17 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
-    "program": "ri_hvacAndWaterHeaterIncentives",
+    "items": [
+      "geothermal_heating_installation",
+      "ducted_heat_pump",
+      "ductless_heat_pump"
+    ],
+    "program": "ri_pascoagUtilityDistrict_hVAC&WaterHeaterIncentives",
     "amount": {
       "type": "dollars_per_unit",
-      "unit": "ton",
       "number": 350,
+      "unit": "ton",
+      "maximum": 700,
       "representative": 700
     },
     "owner_status": [
@@ -29,11 +34,14 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["heat_pump_water_heater"],
-    "program": "ri_hvacAndWaterHeaterIncentives",
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "ri_pascoagUtilityDistrict_hVAC&WaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
       "number": 450,
+      "minimum": 150,
       "maximum": 450
     },
     "owner_status": [
@@ -51,8 +59,10 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["heat_pump_clothes_dryer"],
-    "program": "ri_residentialEnergyStarOfferings",
+    "items": [
+      "heat_pump_clothes_dryer"
+    ],
+    "program": "ri_pascoagUtilityDistrict_residentialEnergyStarOfferings",
     "amount": {
       "type": "dollar_amount",
       "number": 75
@@ -70,10 +80,13 @@
     "authority_type": "utility",
     "authority": "ri-pascoag-utility-district",
     "payment_methods": [
-      "account_credit"
+      "rebate"
     ],
-    "items": ["weatherization"],
-    "program": "ri_residentialEnergyAuditWeatherization",
+    "items": [
+      "air_sealing",
+      "other_insulation"
+    ],
+    "program": "ri_pascoagUtilityDistrict_residentialEnergyAudit-WeatherizationIncentives",
     "amount": {
       "type": "percent",
       "number": 1,
@@ -95,19 +108,23 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
-    "program": "ri_blockIslandEnergyEfficiency",
+    "items": [
+      "ducted_heat_pump"
+    ],
+    "program": "ri_blockIslandPowerCompany_blockIslandUtilityDistrictEnergyEfficiencyProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 750,
-      "maximum": 750
+      "type": "dollars_per_unit",
+      "number": 250,
+      "unit": "ton",
+      "maximum": 750,
+      "representative": 750
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $750 back after purchase and installation of qualifying heat pumps and mini-splits, depending on size.",
-      "es": "Reembolsos hasta $750 después de la compra e instalación de bombas de calor y mini-splits calificados, según el tamaño."
+      "en": "Up to $750 back after purchase and installation of qualifying ducted heat pumps and mini-splits.",
+      "es": "Reembolsos hasta $750 después de la compra e instalación de bombas de calor con ductos calificados, según el tamaño."
     }
   },
   {
@@ -117,11 +134,14 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
-    "program": "ri_blockIslandEnergyEfficiency",
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "ri_blockIslandPowerCompany_blockIslandUtilityDistrictEnergyEfficiencyProgram",
     "amount": {
       "type": "dollar_amount",
       "number": 300,
+      "minimum": 150,
       "maximum": 300
     },
     "owner_status": [
@@ -139,21 +159,25 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
-    "program": "ri_blockIslandEnergyEfficiency",
+    "items": [
+      "air_sealing",
+      "duct_sealing",
+      "other_insulation"
+    ],
+    "program": "ri_blockIslandPowerCompany_blockIslandUtilityDistrictEnergyEfficiencyProgram",
     "amount": {
       "type": "percent",
       "number": 1,
       "maximum": 2000
     },
-    "bonus_available": true,
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
       "en": "100% of weatherization costs, including air/duct sealing and insulation, up to $2,000.",
       "es": "El total de los costos de la impermeabilización, hasta $2000, incluyendo el sellado de conductos de aire y el aislamiento."
-    }
+    },
+    "bonus_available": true
   },
   {
     "id": "RI-9",
@@ -162,11 +186,15 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
-    "program": "ri_drive",
+    "items": [
+      "new_electric_vehicle"
+    ],
+    "program": "ri_oER_dRIVE",
     "amount": {
       "type": "dollar_amount",
-      "number": 1500
+      "number": 1500,
+      "minimum": 1000,
+      "maximum": 1500
     },
     "owner_status": [
       "homeowner",
@@ -178,40 +206,21 @@
     }
   },
   {
-    "id": "RI-11",
-    "authority_type": "state",
-    "authority": "ri-oer",
-    "payment_methods": [
-      "rebate"
-    ],
-    "items": ["new_electric_vehicle"],
-    "program": "ri_drive_plus",
-    "amount": {
-      "type": "dollar_amount",
-      "number": 1500
-    },
-    "owner_status": [
-      "homeowner",
-      "renter"
-    ],
-    "low_income": "default",
-    "short_description": {
-      "en": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers.",
-      "es": "Un reembolso adicional de $1,500 por la compra o arrendamiento de un vehículo eléctrico nuevo para los calificadores de LIHEAP."
-    }
-  },
-  {
     "id": "RI-10",
     "authority_type": "state",
     "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
-    "program": "ri_drive",
+    "items": [
+      "used_electric_vehicle"
+    ],
+    "program": "ri_oER_dRIVE",
     "amount": {
       "type": "dollar_amount",
-      "number": 1000
+      "number": 1000,
+      "minimum": 750,
+      "maximum": 1000
     },
     "owner_status": [
       "homeowner",
@@ -223,27 +232,58 @@
     }
   },
   {
+    "id": "RI-11",
+    "authority_type": "state",
+    "authority": "ri-oer",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "new_electric_vehicle"
+    ],
+    "program": "ri_oER_dRIVE+",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1500,
+      "minimum": 1000,
+      "maximum": 1500
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers.",
+      "es": "Un reembolso adicional de $1,500 por la compra o arrendamiento de un vehículo eléctrico nuevo para los calificadores de LIHEAP."
+    },
+    "low_income": "default"
+  },
+  {
     "id": "RI-12",
     "authority_type": "state",
     "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
-    "program": "ri_drive_plus",
+    "items": [
+      "used_electric_vehicle"
+    ],
+    "program": "ri_oER_dRIVE+",
     "amount": {
       "type": "dollar_amount",
-      "number": 1500
+      "number": 1500,
+      "minimum": 750,
+      "maximum": 1500
     },
     "owner_status": [
       "homeowner",
       "renter"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "Additional $1,500 towards a used EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers. First-come, first-served.",
       "es": "Un reembolso adicional de $1,500 por un vehículo eléctrico usado para los calificadores de LIHEAP. Por orden de llegada."
-    }
+    },
+    "low_income": "default"
   },
   {
     "id": "RI-13",
@@ -252,8 +292,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["ebike"],
-    "program": "ri_erikaNiedowskiMemorialEBikeRebateProgram",
+    "items": [
+      "ebike"
+    ],
+    "program": "ri_oER_erikaNiedowskiMemorialElectricBicycleRebateProgram",
     "amount": {
       "type": "percent",
       "number": 0.3,
@@ -263,34 +305,59 @@
       "homeowner",
       "renter"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "30% up to $350 back on the final purchase of an e-bike or e-cargo bike.",
       "es": "Devolución del 30% hasta $350 dólares en la compra final de una bicicleta e-bike o una e-cargo bike."
-    }
+    },
+    "start_date": "2022-10-24",
+    "low_income": "default"
   },
   {
-    "id": "RI-43",
+    "id": "RI-14",
     "authority_type": "state",
-    "authority": "ri-oer",
+    "authority": "ri-dhs",
     "payment_methods": [
-      "rebate"
+      "assistance_program"
     ],
-    "items": ["ebike"],
-    "program": "ri_erikaNiedowskiMemorialEBikeRebateProgram",
+    "items": [
+      "other_weatherization"
+    ],
+    "program": "ri_dHS_weatherizationAssistanceProgram",
     "amount": {
       "type": "percent",
-      "number": 0.75,
-      "maximum": 750
+      "number": 1
     },
     "owner_status": [
       "homeowner",
       "renter"
     ],
-    "low_income": "default",
     "short_description": {
-      "en": "75% up to $750 back on the final purchase of an e-bike or e-cargo bike for income qualified residents.",
-      "es": "Devolución del 75% hasta $750 dólares en la compra final de una bicicleta e-bike o una e-cargo bike para residentes que cumplan con el nivel de ingresos."
+      "en": "Weatherization Assistance Program reduces energy costs for households that meet LIHEAP criteria. If you qualify, there's no cost to you.",
+      "es": "Este programa tiene el objetivo de reducir los costes de calefacción y refrigeración para los dueños de hogares y arrendatarios que califican para LIHEAP."
+    },
+    "low_income": "ri-dhs"
+  },
+  {
+    "id": "RI-19",
+    "authority_type": "utility",
+    "authority": "ri-rhode-island-energy",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "heat_pump_clothes_dryer"
+    ],
+    "program": "ri_rhodeIslandEnergy_rhodeIslandENERGYSTAR®CertifiedElectricClothesDryerRebate",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 50
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$50 back on ENERGY STAR® certified electric clothes dryer purchased in 2023. Rebate requests must be completed within 90 days of purchase.",
+      "es": "$50 de reembolso en secadoras de ropa eléctricas certificadas por ENERGY STAR y compradas en 2023. Solicita dentro de los 90 días posteriores a la compra."
     }
   },
   {
@@ -300,13 +367,14 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
-    "program": "ri_residentialHeatPumpWaterHeater",
-    "start_date": "2024",
-    "end_date": "2024",
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "ri_rhodeIslandEnergy_residentialHeatPumpWaterHeaterRebate",
     "amount": {
       "type": "dollar_amount",
       "number": 600,
+      "minimum": 150,
       "maximum": 600
     },
     "owner_status": [
@@ -315,7 +383,9 @@
     "short_description": {
       "en": "Up to $600 back on a qualifying electric heat pump water heater when replacing an existing electric water heater or installing in a new home.",
       "es": "Reembolso hasta $600 cuando reemplaza un calentador de agua eléctrico con calentador de agua con bomba de calor calificado o al instalarlo en una casa nueva."
-    }
+    },
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31"
   },
   {
     "id": "RI-21",
@@ -324,16 +394,17 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["rooftop_solar_installation"],
-    "program": "ri_smallScaleSolar",
+    "items": [
+      "rooftop_solar_installation"
+    ],
+    "program": "ri_commerceCorp_smallScaleSolarProgram",
     "amount": {
       "type": "dollars_per_unit",
-      "unit": "watt",
-      "number": 0.65,
+      "number": 650,
+      "unit": "kilowatt",
       "maximum": 5000,
-      "representative": 3000
+      "representative": 5000
     },
-    "bonus_available": true,
     "owner_status": [
       "homeowner"
     ],
@@ -343,39 +414,16 @@
     }
   },
   {
-    "id": "RI-22",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
-    "payment_methods": [
-      "rebate"
-    ],
-    "items": ["heat_pump_air_conditioner_heater"],
-    "program": "ri_electricHeatingAndCoolingRebates",
-    "start_date": "2024",
-    "end_date": "2024",
-    "amount": {
-      "type": "dollars_per_unit",
-      "unit": "ton",
-      "number": 350,
-      "representative": 700
-    },
-    "bonus_available": true,
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "$150+ back on installation of heat pump, depending on size. Additional funding available to replace electric baseboard resistance heating."
-    }
-  },
-  {
     "id": "RI-27",
     "authority_type": "utility",
     "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
-    "program": "ri_incomeEligibleEnergySavings",
+    "items": [
+      "other_weatherization"
+    ],
+    "program": "ri_rhodeIslandEnergy_incomeEligibleEnergySavingsProgram",
     "amount": {
       "type": "percent",
       "number": 1
@@ -383,34 +431,11 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "ri-rhode-island-energy",
     "short_description": {
       "en": "Income-Eligible Energy Savings Program makes your home healthier, more comfortable and more affordable. If you qualify, there's no cost to you.",
       "es": "Este programa hace que su hogar sea más saludable, cómodo y económico. Si califica, no hay costo para usted."
-    }
-  },
-  {
-    "id": "RI-14",
-    "authority_type": "state",
-    "authority": "ri-dhs",
-    "payment_methods": [
-      "assistance_program"
-    ],
-    "items": ["weatherization"],
-    "program": "ri_dhsWeatherizationAssistanceProgram",
-    "amount": {
-      "type": "percent",
-      "number": 1
     },
-    "owner_status": [
-      "homeowner",
-      "renter"
-    ],
-    "low_income": "ri-dhs",
-    "short_description": {
-      "en": "Weatherization Assistance Program reduces energy costs for households that meet LIHEAP criteria. If you qualify, there's no cost to you.",
-      "es": "Este programa tiene el objetivo de reducir los costes de calefacción y refrigeración para los dueños de hogares y arrendatarios que califican para LIHEAP."
-    }
+    "low_income": "ri-rhode-island-energy"
   },
   {
     "id": "RI-30",
@@ -419,13 +444,16 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
-    "program": "ri_cleanHeat",
+    "items": [
+      "ducted_heat_pump",
+      "ductless_heat_pump"
+    ],
+    "program": "ri_oER_cleanHeatRhodeIslandResidentialIncentive",
     "amount": {
       "type": "dollars_per_unit",
       "number": 1000,
-      "representative": 2500,
-      "unit": "ton"
+      "unit": "ton",
+      "maximum": 10000
     },
     "owner_status": [
       "homeowner"
@@ -442,13 +470,15 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["geothermal_heating_installation"],
-    "program": "ri_cleanHeat",
+    "items": [
+      "geothermal_heating_installation"
+    ],
+    "program": "ri_oER_cleanHeatRhodeIslandResidentialIncentive",
     "amount": {
       "type": "dollars_per_unit",
       "number": 1250,
-      "representative": 2500,
-      "unit": "ton"
+      "unit": "ton",
+      "maximum": 10000
     },
     "owner_status": [
       "homeowner"
@@ -465,8 +495,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_panel"],
-    "program": "ri_cleanHeat",
+    "items": [
+      "other"
+    ],
+    "program": "ri_oER_cleanHeatRhodeIslandResidentialIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 500
@@ -486,11 +518,15 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
-    "program": "ri_cleanHeat",
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "ri_oER_cleanHeatRhodeIslandResidentialIncentive",
     "amount": {
       "type": "dollar_amount",
-      "number": 750
+      "number": 1500,
+      "minimum": 750,
+      "maximum": 1500
     },
     "owner_status": [
       "homeowner"
@@ -507,8 +543,11 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
-    "program": "ri_cleanHeat",
+    "items": [
+      "ducted_heat_pump",
+      "ductless_heat_pump"
+    ],
+    "program": "ri_oER_cleanHeatRhodeIslandResidentialIncome-EligibleIncentive",
     "amount": {
       "type": "percent",
       "number": 1
@@ -516,11 +555,12 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades.",
       "es": "Según sus ingresos, el costo total de instalar una aerotermia. Incluye hasta $3,000 para mejoras eléctricas relacionadas."
-    }
+    },
+    "bonus_available": true,
+    "low_income": "default"
   },
   {
     "id": "RI-35",
@@ -529,8 +569,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
-    "program": "ri_cleanHeat",
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "ri_oER_cleanHeatRhodeIslandResidentialIncome-EligibleIncentive",
     "amount": {
       "type": "percent",
       "number": 1,
@@ -539,33 +581,117 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
     "short_description": {
       "en": "Depending on your income, 100% of the cost to install a heat pump water heater, including up to $3,000 towards related electric service upgrades.",
       "es": "Según sus ingresos, el costo total de instalar un calentador de agua con bomba de calor. Incluye hasta $3,000 para mejoras eléctricas relacionadas."
-    }
+    },
+    "low_income": "default"
   },
   {
-    "id": "RI-41",
+    "id": "RI-37",
     "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
+    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "rebate"
     ],
-    "items": ["smart_thermostat"],
-    "program": "ri_residentialEnergyAuditWeatherization",
+    "items": [
+      "ducted_heat_pump"
+    ],
+    "program": "ri_rhodeIslandEnergy_electricHeatingAndCoolingRebates",
+    "amount": {
+      "type": "dollars_per_unit",
+      "number": 350,
+      "unit": "ton"
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$350+ back on qualifying ducted central heat pump, depending on size. Additional funding available for replacing baseboard resistance heating.",
+      "es": "$350+ de reembolso para la instalación de una bomba de calor central por conductos y más para reemplazar la calefacción eléctrica a base de resistencias."
+    },
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31",
+    "bonus_available": true
+  },
+  {
+    "id": "RI-39",
+    "authority_type": "utility",
+    "authority": "ri-rhode-island-energy",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "ductless_heat_pump"
+    ],
+    "program": "ri_rhodeIslandEnergy_electricHeatingAndCoolingRebates",
+    "amount": {
+      "type": "dollars_per_unit",
+      "number": 150,
+      "unit": "ton"
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$150+ back on qualifying mini-split non-ducted heat pump, depending on size. Additional funding available for replacing baseboard resistance heating.",
+      "es": "$150+ de reembolso para una bomba de calor mini-split sin conductos. Reembolso adicional para reemplazar la calefacción eléctrica a base de resistencias."
+    },
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31",
+    "bonus_available": true
+  },
+  {
+    "id": "RI-40",
+    "authority_type": "utility",
+    "authority": "ri-rhode-island-energy",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "smart_thermostat"
+    ],
+    "program": "ri_rhodeIslandEnergy_electricHeatingAndCoolingRebates",
     "amount": {
       "type": "dollar_amount",
-      "number": 100,
-      "maximum": 100
+      "number": 75
     },
     "owner_status": [
       "homeowner",
       "renter"
     ],
     "short_description": {
-      "en": "$100 back on a programmable wireless connection enabled thermostat. $25 back on a programmable non-wireless thermostat.",
-      "es": "$100 dólares de devolución en termostato programable con conexión inalámbrica. $25 dólares de devolución en termostato programable no inalámbrico."
-    }
+      "en": "$75 back on ENERGY STAR certified, wireless connection enabled Smart Thermostat.",
+      "es": "$75 de reembolso en un termostato inteligente certificado por ENERGY STAR con conexión inalámbrica."
+    },
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31"
+  },
+  {
+    "id": "RI-43",
+    "authority_type": "state",
+    "authority": "ri-oer",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "ebike"
+    ],
+    "program": "ri_oER_erikaNiedowskiMemorialElectricBicycleRebateProgram",
+    "amount": {
+      "type": "percent",
+      "number": 0.75,
+      "maximum": 750
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "75% up to $750 back on the final purchase of an e-bike or e-cargo bike for income qualified residents.",
+      "es": "Devolución del 75% hasta $750 dólares en la compra final de una bicicleta e-bike o una e-cargo bike para residentes que cumplan con el nivel de ingresos."
+    },
+    "start_date": "2022-10-24",
+    "low_income": "default"
   }
 ]

--- a/data/VA/incentives.json
+++ b/data/VA/incentives.json
@@ -29,7 +29,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["attic_or_roof_insulation"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -75,7 +75,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["attic_or_roof_insulation"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -98,7 +98,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ductless_heat_pump"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "dollar_amount",
@@ -119,7 +119,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": ["ductless_heat_pump"],
     "program": "va_takeChargeVirginiaEfficientProductsProgram",
     "amount": {
       "type": "dollar_amount",
@@ -142,7 +142,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["air_sealing"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "dollar_amount",
@@ -186,7 +186,7 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": ["attic_or_roof_insulation"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "dollars_per_unit",
@@ -209,7 +209,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_insulation"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "percent",
@@ -231,7 +231,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_insulation"],
     "program": "va_takeChargeVirginiaHomePerformanceProgram",
     "amount": {
       "type": "percent",
@@ -319,7 +319,7 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": ["other_weatherization"],
     "program": "va_incomeAndAgeQualifyingEnergyEfficiencyProgram",
     "owner_status": [
       "homeowner"

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -6,7 +6,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "air_to_water_heat_pump"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontAirToWaterHeatPumpRebate",
     "amount": {
       "type": "dollars_per_unit",
@@ -31,7 +33,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "air_to_water_heat_pump"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontAirToWaterHeatPumpRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -54,7 +58,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "air_to_water_heat_pump"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForAir-To-WaterHeatPump",
     "amount": {
       "type": "dollars_per_unit",
@@ -81,7 +87,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "air_to_water_heat_pump"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForAir-To-WaterHeatPump",
     "amount": {
       "type": "dollar_amount",
@@ -107,7 +115,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "air_to_water_heat_pump"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-AirToWaterHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -131,7 +141,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_clothes_dryer"],
+    "items": [
+      "heat_pump_clothes_dryer"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontClothesDryerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -155,7 +167,9 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontDuctedHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -179,7 +193,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontDuctedHeatPumpRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -201,7 +217,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_greenMountainPower_greenMountainPowerDuctedHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -224,7 +242,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_vPPSA_vPPSAHeatPumpRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -247,7 +267,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctedHeatPump",
     "amount": {
       "type": "dollar_amount",
@@ -273,7 +295,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctedHeatPump",
     "amount": {
       "type": "dollar_amount",
@@ -298,7 +322,9 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_vermontElectricCooperative_thermalEfficiencyBillCreditBonus",
     "amount": {
       "type": "dollar_amount",
@@ -321,7 +347,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ducted_heat_pump"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-DuctedHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -342,7 +370,9 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ductless_heat_pump"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontDuctlessHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -366,7 +396,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ductless_heat_pump"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontDuctlessHeatPumpRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -390,7 +422,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ductless_heat_pump"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-DuctlessHeatPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -411,7 +445,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ductless_heat_pump"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctlessHeatPump",
     "amount": {
       "type": "percent",
@@ -436,7 +472,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ductless_heat_pump"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctlessHeatPump",
     "amount": {
       "type": "dollar_amount",
@@ -461,7 +499,9 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["heat_pump_air_conditioner_heater"],
+    "items": [
+      "ductless_heat_pump"
+    ],
     "program": "vt_vermontElectricCooperative_thermalEfficiencyBillCreditBonus",
     "amount": {
       "type": "dollar_amount",
@@ -483,7 +523,9 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle"
+    ],
     "program": "vt_stateOfVermont_mileageSmartUsedHighEfficiencyVehicleIncentiveProgram",
     "amount": {
       "type": "percent",
@@ -508,7 +550,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_vehicle_charger"],
+    "items": [
+      "electric_vehicle_charger"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-ResidentialEVChargerRebate",
     "amount": {
       "type": "percent",
@@ -533,7 +577,9 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["electric_vehicle_charger"],
+    "items": [
+      "electric_vehicle_charger"
+    ],
     "program": "vt_vermontElectricCooperative_vermontElectricCoop-FreeLevel2EVCharger",
     "amount": {
       "type": "percent",
@@ -555,7 +601,9 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["electric_vehicle_charger"],
+    "items": [
+      "electric_vehicle_charger"
+    ],
     "program": "vt_vermontElectricCooperative_vermontElectricCoop-BillCreditForLevel2HomeEVChargingEquipment",
     "amount": {
       "type": "dollar_amount",
@@ -578,7 +626,9 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["electric_vehicle_charger"],
+    "items": [
+      "electric_vehicle_charger"
+    ],
     "program": "vt_greenMountainPower_greenMountainPower-FreeLevel2EVCharger",
     "amount": {
       "type": "percent",
@@ -602,7 +652,9 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["electric_vehicle_charger"],
+    "items": [
+      "electric_vehicle_charger"
+    ],
     "program": "vt_washingtonElectricCooperative_washingtonElectricCo-Op-PowerShift",
     "amount": {
       "type": "percent",
@@ -627,7 +679,9 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["electric_vehicle_charger"],
+    "items": [
+      "electric_vehicle_charger"
+    ],
     "program": "vt_vPPSA_vPPSA-PowerShift",
     "amount": {
       "type": "percent",
@@ -651,7 +705,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["geothermal_heating_installation"],
+    "items": [
+      "geothermal_heating_installation"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontGroundSourceHeatPumpRebate",
     "amount": {
       "type": "dollars_per_unit",
@@ -674,7 +730,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["geothermal_heating_installation"],
+    "items": [
+      "geothermal_heating_installation"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontGroundSourceHeatPumpRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -698,7 +756,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["geothermal_heating_installation"],
+    "items": [
+      "geothermal_heating_installation"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-GroundSourceHeatPumpRebate",
     "amount": {
       "type": "dollars_per_unit",
@@ -722,7 +782,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["geothermal_heating_installation"],
+    "items": [
+      "geothermal_heating_installation"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForGroundSourceHeatPump",
     "amount": {
       "type": "dollars_per_unit",
@@ -745,7 +807,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
+    "items": [
+      "heat_pump_water_heater"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontHeatPumpWaterHeaterRebateProgram",
     "amount": {
       "type": "dollar_amount",
@@ -767,7 +831,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
+    "items": [
+      "heat_pump_water_heater"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontHeatPumpWaterHeaterRebateProgram",
     "amount": {
       "type": "percent",
@@ -791,7 +857,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
+    "items": [
+      "heat_pump_water_heater"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForHeatPumpWaterHeater",
     "amount": {
       "type": "dollar_amount",
@@ -816,7 +884,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
+    "items": [
+      "heat_pump_water_heater"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-HeatPumpRebates-IncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -841,7 +911,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
+    "items": [
+      "heat_pump_water_heater"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-HeatPumpWaterHeaterRebate",
     "amount": {
       "type": "dollar_amount",
@@ -865,7 +937,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_stove"],
+    "items": [
+      "electric_stove"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForInductionCooktop",
     "amount": {
       "type": "dollar_amount",
@@ -889,7 +963,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_stove"],
+    "items": [
+      "electric_stove"
+    ],
     "program": "vt_greenMountainPower_greenMountainPower-RebateForInductionCooktop",
     "amount": {
       "type": "dollar_amount",
@@ -913,7 +989,9 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["electric_stove"],
+    "items": [
+      "electric_stove"
+    ],
     "program": "vt_vermontElectricCooperative_vermontElectric-BillCreditForInductionCooktop",
     "amount": {
       "type": "dollar_amount",
@@ -936,7 +1014,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_insulation",
+      "air_sealing"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-ResidentialEnergyEfficiencyRebateProgram(DIYWeatherization)",
     "amount": {
       "type": "dollar_amount",
@@ -959,7 +1040,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_insulation"
+    ],
     "program": "vt_efficiencyVermont_homePerformanceWithENERGYSTAR",
     "amount": {
       "type": "percent",
@@ -983,7 +1066,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_insulation"
+    ],
     "program": "vt_efficiencyVermont_homePerformanceWithENERGYSTAR",
     "amount": {
       "type": "percent",
@@ -1008,7 +1093,11 @@
     "payment_methods": [
       "assistance_program"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "energy_audit",
+      "other_insulation",
+      "air_sealing"
+    ],
     "program": "vt_stateOfVermont_incomeBasedWeatherizationAssistanceProgram",
     "amount": {
       "type": "percent",
@@ -1030,7 +1119,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_weatherization"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-WeatherizationProgram",
     "amount": {
       "type": "percent",
@@ -1052,7 +1143,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_weatherization"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWEC-WeatherizationProgram",
     "amount": {
       "type": "percent",
@@ -1075,7 +1168,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_weatherization"
+    ],
     "program": "vt_vGS_vGSWeatherizationProgram",
     "amount": {
       "type": "percent",
@@ -1098,7 +1193,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_weatherization"
+    ],
     "program": "vt_vGS_vGSWeatherizationRebatesForIncome-QualifiedHomeowners",
     "amount": {
       "type": "percent",
@@ -1121,7 +1218,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-LawnCare-ResidentialRebate",
     "amount": {
       "type": "percent",
@@ -1147,7 +1246,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-LawnCare-ResidentialRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1170,7 +1271,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_greenMountainPower_greenMountainPower-YardCareRebates",
     "amount": {
       "type": "dollar_amount",
@@ -1195,7 +1298,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_greenMountainPower_greenMountainPower-YardCareRebates",
     "amount": {
       "type": "dollar_amount",
@@ -1218,7 +1323,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_stoweElectricDepartment_stoweElectricRebates&Incentives",
     "amount": {
       "type": "dollar_amount",
@@ -1243,7 +1350,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_stoweElectricDepartment_stoweElectricRebates&Incentives",
     "amount": {
       "type": "dollar_amount",
@@ -1267,7 +1376,9 @@
     "payment_methods": [
       "account_credit"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_vermontElectricCooperative_energyTransformationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -1290,7 +1401,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["electric_outdoor_equipment"],
+    "items": [
+      "electric_outdoor_equipment"
+    ],
     "program": "vt_vPPSA_electricLawnMowerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1314,7 +1427,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["smart_thermostat"],
+    "items": [
+      "smart_thermostat"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-SmartThermostats",
     "amount": {
       "type": "dollar_amount",
@@ -1337,7 +1452,9 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-DehumidifierRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1361,7 +1478,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-CentralWoodPelletBoilerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1385,7 +1504,9 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-High-PerformanceCirculatorPumpRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1409,7 +1530,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-ResidentialEnergyEfficiencyRebateProgram",
     "amount": {
       "type": "dollar_amount",
@@ -1432,7 +1555,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-LEDsForIndoorGrowing",
     "amount": {
       "type": "dollar_amount",
@@ -1455,7 +1580,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-Washer&DryerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1478,7 +1605,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-WindowAirConditionerRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1501,7 +1630,9 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["other"],
+    "items": [
+      "other"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermont-Wood&PelletStoveRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1524,7 +1655,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1550,7 +1684,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1577,7 +1714,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1603,7 +1743,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1630,7 +1773,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1656,7 +1802,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1683,7 +1832,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1709,7 +1861,10 @@
     "payment_methods": [
       "pos_rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles",
     "amount": {
       "type": "dollar_amount",
@@ -1736,7 +1891,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_greenMountainPower_greenMountainPowerElectricVehicleRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1760,7 +1918,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
+    ],
     "program": "vt_greenMountainPower_greenMountainPowerElectricVehicleRebate",
     "amount": {
       "type": "dollar_amount",
@@ -1784,7 +1945,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle"
+    ],
     "program": "vt_greenMountainPower_greenMountainPowerElectricVehicleRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -1807,7 +1970,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle"
+    ],
     "program": "vt_greenMountainPower_greenMountainPowerElectricVehicleRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -1830,7 +1995,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartmentElectricVehicleRebates",
     "amount": {
       "type": "dollar_amount",
@@ -1854,7 +2022,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartmentElectricVehicleRebates",
     "amount": {
       "type": "dollar_amount",
@@ -1876,7 +2047,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartmentElectricVehicleRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -1901,7 +2075,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
+    ],
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartmentElectricVehicleRebateIncomeBonus",
     "amount": {
       "type": "dollar_amount",
@@ -1924,7 +2101,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWECTransportationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -1947,7 +2127,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle",
+      "used_plugin_hybrid_vehicle"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWECTransportationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -1970,7 +2153,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle"
+    ],
     "program": "vt_washingtonElectricCooperative_buttonUpWECTransportationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -1994,7 +2179,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_vermontElectricCooperative_vermontElectricCo-OpEnergyTransformationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -2019,7 +2207,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["used_electric_vehicle"],
+    "items": [
+      "used_electric_vehicle"
+    ],
     "program": "vt_vermontElectricCooperative_vermontElectricCo-OpEnergyTransformationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -2044,7 +2234,10 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["new_electric_vehicle"],
+    "items": [
+      "new_electric_vehicle",
+      "new_plugin_hybrid_vehicle"
+    ],
     "program": "vt_vermontElectricCooperative_vermontElectricCo-OpEnergyTransformationIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -2067,7 +2260,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["weatherization"],
+    "items": [
+      "other_weatherization"
+    ],
     "program": "vt_vGS_vGSWeatherizationRebatesForIncome-QualifiedHomeowners",
     "amount": {
       "type": "percent",
@@ -2090,7 +2285,9 @@
     "payment_methods": [
       "rebate"
     ],
-    "items": ["heat_pump_water_heater"],
+    "items": [
+      "heat_pump_water_heater"
+    ],
     "program": "vt_efficiencyVermont_efficiencyVermontHeatPumpWaterHeaterRebateProgram",
     "amount": {
       "type": "percent",

--- a/data/WI/incentives.json
+++ b/data/WI/incentives.json
@@ -8,7 +8,8 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation",
+      "air_sealing"
     ],
     "program": "wi_focusOnEnergy_dIYInsulation&AirSealingRebates",
     "amount": {
@@ -108,7 +109,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_focusOnEnergy_heating&CoolingRebates",
     "amount": {
@@ -133,7 +135,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_focusOnEnergy_heating&CoolingRebates",
     "amount": {
@@ -185,7 +188,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -210,7 +213,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -236,7 +239,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -261,7 +264,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "attic_or_roof_insulation"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -287,7 +290,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -312,7 +315,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_insulation"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -338,7 +341,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "wall_insulation"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -363,7 +366,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "duct_sealing"
     ],
     "program": "wi_focusOnEnergy_insulation&AirSealingRebates",
     "amount": {
@@ -458,7 +461,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_barronElectricCooperative_energySavingsRebates:WaterHeaters",
     "amount": {
@@ -510,7 +513,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_barronElectricCooperative_energySavingsRebates:HVAC",
     "amount": {
@@ -583,7 +587,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_barronElectricCooperative_energySavingsRebates:AuditRecommendedImprovements",
     "amount": {
@@ -700,7 +704,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_bayfieldElectricCooperative_waterHeaterRebates",
     "amount": {
@@ -748,7 +752,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_bayfieldElectricCooperative_hVACRebates",
     "amount": {
@@ -818,7 +823,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_bayfieldElectricCooperative_auditRecommendedImprovementRebates",
     "amount": {
@@ -911,7 +916,7 @@
       "account_credit"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_chippewaValleyElectricCooperative_waterHeaterIncentives",
     "amount": {
@@ -961,7 +966,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_chippewaValleyElectricCooperative_hVACIncentives",
     "amount": {
@@ -1031,7 +1037,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_chippewaValleyElectricCooperative_auditRecommendedImprovementsIncentives",
     "amount": {
@@ -1077,7 +1083,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_clarkElectricCooperative_waterHeaterIncentives",
     "amount": {
@@ -1148,7 +1154,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_clarkElectricCooperative_hVACIncentives",
     "amount": {
@@ -1219,7 +1226,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_clarkElectricCooperative_auditRecommendedImprovementsIncentives",
     "amount": {
@@ -1385,7 +1392,7 @@
       "account_credit"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_dunnEnergyCooperative_homeRebates",
     "amount": {
@@ -1435,7 +1442,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_dunnEnergyCooperative_homeRebates",
     "amount": {
@@ -1576,7 +1584,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_eastCentralEnergy_residentialRebates",
     "amount": {
@@ -1736,7 +1745,8 @@
       "account_credit"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_jacksonElectricCooperative_rebatesAndIncentives",
     "amount": {
@@ -1786,7 +1796,7 @@
       "account_credit"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_jacksonElectricCooperative_rebatesAndIncentives",
     "amount": {
@@ -1810,7 +1820,7 @@
       "account_credit"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_jacksonElectricCooperative_rebatesAndIncentives",
     "amount": {
@@ -1953,7 +1963,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_piercePepinCooperativeServices_electricWaterHeaterRebates",
     "amount": {
@@ -2001,7 +2011,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump"
     ],
     "program": "wi_piercePepinCooperativeServices_hVAC-HeatPumps",
     "amount": {
@@ -2025,7 +2035,7 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ductless_heat_pump"
     ],
     "program": "wi_piercePepinCooperativeServices_hVAC-HeatPumps",
     "amount": {
@@ -2095,7 +2105,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_piercePepinCooperativeServices_energyEfficiencyImprovements",
     "amount": {
@@ -2215,7 +2225,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_polk-BurnettElectricCooperative_hVACRebates",
     "amount": {
@@ -2290,7 +2301,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "air_sealing"
     ],
     "program": "wi_polk-BurnettElectricCooperative_homeImprovementMeasureRebates",
     "amount": {
@@ -2361,7 +2372,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_priceElectricCooperative_pECSmartSenseRebates:WaterHeaters",
     "amount": {
@@ -2409,7 +2420,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_priceElectricCooperative_pECSmartSenseRebates:HVAC",
     "amount": {
@@ -2503,7 +2515,7 @@
       "rebate"
     ],
     "items": [
-      "weatherization"
+      "other_weatherization"
     ],
     "program": "wi_priceElectricCooperative_pECSmartSenseRebates:EnergyAudit-RecommendedImprovements",
     "amount": {
@@ -2619,7 +2631,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "non_heat_pump_water_heater"
     ],
     "program": "wi_riverlandEnergyCooperative_waterHeaterRebates",
     "amount": {
@@ -2667,7 +2679,8 @@
       "rebate"
     ],
     "items": [
-      "heat_pump_air_conditioner_heater"
+      "ducted_heat_pump",
+      "ductless_heat_pump"
     ],
     "program": "wi_riverlandEnergyCooperative_hVACRebates",
     "amount": {

--- a/scripts/incentive-spreadsheet-registry.ts
+++ b/scripts/incentive-spreadsheet-registry.ts
@@ -86,6 +86,7 @@ export const FILES: { [ident: string]: IncentiveFile } = {
     sheetUrl:
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vSoBQdIvYNb9fRkFggllmLZmz9nwL6SYxM7cdsiTPDU90C0HXtFh2r1qlYKdfbTzzxiPZ0o4NpOva__/pub?gid=30198531&single=true&output=csv',
     headerRowNumber: 2,
+    runSpreadsheetHealthCheck: true,
   },
   VA: {
     filepath: 'data/VA/incentives.json',

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -100,19 +100,19 @@ export const FIELD_METADATA: Record<
           'Ground Source Heat Pump (GSHP) / Geothermal HP',
         ],
       },
-      heat_pump_air_conditioner_heater: {
-        value_aliases: [
-          'HVAC - Air Source Heat Pump',
-          'HVAC - Air to Water Heat Pump',
-          'HVAC - Ducted Heat Pump',
-          'HVAC - Ductless Heat Pump',
-        ],
+      air_to_water_heat_pump: {
+        value_aliases: ['HVAC - Air to Water Heat Pump'],
       },
+      central_air_conditioner: { value_aliases: ['Central Air Conditioner'] },
+      ducted_heat_pump: { value_aliases: ['HVAC - Ducted Heat Pump'] },
+      ductless_heat_pump: { value_aliases: ['HVAC - Ductless Heat Pump'] },
       heat_pump_water_heater: {
         value_aliases: ['Heat Pump Water Heater (HPWH)'],
       },
       new_electric_vehicle: { value_aliases: ['New Electric Vehicle'] },
       used_electric_vehicle: { value_aliases: ['Used Electric Vehicle'] },
+      new_plugin_hybrid_vehicle: { value_aliases: ['New Plug-in Hybrid'] },
+      used_plugin_hybrid_vehicle: { value_aliases: ['Used Plug-in Hybrid'] },
       electric_vehicle_charger: { value_aliases: ['Electric Vehicle Charger'] },
       rooftop_solar_installation: { value_aliases: ['Rooftop Solar'] },
       battery_storage_installation: { value_aliases: ['Battery Storage'] },
@@ -122,9 +122,18 @@ export const FIELD_METADATA: Record<
       electric_stove: {
         value_aliases: ['Induction Cooktop', 'Electric Stove'],
       },
-      weatherization: {
-        value_aliases: ['Weatherization (Insulation and Air Sealing)'],
-      },
+      air_sealing: { value_aliases: ['Air Sealing'] },
+      duct_sealing: { value_aliases: ['Duct Sealing'] },
+      attic_or_roof_insulation: { value_aliases: ['Insulation - Attic/Roof'] },
+      basement_insulation: { value_aliases: ['Insulation - Basement'] },
+      crawlspace_insulation: { value_aliases: ['Insulation - Crawlspace'] },
+      floor_insulation: { value_aliases: ['Insulation - Floor'] },
+      other_insulation: { value_aliases: ['Insulation - Other'] },
+      wall_insulation: { value_aliases: ['Insulation - Wall'] },
+      door_replacement: { value_aliases: ['Door Replacement'] },
+      window_replacement: { value_aliases: ['Window Replacement'] },
+      other_weatherization: { value_aliases: ['Other Weatherization'] },
+      energy_audit: { value_aliases: ['Energy Audit/Assessment'] },
       electric_panel: { value_aliases: ['Electric Panel', 'Electric Wiring'] },
       electric_outdoor_equipment: {
         value_aliases: [
@@ -219,7 +228,7 @@ export const FIELD_METADATA: Record<
     critical: true,
     values: {
       rebate: {
-        value_aliases: ['Rebate (Post Purchase)'],
+        value_aliases: ['Rebate (Post Purchase)', 'Rebate'],
         description: 'After purchase rebate',
       },
       pos_rebate: {

--- a/scripts/lib/spreadsheet-standardizer.ts
+++ b/scripts/lib/spreadsheet-standardizer.ts
@@ -81,6 +81,18 @@ export class SpreadsheetStandardizer {
     if (colName === 'owner_status' && val === 'Both') {
       val = 'homeowner, renter';
     }
+
+    // Spreadsheets use "air source heat pump" as a shorthand for ducted or
+    // ductless air-source.
+    if (
+      colName === 'items' &&
+      val.indexOf('HVAC - Air Source Heat Pump') !== -1
+    ) {
+      val = val.replace(
+        'HVAC - Air Source Heat Pump',
+        'ducted_heat_pump, ductless_heat_pump',
+      );
+    }
     return val;
   }
 

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -30,7 +30,7 @@ curl \
 &household_size=4\
 &authority_types=state\
 &authority_types=federal\
-&items=heat_pump_air_conditioner_heater\
+&items=ductless_heat_pump\
 &items=new_electric_vehicle" \
   | jq . > test/fixtures/v1-02807-state-items.json
 

--- a/src/data/programs/ri_programs.ts
+++ b/src/data/programs/ri_programs.ts
@@ -1,5 +1,5 @@
 export const RI_PROGRAMS = {
-  ri_hvacAndWaterHeaterIncentives: {
+  'ri_pascoagUtilityDistrict_hVAC&WaterHeaterIncentives': {
     name: {
       en: 'Pascoag Utility District HVAC & Water Heater Incentives',
     },
@@ -7,7 +7,7 @@ export const RI_PROGRAMS = {
       en: 'https://pud-ri.org/conservation/download-rebate-forms',
     },
   },
-  ri_residentialEnergyStarOfferings: {
+  ri_pascoagUtilityDistrict_residentialEnergyStarOfferings: {
     name: {
       en: 'Pascoag Utility District Residential Energy Star Offerings',
     },
@@ -15,7 +15,7 @@ export const RI_PROGRAMS = {
       en: 'https://pud-ri.org/conservation/download-rebate-forms',
     },
   },
-  ri_residentialEnergyAuditWeatherization: {
+  'ri_pascoagUtilityDistrict_residentialEnergyAudit-WeatherizationIncentives': {
     name: {
       en: 'Pascoag Utility District Residential Energy Audit-Weatherization Incentives',
     },
@@ -23,15 +23,16 @@ export const RI_PROGRAMS = {
       en: 'https://pud-ri.org/conservation/download-rebate-forms',
     },
   },
-  ri_blockIslandEnergyEfficiency: {
-    name: {
-      en: 'Block Island Utility District Energy Efficiency Program',
+  ri_blockIslandPowerCompany_blockIslandUtilityDistrictEnergyEfficiencyProgram:
+    {
+      name: {
+        en: 'Block Island Utility District Energy Efficiency Program',
+      },
+      url: {
+        en: 'https://blockislandpowercompany.com/efficiency-program/',
+      },
     },
-    url: {
-      en: 'https://blockislandpowercompany.com/efficiency-program/',
-    },
-  },
-  ri_drive: {
+  ri_oER_dRIVE: {
     name: {
       en: 'RI Office of Energy Resources DRIVE EV',
     },
@@ -39,7 +40,7 @@ export const RI_PROGRAMS = {
       en: 'https://drive.ri.gov/ev-programs/drive-ev',
     },
   },
-  ri_drive_plus: {
+  'ri_oER_dRIVE+': {
     name: {
       en: 'RI Office of Energy Resources DRIVE+',
     },
@@ -47,7 +48,7 @@ export const RI_PROGRAMS = {
       en: 'https://drive.ri.gov/ev-programs/drive-plus',
     },
   },
-  ri_smallScaleSolar: {
+  ri_commerceCorp_smallScaleSolarProgram: {
     name: {
       en: 'Rhode Island Commerce Corp. Small-Scale Solar Program',
     },
@@ -55,7 +56,7 @@ export const RI_PROGRAMS = {
       en: 'https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf',
     },
   },
-  ri_cleanHeat: {
+  ri_oER_cleanHeatRhodeIslandResidentialIncentive: {
     name: {
       en: 'RI Office of Energy Resources Clean Heat RI',
     },
@@ -63,15 +64,32 @@ export const RI_PROGRAMS = {
       en: 'https://cleanheatri.com/',
     },
   },
-  ri_energyStarClothesDryer: {
+  'ri_oER_cleanHeatRhodeIslandResidentialIncome-EligibleIncentive': {
     name: {
-      en: 'Rhode Island Energy ENERGY STAR® Certified Electric Clothes Dryer Rebate',
+      en: 'RI Office of Energy Resources Clean Heat RI Income-Eligible Incentive',
     },
     url: {
-      en: 'https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs',
+      en: 'https://cleanheatri.com/',
     },
   },
-  ri_residentialHeatPumpWaterHeater: {
+  ri_oER_erikaNiedowskiMemorialElectricBicycleRebateProgram: {
+    name: {
+      en: 'Erika Niedowski Memorial Electric Bicycle Rebate Program',
+    },
+    url: {
+      en: 'https://drive.ri.gov/erika-niedowski-memorial-electric-bicycle-rebate-program',
+    },
+  },
+  'ri_rhodeIslandEnergy_rhodeIslandENERGYSTAR®CertifiedElectricClothesDryerRebate':
+    {
+      name: {
+        en: 'Rhode Island Energy ENERGY STAR® Certified Electric Clothes Dryer Rebate',
+      },
+      url: {
+        en: 'https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs',
+      },
+    },
+  ri_rhodeIslandEnergy_residentialHeatPumpWaterHeaterRebate: {
     name: {
       en: 'Rhode Island Energy residential heat pump water heater rebates',
     },
@@ -79,15 +97,15 @@ export const RI_PROGRAMS = {
       en: 'https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs',
     },
   },
-  ri_electricHeatingAndCoolingRebates: {
+  ri_rhodeIslandEnergy_electricHeatingAndCoolingRebates: {
     name: {
-      en: 'Rhode Island Energy residential electric heating and cooling rebates',
+      en: 'Rhode Island Energy Electric Heating and Cooling Rebates',
     },
     url: {
       en: 'https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives',
     },
   },
-  ri_incomeEligibleEnergySavings: {
+  ri_rhodeIslandEnergy_incomeEligibleEnergySavingsProgram: {
     name: {
       en: 'Rhode Island Energy Income-Eligible Energy Savings Program',
     },
@@ -95,7 +113,7 @@ export const RI_PROGRAMS = {
       en: 'https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services',
     },
   },
-  ri_dhsWeatherizationAssistanceProgram: {
+  ri_dHS_weatherizationAssistanceProgram: {
     name: {
       en: 'RI Department of Human Services Weatherization Assistance Program',
     },

--- a/test/fixtures/il-60304-state-utility-lowincome.json
+++ b/test/fixtures/il-60304-state-utility-lowincome.json
@@ -53,7 +53,8 @@
       "program": "Illinois Home Weatherization",
       "program_url": "https://dceo.illinois.gov/communityservices/homeweatherization/howtoapply.html",
       "items": [
-        "weatherization"
+        "other_insulation",
+        "other_weatherization"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -77,7 +78,8 @@
       "program": "Illinois Electric Vehicle Rebate Program",
       "program_url": "https://epa.illinois.gov/topics/ceja/electric-vehicle-rebates.html",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "used_electric_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-02807-state-items.json
+++ b/test/fixtures/v1-02807-state-items.json
@@ -24,39 +24,15 @@
   "incentives": [
     {
       "payment_methods": [
-        "pos_rebate"
-      ],
-      "authority_type": "federal",
-      "program": "Federal Home Electrification and Appliance Rebates (HEAR)",
-      "program_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates",
-      "items": [
-        "heat_pump_air_conditioner_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 8000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2025",
-      "end_date": "2032",
-      "ami_qualification": "less_than_80_ami",
-      "eligible": true,
-      "short_description": "Low-income households get a 100% rebate on heat pumps up to $8,000; moderate-income households get 50% up to $8,000."
-    },
-    {
-      "payment_methods": [
         "rebate"
       ],
       "authority_type": "state",
       "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
+      "program": "RI Office of Energy Resources Clean Heat RI Income-Eligible Incentive",
       "program_url": "https://cleanheatri.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -78,12 +54,13 @@
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1000,
-        "representative": 2500,
+        "maximum": 10000,
         "unit": "ton"
       },
       "owner_status": [
@@ -106,7 +83,8 @@
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 1500
+        "number": 1500,
+        "maximum": 1500
       },
       "owner_status": [
         "homeowner",
@@ -129,7 +107,8 @@
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 1500
+        "number": 1500,
+        "maximum": 1500
       },
       "owner_status": [
         "homeowner",
@@ -165,30 +144,6 @@
       "filing_status": "joint",
       "eligible": true,
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
-    },
-    {
-      "payment_methods": [
-        "tax_credit"
-      ],
-      "authority_type": "federal",
-      "program": "Federal Energy Efficient Home Improvement Credit (25C)",
-      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
-      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
-      "items": [
-        "heat_pump_air_conditioner_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 2000
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2023",
-      "end_date": "2032",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     }
   ]
 }

--- a/test/fixtures/v1-02903-state-utility-lowincome.json
+++ b/test/fixtures/v1-02903-state-utility-lowincome.json
@@ -11,6 +11,9 @@
         "height": 100
       }
     },
+    "ri-dhs": {
+      "name": "Rhode Island Department of Human Services"
+    },
     "ri-rhode-island-energy": {
       "name": "Rhode Island Energy",
       "logo": {
@@ -21,9 +24,6 @@
     },
     "ri-commerce-corp": {
       "name": "Rhode Island Commerce Corporation"
-    },
-    "ri-dhs": {
-      "name": "Rhode Island Department of Human Services"
     }
   },
   "coverage": {
@@ -45,7 +45,7 @@
       "program": "RI Department of Human Services Weatherization Assistance Program",
       "program_url": "https://dhs.ri.gov/programs-and-services/energy-assistance-programs/weatherization-assistance-program-wap",
       "items": [
-        "weatherization"
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -68,7 +68,7 @@
       "program": "Rhode Island Energy Income-Eligible Energy Savings Program",
       "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services",
       "items": [
-        "weatherization"
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -87,10 +87,11 @@
       ],
       "authority_type": "state",
       "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
+      "program": "RI Office of Energy Resources Clean Heat RI Income-Eligible Incentive",
       "program_url": "https://cleanheatri.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -109,7 +110,7 @@
       ],
       "authority_type": "state",
       "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
+      "program": "RI Office of Energy Resources Clean Heat RI Income-Eligible Incentive",
       "program_url": "https://cleanheatri.com/",
       "items": [
         "heat_pump_water_heater"
@@ -146,6 +147,7 @@
         "homeowner",
         "renter"
       ],
+      "start_date": "2022-10-24",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "75% up to $750 back on the final purchase of an e-bike or e-cargo bike for income qualified residents."
@@ -170,6 +172,7 @@
         "homeowner",
         "renter"
       ],
+      "start_date": "2022-10-24",
       "ami_qualification": null,
       "eligible": false,
       "short_description": "30% up to $350 back on the final purchase of an e-bike or e-cargo bike."
@@ -188,7 +191,7 @@
       "amount": {
         "type": "dollars_per_unit",
         "number": 1250,
-        "representative": 2500,
+        "maximum": 10000,
         "unit": "ton"
       },
       "owner_status": [
@@ -207,12 +210,13 @@
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollars_per_unit",
         "number": 1000,
-        "representative": 2500,
+        "maximum": 10000,
         "unit": "ton"
       },
       "owner_status": [
@@ -221,32 +225,6 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "ri-rhode-island-energy",
-      "program": "Rhode Island Energy residential electric heating and cooling rebates",
-      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives",
-      "items": [
-        "heat_pump_air_conditioner_heater"
-      ],
-      "amount": {
-        "type": "dollars_per_unit",
-        "number": 350,
-        "representative": 700,
-        "unit": "ton"
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2024",
-      "end_date": "2024",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "$150+ back on installation of heat pump, depending on size. Additional funding available to replace electric baseboard resistance heating."
     },
     {
       "payment_methods": [
@@ -261,10 +239,10 @@
       ],
       "amount": {
         "type": "dollars_per_unit",
-        "number": 0.65,
+        "number": 650,
         "maximum": 5000,
-        "representative": 3000,
-        "unit": "watt"
+        "representative": 5000,
+        "unit": "kilowatt"
       },
       "owner_status": [
         "homeowner"
@@ -272,6 +250,56 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "10-25% back on installation costs up to $5,000. Includes electricity-generating solar panels and solar domestic hot water technologies."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "ri-rhode-island-energy",
+      "program": "Rhode Island Energy Electric Heating and Cooling Rebates",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives",
+      "items": [
+        "ducted_heat_pump"
+      ],
+      "amount": {
+        "type": "dollars_per_unit",
+        "number": 350,
+        "unit": "ton"
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$350+ back on qualifying ducted central heat pump, depending on size. Additional funding available for replacing baseboard resistance heating."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "ri-rhode-island-energy",
+      "program": "Rhode Island Energy Electric Heating and Cooling Rebates",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives",
+      "items": [
+        "ductless_heat_pump"
+      ],
+      "amount": {
+        "type": "dollars_per_unit",
+        "number": 150,
+        "unit": "ton"
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$150+ back on qualifying mini-split non-ducted heat pump, depending on size. Additional funding available for replacing baseboard resistance heating."
     },
     {
       "payment_methods": [
@@ -286,7 +314,8 @@
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 1500
+        "number": 1500,
+        "maximum": 1500
       },
       "owner_status": [
         "homeowner",
@@ -309,7 +338,8 @@
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 1500
+        "number": 1500,
+        "maximum": 1500
       },
       "owner_status": [
         "homeowner",
@@ -332,7 +362,8 @@
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 1500
+        "number": 1500,
+        "maximum": 1500
       },
       "owner_status": [
         "homeowner",
@@ -348,6 +379,29 @@
       ],
       "authority_type": "state",
       "authority": "ri-oer",
+      "program": "RI Office of Energy Resources Clean Heat RI",
+      "program_url": "https://cleanheatri.com/",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1500,
+        "maximum": 1500
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE EV",
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "items": [
@@ -355,7 +409,8 @@
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 1000
+        "number": 1000,
+        "maximum": 1000
       },
       "owner_status": [
         "homeowner",
@@ -364,28 +419,6 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $1,000 back after purchase or lease of a used EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
-      "program_url": "https://cleanheatri.com/",
-      "items": [
-        "heat_pump_water_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 750
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters."
     },
     {
       "payment_methods": [
@@ -406,8 +439,8 @@
       "owner_status": [
         "homeowner"
       ],
-      "start_date": "2024",
-      "end_date": "2024",
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $600 back on a qualifying electric heat pump water heater when replacing an existing electric water heater or installing in a new home."
@@ -421,7 +454,7 @@
       "program": "RI Office of Energy Resources Clean Heat RI",
       "program_url": "https://cleanheatri.com/",
       "items": [
-        "electric_panel"
+        "other"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -433,6 +466,53 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Additional $500 for an electrical service upgrade at the same time as installation of a heat pump or heat pump water heater."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "ri-rhode-island-energy",
+      "program": "Rhode Island Energy Electric Heating and Cooling Rebates",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives",
+      "items": [
+        "smart_thermostat"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 75
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$75 back on ENERGY STAR certified, wireless connection enabled Smart Thermostat."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "ri-rhode-island-energy",
+      "program": "Rhode Island Energy ENERGY STAR® Certified Electric Clothes Dryer Rebate",
+      "program_url": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs",
+      "items": [
+        "heat_pump_clothes_dryer"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 50
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "$50 back on ENERGY STAR® certified electric clothes dryer purchased in 2023. Rebate requests must be completed within 90 days of purchase."
     }
   ]
 }

--- a/test/fixtures/v1-15289-homeowner-85000-joint-4.json
+++ b/test/fixtures/v1-15289-homeowner-85000-joint-4.json
@@ -29,7 +29,8 @@
       "program": "Pennsylvania Weatherization Assistance Program",
       "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
       "items": [
-        "weatherization"
+        "energy_audit",
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -246,7 +247,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -272,7 +274,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "used_electric_vehicle"
+        "used_electric_vehicle",
+        "used_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -298,7 +301,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -324,7 +328,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "used_electric_vehicle"
+        "used_electric_vehicle",
+        "used_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -81,8 +81,6 @@
       "program": "Colorado Heat Pump Incentives",
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
       "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump",
         "heat_pump_water_heater"
       ],
       "amount": {
@@ -96,7 +94,7 @@
       "start_date": "2023-01-01",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
+      "short_description": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     }
   ]
 }

--- a/test/fixtures/v1-80517-estes-park.json
+++ b/test/fixtures/v1-80517-estes-park.json
@@ -8,6 +8,9 @@
     },
     "co-colorado-energy-office": {
       "name": "Colorado Energy Office"
+    },
+    "co-state-of-colorado": {
+      "name": "State of Colorado"
     }
   },
   "coverage": {
@@ -68,6 +71,32 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "Up to $900 off a heat pump water heater UEF 3.3. ENERGY STAR certified with CTA-2045 certified communication control."
+    },
+    {
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "state",
+      "authority": "co-state-of-colorado",
+      "program": "Colorado Heat Pump Incentives",
+      "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
+      "items": [
+        "ducted_heat_pump",
+        "ductless_heat_pump",
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 0.129
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-01-01",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     }
   ]
 }

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -6,6 +6,9 @@
     "co-colorado-energy-office": {
       "name": "Colorado Energy Office"
     },
+    "co-state-of-colorado": {
+      "name": "State of Colorado"
+    },
     "co-xcel-energy": {
       "name": "Xcel Energy"
     }
@@ -65,6 +68,32 @@
       "ami_qualification": null,
       "eligible": true,
       "short_description": "$800 off qualifying new heat pump water heaters for Xcel customers. Must be installed by registered contractor and may not exceed 80 gallons."
+    },
+    {
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "state",
+      "authority": "co-state-of-colorado",
+      "program": "Colorado Heat Pump Incentives",
+      "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
+      "items": [
+        "ducted_heat_pump",
+        "ductless_heat_pump",
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 0.129
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-01-01",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     }
   ]
 }

--- a/test/fixtures/v1-80517-xcel.json
+++ b/test/fixtures/v1-80517-xcel.json
@@ -6,11 +6,11 @@
     "co-colorado-energy-office": {
       "name": "Colorado Energy Office"
     },
-    "co-state-of-colorado": {
-      "name": "State of Colorado"
-    },
     "co-xcel-energy": {
       "name": "Xcel Energy"
+    },
+    "co-state-of-colorado": {
+      "name": "State of Colorado"
     }
   },
   "coverage": {
@@ -78,8 +78,6 @@
       "program": "Colorado Heat Pump Incentives",
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
       "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump",
         "heat_pump_water_heater"
       ],
       "amount": {
@@ -93,7 +91,7 @@
       "start_date": "2023-01-01",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
+      "short_description": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     }
   ]
 }

--- a/test/fixtures/v1-az-85701-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85701-state-utility-lowincome.json
@@ -26,7 +26,7 @@
       "program": "Weatherization assistance",
       "program_url": "https://www.tep.com/weatherization-assistance/",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-az-85702-state-utility-lowincome.json
+++ b/test/fixtures/v1-az-85702-state-utility-lowincome.json
@@ -26,7 +26,7 @@
       "program": "Weatherization assistance",
       "program_url": "https://www.uesaz.com/weatherization-assistance/",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -48,7 +48,8 @@
       "program": "Efficient Home Program",
       "program_url": "https://www.uesaz.com/efficient-home-program/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -70,7 +71,8 @@
       "program": "Efficient Home Program",
       "program_url": "https://www.uesaz.com/efficient-home-program/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -879,7 +879,30 @@
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
       "items": [
         "ducted_heat_pump",
-        "ductless_heat_pump",
+        "ductless_heat_pump"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 0.129
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2023-01-01",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "12.9% discount on the equipment price of heat pumps, through Colorado State tax credit and sales tax exemption."
+    },
+    {
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "state",
+      "authority": "co-state-of-colorado",
+      "program": "Colorado Heat Pump Incentives",
+      "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
+      "items": [
         "heat_pump_water_heater"
       ],
       "amount": {
@@ -893,7 +916,7 @@
       "start_date": "2023-01-01",
       "ami_qualification": null,
       "eligible": true,
-      "short_description": "12.9% discount on the equipment price of heat pumps and heat pump water heaters, through Colorado State tax credit and sales tax exemption."
+      "short_description": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     },
     {
       "payment_methods": [

--- a/test/fixtures/v1-co-81657-state-utility-lowincome.json
+++ b/test/fixtures/v1-co-81657-state-utility-lowincome.json
@@ -63,7 +63,8 @@
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -86,7 +87,7 @@
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -109,7 +110,8 @@
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -132,7 +134,7 @@
       "program": "Xcel Energy Heat Pump Rebates",
       "program_url": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -154,7 +156,7 @@
       "program": "Walking Mountains Low-Moderate Income Program",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "weatherization"
+        "energy_audit"
       ],
       "amount": {
         "type": "percent",
@@ -176,7 +178,7 @@
       "program": "Energy Outreach Colorado Weatherization Assistance Program",
       "program_url": "https://socgov02.my.site.com/ceoweatherization/s/",
       "items": [
-        "weatherization"
+        "energy_audit"
       ],
       "amount": {
         "type": "percent",
@@ -269,7 +271,8 @@
       "program": "Colorado Heat Pump Tax Credits",
       "program_url": "https://energyoffice.colorado.gov/hptc",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -317,7 +320,9 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "weatherization"
+        "air_sealing",
+        "duct_sealing",
+        "other_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -340,7 +345,8 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -363,7 +369,7 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -386,7 +392,7 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -409,7 +415,7 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -570,7 +576,9 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "weatherization"
+        "air_sealing",
+        "duct_sealing",
+        "other_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -593,7 +601,8 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -616,7 +625,7 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -639,7 +648,7 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -662,7 +671,7 @@
       "program": "Walking Mountains Rebates & Incentives",
       "program_url": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -869,7 +878,9 @@
       "program": "Colorado Heat Pump Incentives",
       "program_url": "https://energysmartcolorado.org/tax-credits-incentives/",
       "items": [
-        "other"
+        "ducted_heat_pump",
+        "ductless_heat_pump",
+        "heat_pump_water_heater"
       ],
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-ct-06002-state-utility-lowincome.json
+++ b/test/fixtures/v1-ct-06002-state-utility-lowincome.json
@@ -29,7 +29,7 @@
       "program": "Energize CT Home Energy Solutions",
       "program_url": "https://energizect.com/energy-evaluations/income-eligible-options",
       "items": [
-        "weatherization"
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -148,7 +148,8 @@
       "program": "Energize CT Residential Air Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -222,7 +223,8 @@
       "program": "Energize CT Residential Air Source Heat Pump Incentive",
       "program_url": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-dc-20303-state-city-lowincome.json
+++ b/test/fixtures/v1-dc-20303-state-city-lowincome.json
@@ -112,7 +112,11 @@
       "program": "Weatherization Assistance Program",
       "program_url": "https://doee.dc.gov/service/wap",
       "items": [
-        "weatherization"
+        "air_sealing",
+        "attic_or_roof_insulation",
+        "wall_insulation",
+        "other_insulation",
+        "crawlspace_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -187,7 +191,7 @@
       "program": "Affordable Home Electrification Program",
       "program_url": "https://www.dcseu.com/affordable-home-electrification",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -212,7 +216,7 @@
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-ga-30033-utility.json
+++ b/test/fixtures/v1-ga-30033-utility.json
@@ -26,7 +26,7 @@
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -51,7 +51,7 @@
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "items": [
-        "weatherization"
+        "air_sealing"
       ],
       "amount": {
         "type": "percent",
@@ -76,7 +76,7 @@
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "items": [
-        "weatherization"
+        "duct_sealing"
       ],
       "amount": {
         "type": "percent",
@@ -201,7 +201,7 @@
       "program": "Home Energy Improvement Program",
       "program_url": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-il-60202-city-lowincome.json
+++ b/test/fixtures/v1-il-60202-city-lowincome.json
@@ -26,7 +26,7 @@
       "program": "Evanston Green Homes Pilot Program",
       "program_url": "https://greenhomes.cnt.org/",
       "items": [
-        "weatherization"
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-mi-48103-state-utility-lowincome.json
+++ b/test/fixtures/v1-mi-48103-state-utility-lowincome.json
@@ -50,7 +50,7 @@
       "program": "Air Conditioners",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -72,7 +72,8 @@
       "program": "Air Conditioners",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -164,7 +165,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -186,7 +187,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "wall_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -230,7 +231,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -252,7 +253,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "basement_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -274,7 +275,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "crawlspace_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -296,7 +297,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "floor_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -318,7 +319,7 @@
       "program": "Insulation & Windows",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-mi-48825-city-lowincome.json
+++ b/test/fixtures/v1-mi-48825-city-lowincome.json
@@ -96,7 +96,7 @@
       "program": "Lansing BWL Heating and Cooling Rebates",
       "program_url": "https://www.lbwl.com/hvac",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -143,7 +143,7 @@
       "program": "Lansing BWL Heating and Cooling Rebates",
       "program_url": "https://www.lbwl.com/hvac",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-nv-89108-state-utility-lowincome.json
+++ b/test/fixtures/v1-nv-89108-state-utility-lowincome.json
@@ -81,7 +81,8 @@
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -127,7 +128,7 @@
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -149,7 +150,8 @@
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -195,7 +197,7 @@
       "program": "NV Energy Residential Air Conditioning",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -285,7 +287,9 @@
       "program": "NV Energy Home Improvements",
       "program_url": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/home-improvements",
       "items": [
-        "weatherization"
+        "other_weatherization",
+        "duct_sealing",
+        "other_insulation"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-ny-11557-state-utility-lowincome.json
+++ b/test/fixtures/v1-ny-11557-state-utility-lowincome.json
@@ -32,7 +32,7 @@
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
       "items": [
-        "weatherization"
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -102,7 +102,8 @@
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -147,7 +148,7 @@
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -169,7 +170,7 @@
       "program": "All Electric Homes Program",
       "program_url": "https://homeenergy.pseg.com",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -191,7 +192,8 @@
       "program": "New York State Comfort Home Program",
       "program_url": "https://www.nyserda.ny.gov/All-Programs/Comfort-Home-Program",
       "items": [
-        "weatherization"
+        "air_sealing",
+        "other_insulation"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-or-97001-state-lowincome.json
+++ b/test/fixtures/v1-or-97001-state-lowincome.json
@@ -26,7 +26,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -93,7 +93,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "window_replacement"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -116,7 +116,7 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -139,7 +139,7 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -162,7 +162,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -185,7 +185,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -208,7 +208,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "window_replacement"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -231,7 +231,7 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "floor_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -254,7 +254,7 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "floor_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -277,7 +277,7 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "wall_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -300,7 +300,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "floor_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -323,7 +323,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "floor_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -346,7 +346,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "weatherization"
+        "wall_insulation"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -369,7 +369,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -392,7 +392,8 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -415,7 +416,7 @@
       "program": "Savings Within Reach",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -438,7 +439,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -461,7 +462,7 @@
       "program": "Extended Capacity Heat Pump",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -484,7 +485,8 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -507,7 +509,7 @@
       "program": "Energy Trust of Oregon",
       "program_url": "https://www.energytrust.org/residential/incentives",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-pa-17555-state-lowincome.json
+++ b/test/fixtures/v1-pa-17555-state-lowincome.json
@@ -32,7 +32,8 @@
       "program": "Pennsylvania Weatherization Assistance Program",
       "program_url": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/",
       "items": [
-        "weatherization"
+        "energy_audit",
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -54,7 +55,8 @@
       "program": "First Energy WARM Program",
       "program_url": "https://www.firstenergycorp.com/save_energy/save_energy_pennsylvania/met_ed/for_your_home/warm-info.html",
       "items": [
-        "weatherization"
+        "energy_audit",
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",
@@ -149,7 +151,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -175,7 +178,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "used_electric_vehicle"
+        "used_electric_vehicle",
+        "used_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -201,7 +205,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -227,7 +232,8 @@
       "program": "Alternative Fuel Vehicle Rebates",
       "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
       "items": [
-        "used_electric_vehicle"
+        "used_electric_vehicle",
+        "used_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -277,7 +283,8 @@
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -302,7 +309,7 @@
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -326,7 +333,7 @@
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
       "items": [
-        "other"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -350,7 +357,7 @@
       "program": "Residential Products Rebate Program",
       "program_url": "https://rebates.energysavepa.com/",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-va-22030-state-utility-lowincome.json
+++ b/test/fixtures/v1-va-22030-state-utility-lowincome.json
@@ -26,7 +26,7 @@
       "program": "Income and Age Qualifying Energy Efficiency Program",
       "program_url": "https://www.dominionenergy.com/virginia/save-energy/income-and-age-qualifying-home-improvements",
       "items": [
-        "weatherization"
+        "other_weatherization"
       ],
       "amount": {
         "type": "percent",

--- a/test/fixtures/v1-vt-05401-state-utility-lowincome.json
+++ b/test/fixtures/v1-vt-05401-state-utility-lowincome.json
@@ -41,7 +41,9 @@
       "program": "Income based Weatherization Assistance Program",
       "program_url": "https://dcf.vermont.gov/benefits/weatherization",
       "items": [
-        "weatherization"
+        "energy_audit",
+        "other_insulation",
+        "air_sealing"
       ],
       "amount": {
         "type": "percent",
@@ -87,7 +89,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -113,7 +116,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -139,7 +143,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -165,7 +170,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -191,7 +197,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -218,7 +225,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -245,7 +253,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -272,7 +281,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -299,7 +309,7 @@
       "program": "Efficiency Vermont Ducted Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -323,7 +333,7 @@
       "program": "Efficiency Vermont Ductless Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -466,7 +476,7 @@
       "program": "Burlington Electric Department - Rebate for Ductless Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Mini-Split%20Heat%20Pump",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "percent",
@@ -515,7 +525,7 @@
       "program": "Home performance with ENERGY STAR",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -539,7 +549,7 @@
       "program": "Home performance with ENERGY STAR",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "percent",
@@ -612,7 +622,7 @@
       "program": "Burlington Electric Department - Rebate for Air-to-Water Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -662,7 +672,7 @@
       "program": "Efficiency Vermont Air to Water Heat Pump Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "dollars_per_unit",
@@ -687,7 +697,7 @@
       "program": "Burlington Electric Department - Rebate for Ducted Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/heatpumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -736,7 +746,8 @@
       "program": "Burlington Electric Department Electric Vehicle Rebates",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -760,7 +771,8 @@
       "program": "Burlington Electric Department Electric Vehicle Rebates",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
       "items": [
-        "used_electric_vehicle"
+        "used_electric_vehicle",
+        "used_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -783,7 +795,7 @@
       "program": "Efficiency Vermont Ductless Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -831,7 +843,8 @@
       "program": "Burlington Electric Department Electric Vehicle Rebate Income Bonus",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -902,7 +915,7 @@
       "program": "Efficiency Vermont Air to Water Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -949,7 +962,7 @@
       "program": "Burlington Electric Department - Rebate for Air-to-Water Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "air_to_water_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -998,7 +1011,7 @@
       "program": "Burlington Electric Department - Rebate for Ducted Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/heatpumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -1023,7 +1036,7 @@
       "program": "Burlington Electric Department - Rebate for Ductless Heat Pump",
       "program_url": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Mini-Split%20Heat%20Pump",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -1072,7 +1085,7 @@
       "program": "Efficiency Vermont Ducted Heat Pump Rebate Income Bonus",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -1144,7 +1157,8 @@
       "program": "Burlington Electric Department Electric Vehicle Rebate Income Bonus",
       "program_url": "https://www.burlingtonelectric.com/evrebates/",
       "items": [
-        "used_electric_vehicle"
+        "used_electric_vehicle",
+        "used_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -1167,7 +1181,8 @@
       "program": "Efficiency Vermont - Residential Energy Efficiency Rebate Program (DIY Weatherization)",
       "program_url": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-residential-diy-weatherization-rebate-form.pdf",
       "items": [
-        "weatherization"
+        "other_insulation",
+        "air_sealing"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-vt-05845-vec-ev-low-income.json
+++ b/test/fixtures/v1-vt-05845-vec-ev-low-income.json
@@ -62,7 +62,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -88,7 +89,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -114,7 +116,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -140,7 +143,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -166,7 +170,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -193,7 +198,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -220,7 +226,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -247,7 +254,8 @@
       "program": "State of Vermont Incentives for New Electric Vehicles",
       "program_url": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -274,7 +282,8 @@
       "program": "Vermont Electric Co-op Energy Transformation Incentives",
       "program_url": "https://vermontelectric.coop/energy-transformation-programs",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -324,7 +333,8 @@
       "program": "Vermont Electric Co-op Energy Transformation Incentives",
       "program_url": "https://vermontelectric.coop/energy-transformation-programs",
       "items": [
-        "new_electric_vehicle"
+        "new_electric_vehicle",
+        "new_plugin_hybrid_vehicle"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/fixtures/v1-wi-53703-state-utility-lowincome.json
+++ b/test/fixtures/v1-wi-53703-state-utility-lowincome.json
@@ -48,7 +48,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "air_sealing"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -72,7 +72,8 @@
       "program": "Heating & Cooling Rebates",
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -121,7 +122,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -145,7 +146,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "air_sealing"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -169,7 +170,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -218,7 +219,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "wall_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -242,7 +243,8 @@
       "program": "Heating & Cooling Rebates",
       "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
       "items": [
-        "heat_pump_air_conditioner_heater"
+        "ducted_heat_pump",
+        "ductless_heat_pump"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -266,7 +268,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -290,7 +292,8 @@
       "program": "DIY Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/diy",
       "items": [
-        "weatherization"
+        "attic_or_roof_insulation",
+        "air_sealing"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -314,7 +317,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "other_insulation"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -338,7 +341,7 @@
       "program": "Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
       "items": [
-        "weatherization"
+        "duct_sealing"
       ],
       "amount": {
         "type": "dollar_amount",

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -118,7 +118,7 @@ test('response with state and item filtering is valid and correct', async t => {
       household_income: 65000,
       tax_filing: 'joint',
       authority_types: ['federal', 'state'],
-      items: ['heat_pump_air_conditioner_heater', 'new_electric_vehicle'],
+      items: ['ductless_heat_pump', 'new_electric_vehicle'],
     },
     './test/fixtures/v1-02807-state-items.json',
   );

--- a/test/scripts/spreadsheet-standardizer.test.ts
+++ b/test/scripts/spreadsheet-standardizer.test.ts
@@ -162,7 +162,7 @@ test('representative example', tap => {
     program_status: 'active',
     start_date: '2022-01-01',
     end_date: '2026-12-31',
-    payment_methods: 'Rebate',
+    payment_methods: 'rebate',
     rebate_value: '$50',
     'amount.type': 'dollar_amount',
     'amount.number': '',


### PR DESCRIPTION
## Description

I went through all the spreadsheets that currently pass the health
test, updated the item enums (on the enum values sheet) to include all
the new items, then updated all the rows that were about HVAC and
weatherization to have the more specific values.

There are plenty of cases where multiple items are needed in one
row. For these, I:

1. turned off the data validation in the spreadsheet,

2. manually set their "technology" column to comma-separated item
   values, such as `Door Replacement,Window Replacement`

3. turned data validation back on.

This is cheating to get around the validation, and it'll be annoying
to anyone who wants to update those cells, but I'm hoping the
spreadsheets won't last much longer.

In addition, I got the RI sheet passing the health test. So **RI is
the only data file that really needs an in-depth review**. I had to
add more program entries, and I made some substantive updates to the
incentives (other than just the items).

For other states where the health check is not passing, I just updated
the JSON.

### Follow-up

I need to make sure the frontend can handle all the extent multi-item
incentives. In particular, in my PR that added the concept of item
groups to the frontend, I didn't handle incentives that combine audit
and weatherization services.

## Test Plan

`yarn test`, and `yarn check-spreadsheet-health`. (The latter is currently
failing because a bunch of Spanish translations just got added, but
that's the only diff.)