### PR TITLE
Support per-county low income thresholds

### DIFF
--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1,6 +1,7 @@
 {
   "AZ": {
     "default": {
+      "type": "hhsize",
       "incentives": [
         "AZ-18",
         "AZ-21"
@@ -20,6 +21,7 @@
   },
   "CO": {
     "co-black-hills-energy": {
+      "type": "hhsize",
       "incentives": [
         "CO-24",
         "CO-25",
@@ -40,6 +42,7 @@
       }
     },
     "co-city-and-county-of-denver": {
+      "type": "hhsize",
       "incentives": [
         "CO-46",
         "CO-47"
@@ -57,6 +60,7 @@
       }
     },
     "co-energy-outreach-colorado": {
+      "type": "hhsize",
       "incentives": [
         "CO-103"
       ],
@@ -75,6 +79,7 @@
       }
     },
     "co-colorado-energy-office": {
+      "type": "hhsize",
       "incentives": [
         "CO-318",
         "CO-319"
@@ -94,6 +99,7 @@
       }
     },
     "co-city-of-boulder": {
+      "type": "hhsize",
       "incentives": [
         "CO-335"
       ],
@@ -110,6 +116,7 @@
       }
     },
     "co-glenwood-springs-electric": {
+      "type": "hhsize",
       "incentives": [
         "CO-376"
       ],
@@ -126,6 +133,7 @@
       }
     },
     "co-sangre-de-cristo": {
+      "type": "hhsize",
       "incentives": [
         "CO-541",
         "CO-542"
@@ -145,6 +153,7 @@
       }
     },
     "co-walking-mountains": {
+      "type": "hhsize",
       "incentives": [
         "CO-494",
         "CO-506",
@@ -174,6 +183,7 @@
   },
   "CT": {
     "default": {
+      "type": "hhsize",
       "incentives": [
         "CT-1",
         "CT-4"
@@ -191,6 +201,7 @@
       }
     },
     "ct-cheapr": {
+      "type": "hhsize",
       "incentives": [
         "CT-33",
         "CT-34"
@@ -210,6 +221,7 @@
   },
   "DC": {
     "dc-dc-sustainable-energy-utility": {
+      "type": "hhsize",
       "incentives": [
         "DC-16",
         "DC-19",
@@ -231,6 +243,7 @@
     },
     "dc-dc-department-of-energy-and-environment-60-ami": {
       "/": "DOEE's Weatherization Assistance Program's threshold is 60% AMI",
+      "type": "hhsize",
       "incentives": [
         "DC-21"
       ],
@@ -250,6 +263,7 @@
   "GA": {},
   "IL": {
     "il-home-weatherization": {
+      "type": "hhsize",
       "incentives": [
         "IL-16"
       ],
@@ -266,6 +280,7 @@
       }
     },
     "il-comEd-single-family-home-energy-savings": {
+      "type": "hhsize",
       "incentives": [
         "IL-6"
       ],
@@ -282,6 +297,7 @@
       }
     },
     "il-solar-for-all": {
+      "type": "hhsize",
       "incentives": [
         "IL-33"
       ],
@@ -298,6 +314,7 @@
       }
     },
     "il-evanston-green-homes-pilot-program": {
+      "type": "hhsize",
       "incentives": [
         "IL-40",
         "IL-41",
@@ -319,6 +336,7 @@
   },
   "MI": {
     "mi-lbwl": {
+      "type": "hhsize",
       "incentives": [
         "MI-73"
       ],
@@ -335,6 +353,7 @@
       }
     },
     "mi-dte": {
+      "type": "hhsize",
       "incentives": [
         "MI-39"
       ],
@@ -353,6 +372,7 @@
   },
   "PA": {
     "pa-department-of-community-and-economic-development": {
+      "type": "hhsize",
       "incentives": [
         "PA-1"
       ],
@@ -369,6 +389,7 @@
       }
     },
     "pa-duquesne-light-company": {
+      "type": "hhsize",
       "incentives": [
         "PA-2"
       ],
@@ -385,6 +406,7 @@
       }
     },
     "pa-first-energy": {
+      "type": "hhsize",
       "incentives": [
         "PA-21",
         "PA-25"
@@ -402,6 +424,7 @@
       }
     },
     "pa-first-energy-warm": {
+      "type": "hhsize",
       "incentives": [
         "PA-26"
       ],
@@ -418,6 +441,7 @@
       }
     },
     "pa-pennsylvania-department-of-environmental-protection": {
+      "type": "hhsize",
       "incentives": [
         "PA-47",
         "PA-48"
@@ -435,6 +459,7 @@
       }
     },
     "pa-pennsylvania-department-of-environmental-protection-bonus": {
+      "type": "hhsize",
       "incentives": [
         "PA-49",
         "PA-50"
@@ -454,6 +479,7 @@
   },
   "NV": {
     "nv-nv-energy-appliance-replacement": {
+      "type": "hhsize",
       "incentives": [
         "NV-17"
       ],
@@ -470,6 +496,7 @@
       }
     },
     "nv-nv-energy-residential-air-conditioning": {
+      "type": "hhsize",
       "incentives": [
         "NV-23",
         "NV-24",
@@ -488,6 +515,7 @@
       }
     },
     "nv-csa-reno": {
+      "type": "hhsize",
       "incentives": [
         "NV-74"
       ],
@@ -504,6 +532,7 @@
       }
     },
     "nv-rural-nevada-development-corporation": {
+      "type": "hhsize",
       "incentives": [
         "NV-75"
       ],
@@ -520,6 +549,7 @@
       }
     },
     "nv-nevada-rural-housing": {
+      "type": "hhsize",
       "incentives": [
         "NV-76",
         "NV-79"
@@ -537,6 +567,7 @@
       }
     },
     "nv-help-of-southern-nevada": {
+      "type": "hhsize",
       "incentives": [
         "NV-77"
       ],
@@ -555,6 +586,7 @@
   },
   "NY": {
     "default": {
+      "type": "hhsize",
       "incentives": [
         "NY-15"
       ],
@@ -573,6 +605,7 @@
   },
   "OR": {
     "or-energy-trust-of-oregon": {
+      "type": "hhsize",
       "incentives": [
         "OR-5",
         "OR-7",
@@ -599,6 +632,7 @@
       }
     },
     "or-pacific-power": {
+      "type": "hhsize",
       "incentives": [
         "OR-36",
         "OR-37"
@@ -620,6 +654,7 @@
       }
     },
     "or-portland-general-electric": {
+      "type": "hhsize",
       "incentives": [
         "OR-39",
         "OR-41"
@@ -643,6 +678,7 @@
   },
   "RI": {
     "default": {
+      "type": "hhsize",
       "incentives": [
         "RI-11",
         "RI-12",
@@ -668,6 +704,7 @@
       }
     },
     "ri-dhs": {
+      "type": "hhsize",
       "incentives": [
         "RI-14"
       ],
@@ -688,6 +725,7 @@
       }
     },
     "ri-rhode-island-energy": {
+      "type": "hhsize",
       "incentives": [
         "RI-27"
       ],
@@ -708,6 +746,7 @@
   },
   "VA": {
     "default": {
+      "type": "hhsize",
       "incentives": [
         "VA-18"
       ],
@@ -730,25 +769,79 @@
   },
   "VT": {
     "default": {
+      "type": "county-hhsize",
       "incentives": [
         "VT-10",
         "VT-28",
         "VT-52",
         "VT-98"
       ],
-      "source_url": "https://www.efficiencyvermont.com/services/income-based-assistance/energy-bill-reduction",
+      "source_url": "https://www.efficiencyvermont.com/income-limit",
       "thresholds": {
-        "1": 55050,
-        "2": 62900,
-        "3": 70750,
-        "4": 78600,
-        "5": 84900,
-        "6": 91200,
-        "7": 97500,
-        "8": 103800
+        "50007": {
+          "1": 66600,
+          "2": 76100,
+          "3": 85600,
+          "4": 95100,
+          "5": 102750,
+          "6": 110350,
+          "7": 117950,
+          "8": 125550
+        },
+        "50011": {
+          "1": 66600,
+          "2": 76100,
+          "3": 85600,
+          "4": 95100,
+          "5": 102750,
+          "6": 110350,
+          "7": 117950,
+          "8": 125550
+        },
+        "50013": {
+          "1": 66600,
+          "2": 76100,
+          "3": 85600,
+          "4": 95100,
+          "5": 102750,
+          "6": 110350,
+          "7": 117950,
+          "8": 125550
+        },
+        "50001": {
+          "1": 61050,
+          "2": 69750,
+          "3": 78500,
+          "4": 87200,
+          "5": 94200,
+          "6": 101200,
+          "7": 108150,
+          "8": 115150
+        },
+        "50023": {
+          "1": 59050,
+          "2": 67450,
+          "3": 75900,
+          "4": 84300,
+          "5": 91050,
+          "6": 97800,
+          "7": 104550,
+          "8": 111300
+        },
+        "other": {
+          "1": 57300,
+          "2": 65500,
+          "3": 73700,
+          "4": 81850,
+          "5": 88400,
+          "6": 94950,
+          "7": 101500,
+          "8": 108050
+        }
       }
     },
     "default-moderate": {
+      "type": "county-hhsize",
       "incentives": [
         "VT-2",
         "VT-8",
@@ -759,19 +852,72 @@
         "VT-51",
         "VT-54"
       ],
-      "source_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
+      "source_url": "https://www.efficiencyvermont.com/income-limit",
       "thresholds": {
-        "1": 82400,
-        "2": 94200,
-        "3": 106000,
-        "4": 117800,
-        "5": 127400,
-        "6": 140800,
-        "7": 146200,
-        "8": 155600
+        "50007": {
+          "1": 100000,
+          "2": 114200,
+          "3": 128400,
+          "4": 142600,
+          "5": 154200,
+          "6": 167840,
+          "7": 189360,
+          "8": 210880
+        },
+        "50011": {
+          "1": 100000,
+          "2": 114200,
+          "3": 128400,
+          "4": 142600,
+          "5": 154200,
+          "6": 167840,
+          "7": 189360,
+          "8": 210880
+        },
+        "50013": {
+          "1": 100000,
+          "2": 114200,
+          "3": 128400,
+          "4": 142600,
+          "5": 154200,
+          "6": 167840,
+          "7": 189360,
+          "8": 210880
+        },
+        "50001": {
+          "1": 91560,
+          "2": 104640,
+          "3": 117720,
+          "4": 130800,
+          "5": 141360,
+          "6": 151800,
+          "7": 162120,
+          "8": 172680
+        },
+        "50023": {
+          "1": 88560,
+          "2": 101280,
+          "3": 113880,
+          "4": 126480,
+          "5": 136680,
+          "6": 146760,
+          "7": 156840,
+          "8": 167040
+        },
+        "other": {
+          "1": 86000,
+          "2": 98400,
+          "3": 110600,
+          "4": 122800,
+          "5": 132800,
+          "6": 142600,
+          "7": 152400,
+          "8": 162200
+        }
       }
     },
     "vt-burlington-electric-department": {
+      "type": "hhsize",
       "incentives": [
         "VT-4",
         "VT-13",
@@ -791,6 +937,7 @@
       }
     },
     "vt-burlington-electric-department-ev": {
+      "type": "hhsize",
       "incentives": [
         "VT-89",
         "VT-90"
@@ -808,6 +955,7 @@
       }
     },
     "vt-green-mountain-power-ev": {
+      "type": "hhsize",
       "incentives": [
         "VT-85",
         "VT-86"
@@ -825,6 +973,7 @@
       }
     },
     "vt-vgs-low": {
+      "type": "hhsize",
       "incentives": [
         "VT-97"
       ],
@@ -841,6 +990,7 @@
       }
     },
     "vt-vgs-moderate": {
+      "type": "hhsize",
       "incentives": [
         "VT-56"
       ],
@@ -857,6 +1007,7 @@
       }
     },
     "vt-washington-electric-cooperative-ev": {
+      "type": "hhsize",
       "incentives": [
         "VT-93"
       ],
@@ -875,6 +1026,7 @@
   },
   "WI": {
     "wi-focus-on-energy": {
+      "type": "hhsize",
       "incentives": [
         "WI-26",
         "WI-28",

--- a/scripts/incentive-spreadsheet-to-json.ts
+++ b/scripts/incentive-spreadsheet-to-json.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { GaxiosPromise } from 'gaxios';
 import { GEO_GROUPS_BY_STATE, GeoGroupsByState } from '../src/data/geo_groups';
 import {
-  LOW_INCOME_THRESHOLDS_BY_AUTHORITY,
+  LOW_INCOME_THRESHOLDS_BY_STATE,
   LowIncomeThresholdsMap,
 } from '../src/data/low_income_thresholds';
 import {
@@ -186,7 +186,7 @@ async function convertToJson(
   lowIncome: boolean,
   geoGroups: boolean,
 ) {
-  if (lowIncome && !(state in LOW_INCOME_THRESHOLDS_BY_AUTHORITY)) {
+  if (lowIncome && !(state in LOW_INCOME_THRESHOLDS_BY_STATE)) {
     throw new Error(
       `No low-income thresholds defined for ${state} - define them or turn off strict mode.`,
     );
@@ -225,7 +225,7 @@ async function convertToJson(
     state,
     rows,
     strict,
-    lowIncome ? LOW_INCOME_THRESHOLDS_BY_AUTHORITY : null,
+    lowIncome ? LOW_INCOME_THRESHOLDS_BY_STATE : null,
     geoGroups ? GEO_GROUPS_BY_STATE : null,
   );
 

--- a/scripts/spreadsheets-health.test.ts
+++ b/scripts/spreadsheets-health.test.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import fetch from 'make-fetch-happen';
 import { test } from 'tap';
 import { GEO_GROUPS_BY_STATE } from '../src/data/geo_groups';
-import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../src/data/low_income_thresholds';
+import { LOW_INCOME_THRESHOLDS_BY_STATE } from '../src/data/low_income_thresholds';
 import {
   PASS_THROUGH_FIELDS,
   StateIncentive,
@@ -44,7 +44,7 @@ test('registered spreadsheets are in sync with checked-in JSON files', async tap
         state,
         rows,
         false,
-        LOW_INCOME_THRESHOLDS_BY_AUTHORITY,
+        LOW_INCOME_THRESHOLDS_BY_STATE,
         GEO_GROUPS_BY_STATE,
       );
       const invalidCollectedPath = file.filepath.replace(

--- a/scripts/update-fixtures.sh
+++ b/scripts/update-fixtures.sh
@@ -220,6 +220,28 @@ curl \
 &utility=vt-vermont-electric-cooperative" \
   | jq . > test/fixtures/v1-vt-05845-vec-ev-low-income.json
 
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?zip=05753\
+&owner_status=homeowner\
+&household_income=60000\
+&tax_filing=single\
+&household_size=1\
+&authority_types=state\
+&items=heat_pump_water_heater" \
+  | jq . > test/fixtures/v1-vt-addison-co-low-income.json
+
+curl \
+  "http://localhost:3000/api/v1/calculator\
+?zip=05201\
+&owner_status=homeowner\
+&household_income=60000\
+&tax_filing=single\
+&household_size=1\
+&authority_types=state\
+&items=heat_pump_water_heater" \
+  | jq . > test/fixtures/v1-vt-bennington-co-not-low-income.json
+
 # TODO: Remove beta states argument when CO is fully launched.
 curl \
   "http://localhost:3000/api/v1/calculator\

--- a/src/lib/low-income.ts
+++ b/src/lib/low-income.ts
@@ -22,8 +22,6 @@ export function isLowIncome(
         thresholds.thresholds['other'];
   const threshold = bySize?.[household_size];
 
-  console.log(location, bySize);
-
   // The only way the threshold should be missing is if they are defined by
   // county, the user's county doesn't have thresholds defined, and there's no
   // "other" fallback. (All possible input HH sizes should be present in the

--- a/src/lib/low-income.ts
+++ b/src/lib/low-income.ts
@@ -1,0 +1,33 @@
+import {
+  HHSizeThresholds,
+  LowIncomeThresholdsAuthority,
+} from '../data/low_income_thresholds';
+import { CalculateParams } from './incentives-calculation';
+import { ResolvedLocation } from './location';
+
+/**
+ * Chooses the right income threshold and determines whether the given income
+ * is below it. Which threshold is chosen is conditioned on household size, and,
+ * in some cases, location.
+ */
+export function isLowIncome(
+  { household_size, household_income }: CalculateParams,
+  thresholds: LowIncomeThresholdsAuthority,
+  location: ResolvedLocation,
+): boolean {
+  const bySize: HHSizeThresholds =
+    thresholds.type === 'hhsize'
+      ? thresholds.thresholds
+      : thresholds.thresholds[location.countyFips] ??
+        thresholds.thresholds['other'];
+  const threshold = bySize?.[household_size];
+
+  console.log(location, bySize);
+
+  // The only way the threshold should be missing is if they are defined by
+  // county, the user's county doesn't have thresholds defined, and there's no
+  // "other" fallback. (All possible input HH sizes should be present in the
+  // data; this is enforced by a unit test.) If the threshold is missing, be
+  // conservative and return false (i.e. "not low income").
+  return typeof threshold === 'number' && household_income <= threshold;
+}

--- a/test/data/low_income_thresholds.test.ts
+++ b/test/data/low_income_thresholds.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap';
-import { LOW_INCOME_THRESHOLDS_BY_AUTHORITY } from '../../src/data/low_income_thresholds';
+import { LOW_INCOME_THRESHOLDS_BY_STATE } from '../../src/data/low_income_thresholds';
 import {
   STATE_INCENTIVES_BY_STATE,
   StateIncentive,
@@ -18,7 +18,7 @@ test('low-income thresholds are equivalent in JSON config and incentives', async
   const map = computeIdToIncentiveMap(
     Object.values(STATE_INCENTIVES_BY_STATE).flat(),
   );
-  Object.entries(LOW_INCOME_THRESHOLDS_BY_AUTHORITY).forEach(
+  Object.entries(LOW_INCOME_THRESHOLDS_BY_STATE).forEach(
     ([, stateThresholds]) => {
       for (const [identifier, thresholds] of Object.entries(stateThresholds)) {
         for (const incentiveId of thresholds.incentives) {
@@ -41,13 +41,32 @@ test('low-income thresholds are equivalent in JSON config and incentives', async
   )) {
     for (const incentive of stateIncentives) {
       if (incentive.low_income) {
-        const stateThresholds = LOW_INCOME_THRESHOLDS_BY_AUTHORITY[stateId];
+        const stateThresholds = LOW_INCOME_THRESHOLDS_BY_STATE[stateId];
         t.hasProp(stateThresholds, incentive.low_income);
         t.ok(
           stateThresholds[incentive.low_income].incentives.includes(
             incentive.id,
           ),
         );
+      }
+    }
+  }
+});
+
+test('low-income thresholds have HH sizes 1-8', async t => {
+  const hasRequiredKeys = (obj: Record<string, unknown>) => {
+    const keys = Object.keys(obj);
+    return [1, 2, 3, 4, 5, 6, 7, 8].every(num => keys.includes(num.toString()));
+  };
+
+  for (const stateThresholds of Object.values(LOW_INCOME_THRESHOLDS_BY_STATE)) {
+    for (const thresholds of Object.values(stateThresholds)) {
+      if (thresholds.type === 'hhsize') {
+        t.ok(hasRequiredKeys(thresholds.thresholds));
+      } else {
+        for (const countyThresholds of Object.values(thresholds.thresholds)) {
+          t.ok(hasRequiredKeys(countyThresholds));
+        }
       }
     }
   }

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../src/data/ira_state_savings';
 import { LOCALES, SCHEMA as L_SCHEMA } from '../../src/data/locale';
 import {
-  LOW_INCOME_THRESHOLDS_BY_AUTHORITY,
+  LOW_INCOME_THRESHOLDS_BY_STATE,
   SCHEMA as LOW_INCOME_THRESHOLDS_SCHEMA,
 } from '../../src/data/low_income_thresholds';
 import { SOLAR_PRICES, SCHEMA as SP_SCHEMA } from '../../src/data/solar_prices';
@@ -90,7 +90,7 @@ const TESTS = [
   [AUTHORITIES_SCHEMA, AUTHORITIES_BY_STATE, 'authorities'],
   [
     LOW_INCOME_THRESHOLDS_SCHEMA,
-    LOW_INCOME_THRESHOLDS_BY_AUTHORITY,
+    LOW_INCOME_THRESHOLDS_BY_STATE,
     'State low income',
   ],
   [GEO_GROUPS_SCHEMA, GEO_GROUPS_BY_STATE, 'geo_groups'],

--- a/test/fixtures/v1-vt-addison-co-low-income.json
+++ b/test/fixtures/v1-vt-addison-co-low-income.json
@@ -1,0 +1,100 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "vt-efficiency-vermont": {
+      "name": "Efficiency Vermont"
+    }
+  },
+  "coverage": {
+    "state": "VT",
+    "utility": null
+  },
+  "location": {
+    "state": "VT",
+    "city": "Middlebury"
+  },
+  "data_partners": {
+    "vt-efficiency-vermont": {
+      "name": "Efficiency Vermont",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/vt-efficiency-vermont-color.png",
+        "width": 300,
+        "height": 200
+      }
+    }
+  },
+  "incentives": [
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "vt-efficiency-vermont",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 1,
+        "maximum": 5000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "100% off a heat pump water heater, up to $5,000, for low-income customers."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "vt-efficiency-vermont",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 1,
+        "maximum": 4500
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2020-01-01",
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "90% off a heat pump water heater, up to $4,500, for moderate-income customers."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "vt-efficiency-vermont",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 600
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2020-01-01",
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "$600 rebate for a heat pump water heater, or $600 instant discount through participating distributors."
+    }
+  ]
+}

--- a/test/fixtures/v1-vt-bennington-co-not-low-income.json
+++ b/test/fixtures/v1-vt-bennington-co-not-low-income.json
@@ -1,0 +1,100 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "vt-efficiency-vermont": {
+      "name": "Efficiency Vermont"
+    }
+  },
+  "coverage": {
+    "state": "VT",
+    "utility": null
+  },
+  "location": {
+    "state": "VT",
+    "city": "Bennington"
+  },
+  "data_partners": {
+    "vt-efficiency-vermont": {
+      "name": "Efficiency Vermont",
+      "logo": {
+        "src": "https://storage.googleapis.com/rewiring-america-incentives-assets/vt-efficiency-vermont-color.png",
+        "width": 300,
+        "height": 200
+      }
+    }
+  },
+  "incentives": [
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "vt-efficiency-vermont",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 1,
+        "maximum": 4500
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2020-01-01",
+      "ami_qualification": null,
+      "eligible": true,
+      "short_description": "90% off a heat pump water heater, up to $4,500, for moderate-income customers."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "vt-efficiency-vermont",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 1,
+        "maximum": 5000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "100% off a heat pump water heater, up to $5,000, for low-income customers."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "vt-efficiency-vermont",
+      "program": "Efficiency Vermont Heat Pump Water Heater Rebate Program",
+      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 600
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2020-01-01",
+      "ami_qualification": null,
+      "eligible": false,
+      "short_description": "$600 rebate for a heat pump water heater, or $600 instant discount through participating distributors."
+    }
+  ]
+}

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -461,6 +461,31 @@ test('VT low income EV incentives are correct', async t => {
   );
 });
 
+// VT per-county low income
+test('VT uses per-county low income thresholds', async t => {
+  const baseQuery = {
+    // Low income in Addison County, but not in Bennington County.
+    // Addison has thresholds defined; Bennington will use fallback
+    household_income: 60000,
+    owner_status: 'homeowner',
+    household_size: 1,
+    tax_filing: 'single',
+    authority_types: 'state',
+    items: ['heat_pump_water_heater'],
+  };
+
+  await validateResponse(
+    t,
+    { ...baseQuery, zip: '05753' },
+    './test/fixtures/v1-vt-addison-co-low-income.json',
+  );
+  await validateResponse(
+    t,
+    { ...baseQuery, zip: '05201' },
+    './test/fixtures/v1-vt-bennington-co-not-low-income.json',
+  );
+});
+
 // WI low income test
 test('WI low income response with state and utility filtering is valid and correct', async t => {
   await validateResponse(

--- a/test/scripts/data-refiner.test.ts
+++ b/test/scripts/data-refiner.test.ts
@@ -11,6 +11,7 @@ test('correctly associates low-income thresholds with record', tap => {
   const thresholds: LowIncomeThresholdsMap = {
     CT: {
       'ct-low-income-program': {
+        type: 'hhsize',
         incentives: ['CT-1'],
         source_url: 'foo.com',
         thresholds: {},

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -15,6 +15,7 @@ import {
   VALUE_MAPPINGS,
 } from '../../scripts/lib/spreadsheet-mappings';
 import { SpreadsheetStandardizer } from '../../scripts/lib/spreadsheet-standardizer';
+import { LowIncomeThresholdsMap } from '../../src/data/low_income_thresholds';
 
 test('correct row to record transformation', tap => {
   const testCases: {
@@ -86,9 +87,10 @@ test('correct row to record transformation', tap => {
     },
   ];
 
-  const fakeIncomeThresholds = {
+  const fakeIncomeThresholds: LowIncomeThresholdsMap = {
     va: {
       'va-appalachian-power': {
+        type: 'hhsize',
         source_url: 'url',
         thresholds: {},
         incentives: ['VA-1'],


### PR DESCRIPTION
## Description

This has been hanging over our heads since Vermont, but now NY's HEAR
program has them, so it's time to actually do it.

I added a `type` field to each threshold definition, which can have
the values `hhsize` or `county-hhsize`, indicating the sequence of
keys to be used with the `thresholds` structure. Counties are
identified by FIPS code, same as in the authorities files.

To demonstrate this working, I updated the county-specific Vermont
incentives (it's a lot less data than the NY ones, which I'll do
separately).

I've also switched the low-income-thresholds JSON-Schema-to-TS logic
away from ajv and to `json-schema-to-ts`. The latter is what I prefer
to use for this because it's what Fastify uses to turn endpoint
schemas into types, and I think it's worthwhile to have everything use
the same solution for that (because every schema-to-TS thing has
subtle differences). I've been converting things gradually. Anyway,
this resulted most notably in having to remove the `required:
[1,2,...]` constraint on the household-size-thresholds struct, so I
added a unit test for that.

## Test Plan

New test for county-specific Vermont thresholds (same income is LI in
one county but not in another). Other tests pass.
