### PR TITLE
Add heat_pump_air_conditioner_heater and weatherization back to items enum

### DIFF
--- a/src/data/types/items.ts
+++ b/src/data/types/items.ts
@@ -45,6 +45,9 @@ export const ITEMS_SCHEMA = {
   wall_insulation: { type: 'string' },
   whole_house_fan: { type: 'string' },
   window_replacement: { type: 'string' },
+  // TODO remove the two below once frontends are not using them anymore
+  heat_pump_air_conditioner_heater: { type: 'string' },
+  weatherization: { type: 'string' },
 } as const;
 
 export type Item = keyof typeof ITEMS_SCHEMA;


### PR DESCRIPTION
## Description

Removing these from the enum was over-eager, because the embed and PEP
clients are sending them as part of the `items` request param.

Adding them back lets us deploy the split-items change without
breaking the clients. Once the clients are updated, these enum values
can be removed again.

## Test Plan

Run unmodified embed frontend against local backend without this
change; see the error on any form submission. Apply this change to the
backend; make sure the calculator successfully shows results.
