### PR TITLE
Update low income keys to be unique

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -282,7 +282,7 @@
       "en": "Weatherization improvements for homes for limited-income customers.",
       "es": "Mejoras de climatización para viviendas de clientes con ingresos limitados."
     },
-    "low_income": "default"
+    "low_income": "az-default"
   },
   {
     "id": "AZ-19",
@@ -331,7 +331,7 @@
       "en": "Assistance available for energy efficient retrofitting to homes of income-qualifying customers.",
       "es": "Reacondicionamiento para la eficiencia energética en hogares de clientes que cumplen nivel de ingresos."
     },
-    "low_income": "default"
+    "low_income": "az-default"
   },
   {
     "id": "AZ-22",

--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -16,7 +16,7 @@
       "homeowner",
       "renter"
     ],
-    "low_income": "default",
+    "low_income": "ct-default",
     "short_description": {
       "en": "The Home Energy Solutions program provides income-eligible households with no-cost energy assessments and incentives for weatherization services.",
       "es": "El programa Home Energy Solutions (Soluciones Energéticas para el Hogar) ofrece a los hogares que cumplen los requisitos de ingresos, evaluaciones de consumo de energía sin costo además de incentivos para diversos servicios de climatización."
@@ -87,7 +87,7 @@
       "homeowner",
       "renter"
     ],
-    "low_income": "default",
+    "low_income": "ct-default",
     "short_description": {
       "en": "The Home Energy Solutions program provides income-eligible households with no-cost energy assessments and incentives for weatherization services.",
       "es": "El programa Home Energy Solutions brinda a los hogares que cumplan los requisitos de ingresos una evaluación de sus necesidades de energía al igual que incentivos para recibir servicios de climatización."

--- a/data/NY/incentives.json
+++ b/data/NY/incentives.json
@@ -271,7 +271,7 @@
     "owner_status": [
       "homeowner"
     ],
-    "low_income": "default",
+    "low_income": "ny-default",
     "short_description": {
       "en": "Up to $7,500 in weatherization and health and safety services for income eligible households."
     }

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -256,7 +256,7 @@
       "en": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers.",
       "es": "Un reembolso adicional de $1,500 por la compra o arrendamiento de un vehículo eléctrico nuevo para los calificadores de LIHEAP."
     },
-    "low_income": "default"
+    "low_income": "ri-default"
   },
   {
     "id": "RI-12",
@@ -283,7 +283,7 @@
       "en": "Additional $1,500 towards a used EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers. First-come, first-served.",
       "es": "Un reembolso adicional de $1,500 por un vehículo eléctrico usado para los calificadores de LIHEAP. Por orden de llegada."
     },
-    "low_income": "default"
+    "low_income": "ri-default"
   },
   {
     "id": "RI-13",
@@ -310,7 +310,7 @@
       "es": "Devolución del 30% hasta $350 dólares en la compra final de una bicicleta e-bike o una e-cargo bike."
     },
     "start_date": "2022-10-24",
-    "low_income": "default"
+    "low_income": "ri-default"
   },
   {
     "id": "RI-14",
@@ -560,7 +560,7 @@
       "es": "Según sus ingresos, el costo total de instalar una aerotermia. Incluye hasta $3,000 para mejoras eléctricas relacionadas."
     },
     "bonus_available": true,
-    "low_income": "default"
+    "low_income": "ri-default"
   },
   {
     "id": "RI-35",
@@ -585,7 +585,7 @@
       "en": "Depending on your income, 100% of the cost to install a heat pump water heater, including up to $3,000 towards related electric service upgrades.",
       "es": "Según sus ingresos, el costo total de instalar un calentador de agua con bomba de calor. Incluye hasta $3,000 para mejoras eléctricas relacionadas."
     },
-    "low_income": "default"
+    "low_income": "ri-default"
   },
   {
     "id": "RI-37",
@@ -740,6 +740,6 @@
       "es": "Devolución del 75% hasta $750 dólares en la compra final de una bicicleta e-bike o una e-cargo bike para residentes que cumplan con el nivel de ingresos."
     },
     "start_date": "2022-10-24",
-    "low_income": "default"
+    "low_income": "ri-default"
   }
 ]

--- a/data/VA/incentives.json
+++ b/data/VA/incentives.json
@@ -328,7 +328,7 @@
       "type": "percent",
       "number": 1
     },
-    "low_income": "default",
+    "low_income": "va-default",
     "short_description": {
       "en": "Receive no cost energy efficient weatherization upgrades for qualified income and age levels by qualified service providers.",
       "es": "Reciba sin costo alguno actualizaciones de sus instalaciones de climatización si cumple los requisitos de nivel de ingresos o de edad realizados por proveedores de servicios competentes."

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -49,7 +49,7 @@
       "en": "$500 bonus rebate for income-eligible Vermonters to work with an Efficiency Excellence Network contractor to install an air-to-water heat pump.",
       "es": "Los residentes de Vermont que cumplan con el nivel de ingresos pueden obtener un reembolso adicional de $500 si trabajan con un contratista de la red Efficiency Excellence Network para instalar su bomba de calor de aire a agua."
     },
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-3",
@@ -208,7 +208,7 @@
       "en": "Vermonters with low or moderate household income may qualify for a $200 bonus rebate on a ducted heat pump, depending on their utility.",
       "es": "Los residentes de Vermont cuyos ingresos familiares sean iguales o inferiores al nivel de ingresos siguiente (rango moderado) ftienen derecho a un reembolso adicional de $200 por una bomba de calor con ductos, dependiendo de la compañía de suministro de luz que utilicen."
     },
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-10",
@@ -232,7 +232,7 @@
       "en": "Income-eligible GMP customers qualify for a $2,200 bonus rebate on a ducted heat pump.",
       "es": "Los clientes de GMP que cumplen con el nivel de ingresos tienen derecho a un reembolso de $2,200 para una bomba de calor con ductos."
     },
-    "low_income": "default"
+    "low_income": "vt-default"
   },
   {
     "id": "VT-11",
@@ -258,7 +258,7 @@
       "en": "Income-eligible Vermonters can receive $1,000 rebate on a ducted heat pump.",
       "es": "Los residentes de Vermont que cumplan con el nivel de ingresos pueden recibir un reembolso de $1,000 en una bomba de calor con ductos."
     },
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-12",
@@ -413,7 +413,7 @@
       "en": "Income-eligible Vermonters qualify for a $200-$1,000 bonus rebate on a ductless heat pump, depending on their utility.",
       "es": "Los residentes de Vermont que cumplan el nivel de ingresos pueden optar a un reembolso adicional de entre $200 y $1,000 por una bomba de calor sin ductos, dependiendo de la compañía de suministro de luz que utilicen."
     },
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-22",
@@ -541,7 +541,7 @@
       "es": "El Estado de Vermont ha colaborado con Capstone para ofrecer el programa MileageSmart. Éste ofrece a los compradores de automóviles con ingresos bajos y moderados un incentivo que cubre el 25% del costo inicial de un vehículo usado de alta eficiencia, hasta un máximo de $5,000l."
     },
     "bonus_available": true,
-    "low_income": "default"
+    "low_income": "vt-default"
   },
   {
     "id": "VT-31",
@@ -747,7 +747,7 @@
       "es": "Los residentes de Vermont que cumplan el nivel de ingresos podrán beneficiarse de un reembolso adicional de $500 en la compra de una bomba de calor Ground Source autorizada."
     },
     "start_date": "2021-07-01",
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-39",
@@ -848,7 +848,7 @@
       "es": "Un 90% de descuento en un calentador de agua con bomba de calor, hasta $4,500, para clientes con ingresos moderados."
     },
     "start_date": "2020-01-01",
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-43",
@@ -1084,7 +1084,7 @@
     },
     "start_date": "2023-08-01",
     "bonus_available": true,
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-52",
@@ -1110,7 +1110,7 @@
       "en": "The State's Weatherization Assistance Program offers free services including energy audits, insulation and air sealing for income-eligible households.",
       "es": "El Programa Estatal Weatherization Assistance Program (de Asistencia para la Climatización) ofrece servicios gratuitos que incluyen auditorías de consumo energético, aislamiento y sellos herméticos para hogares que cumplen con el nivel de ingresos"
     },
-    "low_income": "default"
+    "low_income": "vt-default"
   },
   {
     "id": "VT-53",
@@ -1159,7 +1159,7 @@
       "en": "Vermont residents whose annual household income falls at or below moderate income thresholds are eligible for 75% of project costs back, up to $5,000.",
       "es": "Los residentes de Vermont cuyos ingresos familiares anuales se sitúen en el umbral de ingresos moderados o por debajo del mismo, pueden optar a la devolución del 75% de los costos del proyecto, hasta un máximo de $5,000."
     },
-    "low_income": "default-moderate"
+    "low_income": "vt-default-moderate"
   },
   {
     "id": "VT-55",
@@ -2301,6 +2301,6 @@
       "en": "100% off a heat pump water heater, up to $5,000, for low-income customers.",
       "es": "Un 100% de descuento en un calentador de agua con bomba de calor, hasta $5,000, para clientes con bajos ingresos."
     },
-    "low_income": "default"
+    "low_income": "vt-default"
   }
 ]

--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1,6 +1,6 @@
 {
   "AZ": {
-    "default": {
+    "az-default": {
       "type": "hhsize",
       "incentives": [
         "AZ-18",
@@ -182,7 +182,7 @@
     }
   },
   "CT": {
-    "default": {
+    "ct-default": {
       "type": "hhsize",
       "incentives": [
         "CT-1",
@@ -585,7 +585,7 @@
     }
   },
   "NY": {
-    "default": {
+    "ny-default": {
       "type": "hhsize",
       "incentives": [
         "NY-15"
@@ -677,7 +677,7 @@
     }
   },
   "RI": {
-    "default": {
+    "ri-default": {
       "type": "hhsize",
       "incentives": [
         "RI-11",
@@ -745,7 +745,7 @@
     }
   },
   "VA": {
-    "default": {
+    "va-default": {
       "type": "hhsize",
       "incentives": [
         "VA-18"
@@ -768,7 +768,7 @@
     }
   },
   "VT": {
-    "default": {
+    "vt-default": {
       "type": "county-hhsize",
       "incentives": [
         "VT-10",
@@ -840,7 +840,7 @@
         }
       }
     },
-    "default-moderate": {
+    "vt-default-moderate": {
       "type": "county-hhsize",
       "incentives": [
         "VT-2",


### PR DESCRIPTION
To aid in ingesting the low income thresholds data in incentive admin with this [ticket](https://app.asana.com/0/1207304265252553/1207304265868262/f), I've updated the low_income reference keys to be unique. This uniqueness constraint will exist in the relational database in incentive admin. 