### PR TITLE
Fix some issues with RI data

### DIFF
--- a/data/RI/incentive_relationships.json
+++ b/data/RI/incentive_relationships.json
@@ -4,10 +4,11 @@
       "RI-13"
     ]
   },
-  "prerequesites": {
+  "prerequisites": {
     "RI-32": {
       "anyOf": ["RI-30", "RI-31", "RI-33"]
     },
-    "RI-41": "RI-4"
+    "RI-41": "RI-4",
+    "RI-42": "RI-4"
   }
 }

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -668,6 +668,54 @@
     "end_date": "2024-12-31"
   },
   {
+    "id": "RI-41",
+    "authority_type": "utility",
+    "authority": "ri-pascoag-utility-district",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "smart_thermostat"
+    ],
+    "program": "ri_pascoagUtilityDistrict_residentialEnergyAudit-WeatherizationIncentives",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 100
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$100 back on programmable wireless connection enabled thermostat.",
+      "es": "$100 dólares de devolución en termostato programable con conexión inalámbrica."
+    }
+  },
+  {
+    "id": "RI-42",
+    "authority_type": "utility",
+    "authority": "ri-pascoag-utility-district",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "smart_thermostat"
+    ],
+    "program": "ri_pascoagUtilityDistrict_residentialEnergyAudit-WeatherizationIncentives",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 25
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$25 back on programmable non-wireless thermostat.",
+      "es": "$25 dólares de devolución en termostato programable no inalámbrico."
+    }
+  },
+  {
     "id": "RI-43",
     "authority_type": "state",
     "authority": "ri-oer",

--- a/src/data/state_incentive_relationships.ts
+++ b/src/data/state_incentive_relationships.ts
@@ -53,6 +53,7 @@ export const INCENTIVE_RELATIONSHIPS_SCHEMA = {
       },
     },
   },
+  additionalProperties: false,
 } as const;
 
 export type IncentivePrerequisites = FromSchema<typeof prerequisiteSchema>;


### PR DESCRIPTION
## Description

While scanning the RI data for an unrelated reason
(https://app.asana.com/0/1206661332626418/1205768907565555), I noticed
that `prerequisites` was misspelled in the relationships file. This
led me to discover a whole cascading series of issues:

- The schema for relationships files did not include
  `additionalProperties: false` which would have caught this. I added
  that.

- The schemas test wasn't even testing the RI relationships file
  because it relied on a redundant and outdated list of relationships
  files. I deleted the redundant list and made it use the real one.

- The prereqs contained a reference to an incentive that wasn't in the
  data: it was a smart thermostat incentive that had been marked as
  "omit" in the spreadsheet (from before we had smart thermostats
  represented). Un-omitted those and added them to the JSON via script.

- There was a second smart thermostat incentive that needed the same
  prereq. Added that relationship.

## Test Plan

`yarn test`
