### PR TITLE
Don't list out relationships files explicitly

### DIFF
--- a/src/data/state_incentive_relationships.ts
+++ b/src/data/state_incentive_relationships.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
+import { STATES_PLUS_DC } from './types/states';
 
 export const anyOrAllSchema = {
   type: 'array',
@@ -66,46 +67,14 @@ export type IncentiveRelationshipsMap = {
   [stateId: string]: IncentiveRelationships;
 };
 
-export const CO_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/CO/incentive_relationships.json', 'utf-8'),
-);
-
-export const CT_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/CT/incentive_relationships.json', 'utf-8'),
-);
-
-export const GA_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/GA/incentive_relationships.json', 'utf-8'),
-);
-
-export const OR_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/OR/incentive_relationships.json', 'utf-8'),
-);
-
-export const PA_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/PA/incentive_relationships.json', 'utf-8'),
-);
-
-export const RI_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/RI/incentive_relationships.json', 'utf-8'),
-);
-
-export const VT_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/VT/incentive_relationships.json', 'utf-8'),
-);
-
-export const WI_RELATIONSHIPS: IncentiveRelationships = JSON.parse(
-  fs.readFileSync('./data/WI/incentive_relationships.json', 'utf-8'),
-);
-
-export const INCENTIVE_RELATIONSHIPS_BY_STATE: IncentiveRelationshipsMap = {
-  CO: CO_RELATIONSHIPS,
-  CT: CT_RELATIONSHIPS,
-  GA: GA_RELATIONSHIPS,
-  NY: {},
-  OR: OR_RELATIONSHIPS,
-  PA: PA_RELATIONSHIPS,
-  RI: RI_RELATIONSHIPS,
-  VT: VT_RELATIONSHIPS,
-  WI: WI_RELATIONSHIPS,
-};
+export const INCENTIVE_RELATIONSHIPS_BY_STATE: IncentiveRelationshipsMap =
+  (() => {
+    const result: IncentiveRelationshipsMap = {};
+    for (const state of STATES_PLUS_DC) {
+      const filepath = `./data/${state}/incentive_relationships.json`;
+      if (fs.existsSync(filepath)) {
+        result[state] = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+      }
+    }
+    return result;
+  })();

--- a/test/snapshots/v1-dc-20303-state-city-lowincome.json
+++ b/test/snapshots/v1-dc-20303-state-city-lowincome.json
@@ -216,31 +216,6 @@
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
       "items": [
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 700,
-        "maximum": 700
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2023-12-31",
-      "end_date": "2024-09-30",
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "$375-$700 rebate for qualified ducted or ductless heat pump systems."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "DC Residential Rebates",
-      "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "items": [
         "electric_outdoor_equipment"
       ],
       "amount": {

--- a/test/snapshots/v1-mi-48825-city-lowincome.json
+++ b/test/snapshots/v1-mi-48825-city-lowincome.json
@@ -116,30 +116,6 @@
       ],
       "authority_type": "utility",
       "authority": "mi-lansing-board-of-water-and-light",
-      "program": "Lansing BWL Electrification Programs",
-      "program_url": "https://www.lbwl.com/customers/save-money-energy/electrification-programs",
-      "items": [
-        "ebike"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 500,
-        "maximum": 500
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "ami_qualification": null,
-      "eligible": true,
-      "short_description": "$500 rebate for a cargo e-bike or $300 rebate for a standard e-bike. Must be UL 2849 certified. Motor must be 750 watts or less. Limit 1."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "mi-lansing-board-of-water-and-light",
       "program": "Lansing BWL Heating and Cooling Rebates",
       "program_url": "https://www.lbwl.com/hvac",
       "items": [


### PR DESCRIPTION
## Description

It's way too easy to forget to add this when adding a new state. Do
what's done for authorities.json files and just read them all by
iterating over state codes.

The MI and DC relationships files actually weren't being read in, so
this does cause visible changes (two incentives that should have been
excluded, weren't).

## Test Plan

`yarn test`
