### PR TITLE
Add lint rule to enforce braces on control flow statements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,5 +6,6 @@ module.exports = {
   root: true,
   rules: {
     eqeqeq: ['error', 'always'],
+    curly: ['error', 'all'],
   },
 };

--- a/scripts/export-to-google-sheets.ts
+++ b/scripts/export-to-google-sheets.ts
@@ -12,10 +12,11 @@ import { FIELD_MAPPINGS, FIELD_METADATA } from './lib/spreadsheet-mappings';
 const INCENTIVE_SHEET_NAME = 'Incentives Data';
 
 async function exportToGoogleSheets(state: string, file: IncentiveFile) {
-  if (!file.collectedFilepath)
+  if (!file.collectedFilepath) {
     throw new Error(
       `No collected data defined for state ${state}; modify spreadsheet registry.`,
     );
+  }
 
   const collected: CollectedIncentive[] = JSON.parse(
     fs.readFileSync(file.collectedFilepath!, 'utf-8'),

--- a/scripts/generate-spanish-descriptions.ts
+++ b/scripts/generate-spanish-descriptions.ts
@@ -129,8 +129,9 @@ async function logTranslations(file: IncentiveFile, model_family: string) {
       [EXAMPLE_USER, EXAMPLE_RESPONSE],
     ]);
     const resp = await queryGpt(prompt, model_family);
-    if (resp === undefined)
+    if (resp === undefined) {
       throw new Error('Undefined response received from GPT');
+    }
     const spanish = resp.split('\n');
     if (spanish.length !== english.length) {
       throw new Error(

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -58,7 +58,9 @@ function updateJsonFiles(
   deleteEmpty: boolean = true,
 ) {
   const dir = path.dirname(filepath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+  }
   if (records.length === 0 && deleteEmpty) {
     safeDeleteFiles(filepath);
   } else {
@@ -132,7 +134,9 @@ const urlRegex = new RegExp(
 );
 export function extractIdsFromUrl(url: string): UrlParts {
   const match = url.match(urlRegex);
-  if (!match) throw new Error(`Could not extract IDs from URL: ${url}`);
+  if (!match) {
+    throw new Error(`Could not extract IDs from URL: ${url}`);
+  }
   return {
     spreadsheetId: match[1],
     incentiveDataSheetId: +match[2],
@@ -191,10 +195,11 @@ async function convertToJson(
   let rows: Record<string, string>[];
   if (file.collectedFilepath) {
     const auth = await authorize();
-    if (!auth)
+    if (!auth) {
       throw new Error(
         'Unable to authenticate to Google Sheets API. Confirm you have credentials in the secrets/ folder.',
       );
+    }
     const sheetsClient = google.sheets({ version: 'v4', auth: auth });
     const data = await retrieveGoogleSheet(file, sheetsClient);
     rows = googleSheetToFlatData(

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -57,8 +57,9 @@ export function createAuthorityName(
   state: string,
   authorityName: string,
 ): string {
-  if (authorityName === undefined)
+  if (authorityName === undefined) {
     throw new Error('Undefined authority: check input file');
+  }
   return (
     state.toLowerCase() + '-' + kebabCase(authorityName.replaceAll('.', ''))
   );
@@ -69,10 +70,12 @@ export function createProgramName(
   authorityName: string,
   programName: string,
 ): string {
-  if (authorityName === undefined)
+  if (authorityName === undefined) {
     throw new Error('Undefined authority: check input file');
-  if (programName === undefined)
+  }
+  if (programName === undefined) {
     throw new Error('Undefined program title: check input file');
+  }
   return (
     state.toLowerCase() +
     '_' +
@@ -221,9 +224,13 @@ export function maybeUpdateProgramsTsFile(
   let lastStateImport = 0;
   for (const [ind, importDec] of sourceFile.getImportDeclarations().entries()) {
     const defaultImport = importDec.getDefaultImport();
-    if (!defaultImport) continue;
+    if (!defaultImport) {
+      continue;
+    }
     // Skip non-state imports.
-    if (!defaultImport!.getText().endsWith('_PROGRAMS')) continue;
+    if (!defaultImport!.getText().endsWith('_PROGRAMS')) {
+      continue;
+    }
     lastStateImport = ind;
     // If the current import is alphabetically greater than the new one,
     // insert a new import and exit the loop.
@@ -257,7 +264,9 @@ export function maybeUpdateProgramsTsFile(
   // See tests for how this string-hacking is supposed to work.
   const components = varInitializer.getText().split(',\n');
   for (const [ind, component] of components.entries()) {
-    if (ind === 0) continue; // skip ira_incentives
+    if (ind === 0) {
+      continue;
+    } // skip ira_incentives
     // This still works for the last component since it starts with }
     if (component > `  ...${newDefaultImport}`) {
       components.splice(ind, 0, `  ...${newDefaultImport}`);

--- a/scripts/lib/format-converter.ts
+++ b/scripts/lib/format-converter.ts
@@ -92,9 +92,13 @@ export function flatToNested(
   for (const row of rows) {
     const output: NestedKeyVal = {};
     for (const columnName in row) {
-      if (ignoreCols.includes(columnName)) continue;
+      if (ignoreCols.includes(columnName)) {
+        continue;
+      }
       let val = row[columnName];
-      if (val === '') continue;
+      if (val === '') {
+        continue;
+      }
       if (arrayCols.includes(columnName)) {
         // Assume comma-delimited array and split into components.
         val = val.split(',').map((s: string) => s.trim());
@@ -132,8 +136,12 @@ export function flatToNested(
 // values. Any other value will (appropriately) cause the schema validation to
 // fail, so we don't deal with errors here.
 function coerceToBoolean(input: string): boolean | string {
-  if (input.toLowerCase() === 'true') return true;
-  if (input.toLowerCase() === 'false') return false;
+  if (input.toLowerCase() === 'true') {
+    return true;
+  }
+  if (input.toLowerCase() === 'false') {
+    return false;
+  }
   return input;
 }
 
@@ -184,13 +192,17 @@ export function googleSheetToFlatData(
   convertLinks: LinkMode,
   headerRow: number,
 ): Record<string, string>[] {
-  if (!incentives.data) throw new Error('No grid data in GoogleSheet');
+  if (!incentives.data) {
+    throw new Error('No grid data in GoogleSheet');
+  }
 
   const cellAddressToHyperlinks: { [index: string]: string[] } = {};
   const records: Record<string, string>[] = [];
   const headers: string[] = [];
   incentives.data[0].rowData!.forEach((row, rIndex) => {
-    if (rIndex < headerRow - 1) return; // skip pre-header rows
+    if (rIndex < headerRow - 1) {
+      return;
+    } // skip pre-header rows
     if (rIndex === headerRow - 1) {
       if (!row.values) {
         throw new Error(
@@ -220,7 +232,9 @@ export function googleSheetToFlatData(
       });
       // This targets spreadsheet rows where we only have the ID and nothing
       // else is populated. We have this in some spreadsheets for convenience.
-      if (Object.keys(record).length < 2) return;
+      if (Object.keys(record).length < 2) {
+        return;
+      }
       records.push(record);
     }
   });
@@ -249,7 +263,9 @@ export type StringKeyed = { [index: string]: any };
 export function nestedToFlat(input: StringKeyed): StringKeyed {
   const output: StringKeyed = {};
   for (const [fieldName, fieldValue] of Object.entries(input)) {
-    if (fieldValue === undefined) continue;
+    if (fieldValue === undefined) {
+      continue;
+    }
     if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
       for (const [nestedKey, nestedVal] of Object.entries(
         nestedToFlat(fieldValue),

--- a/scripts/spreadsheets-health.test.ts
+++ b/scripts/spreadsheets-health.test.ts
@@ -29,7 +29,9 @@ function filterToKeyFields(
 
 test('registered spreadsheets are in sync with checked-in JSON files', async tap => {
   for (const [state, file] of Object.entries(FILES)) {
-    if (!file.runSpreadsheetHealthCheck) continue;
+    if (!file.runSpreadsheetHealthCheck) {
+      continue;
+    }
     try {
       const response = await fetch(file.sheetUrl);
       const csvContent = await response.text();

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -276,7 +276,9 @@ function skipBasedOnRequestParams(
   // tracks long-term work in this space.
   if (incentive.authority_type === AuthorityType.County) {
     // Skip if we didn't get location data.
-    if (location.countyFips === undefined) return true;
+    if (location.countyFips === undefined) {
+      return true;
+    }
 
     // We have tests to ensure county authorities are registered.
     const authorityDetails = stateAuthorities.county![incentive.authority];

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -13,8 +13,11 @@ export const isStateIncluded = (
   (includeBeta && BETA_STATES.includes(stateId));
 
 const getStatus = (state: string) => {
-  if (LAUNCHED_STATES.includes(state)) return StateStatus.Launched;
-  else if (BETA_STATES.includes(state)) return StateStatus.Beta;
+  if (LAUNCHED_STATES.includes(state)) {
+    return StateStatus.Launched;
+  } else if (BETA_STATES.includes(state)) {
+    return StateStatus.Beta;
+  }
   return StateStatus.None;
 };
 


### PR DESCRIPTION
## Description

I'm personally opposed to `if (condition) doStuff()`; I think it's
best to always have braces in those situations to avoid silly and
potentially quite consequential mistake. This adds an eslint rule to
enforce that, and fixes all existing instances.

## Test Plan

`yarn lint`, `yarn test`
