### PR TITLE
Document all the fields

### DIFF
--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -26,7 +26,7 @@ export enum AuthorityType {
   Other = 'other',
 }
 
-export const API_AUTHORITY_SCHEMA = {
+const AUTHORITY_SCHEMA = {
   type: 'object',
   properties: {
     name: { type: 'string' },
@@ -38,11 +38,25 @@ export const API_AUTHORITY_SCHEMA = {
   additionalProperties: false,
 } as const;
 
-export type Authority = FromSchema<typeof API_AUTHORITY_SCHEMA>;
+/**
+ * The same as the above, but with only the name and logo fields; this is what
+ * is exposed via the API.
+ */
+export const API_AUTHORITY_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    logo: API_IMAGE_SCHEMA,
+  },
+  required: ['name'],
+  additionalProperties: false,
+} as const;
+
+export type APIAuthority = FromSchema<typeof API_AUTHORITY_SCHEMA>;
 
 const authoritiesMapSchema = {
   type: 'object',
-  additionalProperties: API_AUTHORITY_SCHEMA,
+  additionalProperties: AUTHORITY_SCHEMA,
   required: [],
 } as const;
 

--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -39,8 +39,8 @@ const AUTHORITY_SCHEMA = {
 } as const;
 
 /**
- * The same as the above, but with only the name and logo fields; this is what
- * is exposed via the API.
+ * The same as AUTHORITY_SCHEMA, but with only the name and logo fields; this is
+ * what is exposed via the API.
  */
 export const API_AUTHORITY_SCHEMA = {
   type: 'object',

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -355,13 +355,8 @@ export default function calculateIncentives(
   if (stateAuthorities) {
     incentives.forEach(i => {
       if ('authority' in i && i.authority && i.authority_type !== 'federal') {
-        // Just return the name and logo; omit stuff that specifies location
-        // since it's not part of the public API.
-        authorities[i.authority] = _.pick(
-          stateAuthorities[i.authority_type]![i.authority],
-          'name',
-          'logo',
-        );
+        authorities[i.authority] =
+          stateAuthorities[i.authority_type]![i.authority];
       }
     });
   }

--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -1,5 +1,5 @@
 import { Database } from 'sqlite';
-import { AUTHORITIES_BY_STATE, Authority } from '../data/authorities';
+import { APIAuthority, AUTHORITIES_BY_STATE } from '../data/authorities';
 import { ResolvedLocation } from './location';
 
 /** Models the zip_to_utility table in sqlite. */
@@ -22,7 +22,7 @@ export async function getUtilitiesForLocation(
   db: Database,
   location: ResolvedLocation,
 ): Promise<{
-  [id: string]: Authority;
+  [id: string]: APIAuthority;
 }> {
   const stateUtilities = AUTHORITIES_BY_STATE[location.state]?.utility;
 

--- a/src/plugins/swagger.ts
+++ b/src/plugins/swagger.ts
@@ -1,17 +1,39 @@
 import FastifySwagger from '@fastify/swagger';
 import fp from 'fastify-plugin'; // the use of fastify-plugin is required to be able to export the decorators to the outer scope
 
+const DESCRIPTION = `Rewiring America’s API offers comprehensive, up-to-date \
+information about electrification incentive programs and eligibility.
+
+We are actively developing the "v1" revision of this API. It currently powers \
+our [incentives calculator](https://homes.rewiringamerica.org/calculator), \
+and we aim for it to be suitable for inclusion in third-party applications.
+
+The "v0" of this API is still available, but deprecated; we plan to remove it \
+in the near future, and new applications should not use it.
+
+**To generate an API key, click on the "Sign In" button. You can also use \
+[this link](https://www.rewiringamerica.org/api) to sign up if needed**.
+
+If you have feedback, or if you've stumbled across this page by accident and \
+you'd like to learn more, reach out to us at \
+[api@rewiringamerica.org](mailto:api@rewiringamerica.org).
+
+Usage of the API is governed by our \
+[API Terms of Service (PDF)](http://content.rewiringamerica.org/api/terms.pdf) \
+(including our API Guidelines and Acceptable Use Policy) and our \
+[Privacy Policy](https://content.rewiringamerica.org/view/privacy-policy.pdf).`;
+
 export default fp(async function (fastify) {
   await fastify.register(FastifySwagger, {
     openapi: {
       info: {
         title: 'Rewiring America Incentives API',
-        description: 'Query federal electrification incentives.',
+        description: DESCRIPTION,
         version: '0.0.0',
       },
       externalDocs: {
-        url: 'https://www.rewiringamerica.org/app/ira-calculator',
-        description: 'IRA Savings Calculator',
+        url: 'https://api.rewiringamerica.org/docs',
+        description: 'API Documentation',
       },
     },
     refResolver: {

--- a/src/routes/v0.ts
+++ b/src/routes/v0.ts
@@ -73,7 +73,11 @@ function translateIncentives(incentives: IRAIncentive[]): WebsiteIncentive[] {
 }
 
 const CalculatorSchema = {
-  description: 'How much money will you get with the Inflation Reduction Act?',
+  summary: '(Deprecated) Find eligible incentives',
+  description: `Compute incentives for which the user is eligible, given the \
+criteria in the request parameters.`,
+  deprecated: true,
+  operationId: 'calculator-get',
   querystring: WEBSITE_CALCULATOR_REQUEST_SCHEMA,
   response: {
     200: {
@@ -89,7 +93,13 @@ const CalculatorSchema = {
 } as const;
 
 const IncentivesSchema = {
-  description: 'What are all the incentives from the Inflation Reduction Act?',
+  summary: '(Deprecated) List all incentives',
+  description: `List all available incentives, before applying eligibility \
+criteria. Note that there will be duplicates with only subtle differences \
+between eligibility tiers. Use the calculator endpoint to get de-duped \
+incentives.`,
+  deprecated: true,
+  operationId: 'incentives-get',
   response: {
     200: {
       description: 'Successful response',
@@ -105,7 +115,7 @@ const IncentivesSchema = {
       },
     },
   },
-};
+} as const;
 
 export default async function (
   fastify: FastifyInstance & { sqlite: Database },

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -14,20 +14,20 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
   properties: {
     zip: {
       type: 'string',
-      description:
-        'Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.',
+      description: `Find incentives that may be available in this ZIP code. \
+Exactly one of this and "address" is required.`,
       maxLength: 5,
       minLength: 5,
     },
     address: {
       type: 'string',
-      description:
-        "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
+      description: `Find incentives that may be available at this address. \
+Exactly one of this and "zip" is required.`,
     },
     authority_types: {
       type: 'array',
-      description:
-        'Which types of authority to fetch incentives for: "federal", "state", or "utility".',
+      description: `Find incentives offered by these types of authorities. \
+If absent, incentives from all types of authorities will be considered.`,
       items: {
         type: 'string',
         enum: Object.values(AuthorityType),
@@ -37,14 +37,14 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
     },
     utility: {
       type: 'string',
-      description:
-        'The ID of your utility company, as returned from /utilities. ' +
-        'Required if authority_types includes "utility".',
+      description: `The ID of your utility company, as returned from \
+\`/api/v1/utilities\`. Required if authority_types includes "utility". If \
+absent, no incentives offered by utilities will be returned.`,
     },
     items: {
       type: 'array',
-      description:
-        'Which types of product or project to fetch incentives for. If absent, include all products/projects.',
+      description: `Which types of product or service to fetch incentives for. \
+If absent, include incentives for all products and services.`,
       items: {
         type: 'string',
         enum: ALL_ITEMS,
@@ -54,13 +54,15 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
     },
     owner_status: {
       type: 'string',
-      description: 'Homeowners and renters qualify for different incentives.',
+      description: 'Whether the consumer owns or rents their home.',
       enum: Object.values(OwnerStatus),
     },
     household_income: {
       type: 'integer',
-      description:
-        'Enter your gross income (income before taxes). Include wages and salary plus other forms of income, including pensions, interest, dividends, and rental income. If you are married and file jointly, include your spouse’s income.',
+      description: `The consumer's gross income (pre-tax). Include wages and \
+salary plus other forms of income, including pensions, interest, dividends, \
+and rental income. Married taxpayers filing jointly should include their \
+spouse's income.`,
       minimum: 0,
       maximum: 100000000,
       examples: [
@@ -70,13 +72,14 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
     tax_filing: {
       type: 'string',
       description:
-        'Select "Head of Household" if you have a child or relative living with you, and you pay more than half the costs of your home. Select "Joint" if you file your taxes as a married couple.',
+        'The status under which the consumer files their federal taxes.',
       enum: Object.values(FilingStatus),
     },
     household_size: {
       type: 'integer',
-      description:
-        'Include anyone you live with who you claim as a dependent on your taxes, and your spouse or partner if you file taxes together.',
+      description: `The consumer's household size for tax purposes. Should \
+include anyone the consumer lives with who they claim as a dependent on their \
+taxes, and their spouse if they file taxes jointly.`,
       minimum: 1,
       maximum: 8,
       examples: [
@@ -85,8 +88,7 @@ const API_CALCULATOR_REQUEST_SCHEMA = {
     },
     language: {
       type: 'string',
-      description:
-        'Optional choice of language for `item`, `program` and `item_url` properties.',
+      description: 'Optional choice of language for user-visible strings.',
       enum: [
         'en',
         'es',
@@ -128,21 +130,31 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
   properties: {
     is_under_80_ami: {
       type: 'boolean',
+      description: `Whether the given household income is below the "80% of \
+Area Median Income" level for the given household size and location.`,
     },
     is_under_150_ami: {
       type: 'boolean',
+      description: `Whether the given household income is below the "150% of \
+Area Median Income" level for the given household size and location.`,
     },
     is_over_150_ami: {
       type: 'boolean',
+      description: `Whether the given household income is above the "150% of \
+Area Median Income" level for the given household size and location.`,
     },
     authorities: {
       type: 'object',
+      description: `Information on the entities (government agencies, \
+companies, other organizations) that offer incentives in this result set.`,
       additionalProperties: API_AUTHORITY_SCHEMA,
     },
     coverage: API_COVERAGE_SCHEMA,
     location: API_RESPONSE_LOCATION_SCHEMA,
     data_partners: {
       type: 'object',
+      description: `Information on organizations that assist in collecting, \
+verifying, and maintaining incentive data included in this result set.`,
       additionalProperties: API_DATA_PARTNER_SCHEMA,
     },
     incentives: {
@@ -154,8 +166,10 @@ export const API_CALCULATOR_RESPONSE_SCHEMA = {
 } as const;
 
 export const API_CALCULATOR_SCHEMA = {
-  description:
-    'How much money will your customer get with the Inflation Reduction Act?',
+  summary: 'Find eligible incentives',
+  description: `Compute incentives for which the user is eligible, given the \
+criteria in the request parameters.`,
+  operationId: 'getCalculatedIncentives',
   querystring: API_CALCULATOR_REQUEST_SCHEMA,
   response: {
     200: {

--- a/src/schemas/v1/image.ts
+++ b/src/schemas/v1/image.ts
@@ -5,12 +5,15 @@ export const API_IMAGE_SCHEMA = {
   properties: {
     src: {
       type: 'string',
+      description: 'The URL to fetch the image from.',
     },
     width: {
       type: 'number',
+      description: "The image's width in pixels.",
     },
     height: {
       type: 'number',
+      description: "The image's height in pixels.",
     },
   },
   required: ['src', 'width', 'height'],

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -22,6 +22,16 @@ export const API_INCENTIVE_SCHEMA = {
   properties: {
     payment_methods: {
       type: 'array',
+      description: `How a consumer receives value from this incentive.
+
+- \`rebate\`: a post-purchase rebate.
+- \`pos_rebate\`: a "point-of-sale" rebate; an upfront discount.
+- \`tax_credit\`: a credit against federal or state taxes paid.
+- \`account_credit\`: a credit on the consumer's utility account.
+- \`assistance_program\`: no-cost products or services.
+- \`performance_rebate\`: a post-purchase rebate that depends on measured or \
+modeled efficiency improvements.
+- \`unknown\`: something else.`,
       items: {
         type: 'string',
         enum: Object.values(PaymentMethod),
@@ -30,22 +40,38 @@ export const API_INCENTIVE_SCHEMA = {
     },
     authority_type: {
       type: 'string',
+      description: 'The nature of the entity offering the incentive.',
       enum: Object.values(AuthorityType),
     },
     authority: {
       type: 'string',
+      description: `The government agency, company, or organization that \
+offers this incentive. This generally means the entity that the consumer will \
+interact with to _claim the incentive_, as opposed to the entity that sets the \
+program rules, or that provides funding.`,
     },
     program: {
       type: 'string',
+      description: `Consumer-facing name of the program that this incentive is \
+part of. If the program has no distinct brand name, this string will usually \
+include the name of the offering authority as well.`,
     },
     program_url: {
       type: 'string',
+      description: `A URL to the best available official source of information \
+on this program.`,
     },
     more_info_url: {
       type: 'string',
+      description: `A URL to supplemental information on the program, usually \
+from a third party rather than the offering authority. Localized according to \
+the \`language\` request parameter.`,
     },
     items: {
       type: 'array',
+      description: `What products or services the incentive can be used on. \
+**NOTE**: we expect to add possible values to this field over time. Client \
+code should gracefully handle unknown values it sees here.`,
       items: {
         type: 'string',
         enum: ALL_ITEMS,
@@ -53,16 +79,45 @@ export const API_INCENTIVE_SCHEMA = {
     },
     amount: {
       type: 'object',
+      description: `The amount of monetary value that a consumer can receive \
+from this incentive.
+
+This format does not capture the full range of possible incentive structures, \
+which can be very complex and dependent on a wide range of factors. It is a \
+simplification in many cases.`,
       properties: {
         type: {
           type: 'string',
+          description: `The structure of the amount.
+
+- \`dollar_amount\`: a flat amount. This value is also used as a catchall for \
+amount structures that don't fit into the other categories; in such cases, the \
+aim is to at least capture the maximum value the incentive can have.
+- \`dollars_per_unit\`: an amount that scales with the size or capacity of the \
+equipment.
+- \`percent\`: an amount that is a percentage of the cost of the product or \
+service.`,
           enum: Object.values(AmountType),
         },
-        number: { type: 'number' },
-        maximum: { type: 'number' },
-        representative: { type: 'number' },
+        number: {
+          type: 'number',
+          description: `The dollar amount for \`dollar_amount\` and \
+\`dollars_per_unit\` types, and a number between 0 and 1 inclusive for \
+\`percent\` type (where 1 means 100%).`,
+        },
+        maximum: {
+          type: 'number',
+          description: 'The maximum dollar amount the incentive can have.',
+        },
+        representative: {
+          type: 'number',
+          description:
+            "For non-flat amounts, an estimate of the incentive's typical value.",
+        },
         unit: {
           type: 'string',
+          description:
+            'For `dollars_per_unit` type, the unit the amount depends on.',
           enum: Object.values(AmountUnit),
         },
       },
@@ -74,6 +129,8 @@ export const API_INCENTIVE_SCHEMA = {
     },
     owner_status: {
       type: 'array',
+      description: `Whether the consumer must be a homeowner or renter (or \
+either) to claim this incentive.`,
       items: {
         type: 'string',
         enum: Object.values(OwnerStatus),
@@ -82,12 +139,20 @@ export const API_INCENTIVE_SCHEMA = {
     },
     start_date: {
       type: 'string',
+      description: `The time period when the incentive began, or will begin, \
+to be available. Format is similar to an ISO-8601 date, but with some \
+modifications and additions. Examples:
+
+- \`2025\`: incentive begins some time during that year.
+- \`2025-03\`: incentive begins some time during that month.
+- \`2025-03-10\`: incentive begins that day.
+- \`2025H2\`: incentive begins some time during that half-year.
+- \`2025Q3\`: incentive begins some time during that quarter.`,
     },
     end_date: {
       type: 'string',
-    },
-    special_note: {
-      type: 'string',
+      description: `The date when the incentive stopped, or will stop, being \
+available. Format is the same as for \`start_date\`.`,
     },
     ami_qualification: {
       type: 'string',
@@ -109,8 +174,11 @@ export const API_INCENTIVE_SCHEMA = {
     },
     short_description: {
       type: 'string',
-      description:
-        'A 150 character (or shorter) display description for the incentive.',
+      description: `A short display description for the incentive, localized \
+according to the \`language\` request parameter. English descriptions are \
+150 characters or less in almost all cases. May be slightly longer in other \
+languages. Attempts to capture important data not expressed in other fields, \
+such as required equipment specs, restrictions on existing home situation, etc.`,
     },
   },
   additionalProperties: false,

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -158,19 +158,23 @@ available. Format is the same as for \`start_date\`.`,
       type: 'string',
       nullable: true,
       enum: [...Object.values(AmiQualification), null],
+      deprecated: true,
     },
     agi_max_limit: {
       type: 'number',
       nullable: true,
+      deprecated: true,
     },
     agi_min_limit: {
       type: 'number',
       nullable: true,
+      deprecated: true,
     },
     filing_status: {
       type: 'string',
       nullable: true,
       enum: [...Object.values(FilingStatus), null],
+      deprecated: true,
     },
     short_description: {
       type: 'string',

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -10,21 +10,23 @@ import { FromSchema } from 'json-schema-to-ts';
  */
 export const API_RESPONSE_LOCATION_SCHEMA = {
   type: 'object',
+  description:
+    'The computed location of the request\'s "zip" or "address" parameter.',
   properties: {
     state: {
       type: 'string',
-      description:
-        'The two-letter abbreviation for the state, district, or territory of the location submitted in the request.',
+      description: `The two-letter abbreviation for the state, district, or \
+territory of the location submitted in the request.`,
     },
     city: {
       type: 'string',
       description:
-        'The city name as determined by looking up the zip code in our database.',
+        'The city name as determined by looking up the ZIP code in our database.',
     },
     county: {
       type: 'string',
       description:
-        'The county name as determined by looking up the zip code in our database.',
+        'The county name as determined by looking up the ZIP code in our database.',
     },
   },
   required: ['state'],

--- a/src/schemas/v1/states-endpoint.ts
+++ b/src/schemas/v1/states-endpoint.ts
@@ -12,6 +12,8 @@ export const API_STATES_RESPONSE_SCHEMA = {
         properties: {
           status: { type: 'string', enum: Object.values(StateStatus) },
         },
+        required: ['status'],
+        additionalProperties: false,
       },
     ]),
   ),
@@ -19,7 +21,17 @@ export const API_STATES_RESPONSE_SCHEMA = {
 };
 
 export const API_STATES_SCHEMA = {
-  description: 'What is the rollout status of each state?',
+  summary: 'Get state rollout status',
+  description: `For each state (and Washington, DC), return the development \
+status of its state-, utility-, and local-level incentive data. (Note that \
+federal-level incentive data is available regardless of location.)
+
+\`none\` means that state, local, and utility (SLU) incentives \
+for the state are not in the API at all. \`beta\` means that SLU incentives \
+have not been fully vetted, and will be returned from \`/api/v1/calculator\` \
+only if the \`include_beta_states\` request parameter is true. \`launched\` \
+means that SLU incentives are fully vetted and returned in the API.`,
+  operationId: 'getStateStatus',
   response: {
     200: {
       ...API_STATES_RESPONSE_SCHEMA,

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -7,10 +7,15 @@ export const API_UTILITIES_RESPONSE_SCHEMA = {
     location: API_RESPONSE_LOCATION_SCHEMA,
     utilities: {
       type: 'object',
+      description: 'A map of utility IDs to info about each utility.',
       additionalProperties: {
         type: 'object',
         properties: {
-          name: { type: 'string' },
+          name: {
+            type: 'string',
+            description: `The customer-facing brand name of the utility. This \
+may differ from the name of the utility's legal entity.`,
+          },
         },
       },
     },
@@ -20,21 +25,26 @@ export const API_UTILITIES_RESPONSE_SCHEMA = {
 };
 
 export const API_UTILITIES_SCHEMA = {
-  description: 'Which utilities might serve a given location?',
+  summary: 'Find utilities by location',
+  description: `Returns the electric utilities that may serve the given \
+location. Because the location is imprecise, and because utility service \
+territories aren't precisely defined, there may be multiple results, including \
+utilities that don't actually serve the given location.`,
+  operationId: 'getUtilities',
   querystring: {
     type: 'object',
     properties: {
       zip: {
         type: 'string',
-        description:
-          'Your zip code helps us estimate the amount of discounts and tax credits you qualify for by finding representative census tracts in your area.',
+        description: `Find utilities that may serve this ZIP code. Exactly one \
+of this or "address" is required.`,
         maxLength: 5,
         minLength: 5,
       },
       address: {
         type: 'string',
-        description:
-          "Your address can determine the precise census tract you're in that determines the correct amount of discounts and tax credits you qualify for.",
+        description: `Find utilities that may serve this address. Exactly one \
+of this or "zip" is required.`,
       },
       language: {
         type: 'string',
@@ -44,12 +54,6 @@ export const API_UTILITIES_SCHEMA = {
           'es',
         ],
         default: 'en',
-      },
-      include_beta_states: {
-        type: 'boolean',
-        description:
-          'Option to include states which are in development and not fully launched.',
-        default: 'false',
       },
     },
     oneOf: [


### PR DESCRIPTION
## Description

Added description strings for almost all the request and response
fields of all endpoints.

I didn't describe all the possible `items` enum values. That's going
to be very long, and I think is best left for its own separate
page. I'll add a link to that page from the doc string, once it's
ready.

There are some other OpenAPI hygiene changes like adding summaries for
endpoints (which makes them show up better in doc generators), and
adding operation IDs.

I snuck in two substantive changes:

- The same schema that represents authorities in the backend JSON data
  was being used to represent them in the API. However, the JSON has
  more fields than we want to expose in the API, so create a new
  schema for authorities that excludes them.

- Remove the `include_beta_states` parameter from the utilities
  endpoint, since it's not read anymore. I already deployed a change
  to the embed to stop passing it, and made sure PEP doesn't use it.

## Test Plan

Use a work-in-progress script I have that merges the spec generated
from `/spec.json` into Zuplo's config file. The result is deployed
here:

https://api-main-4ba10f3.d2.zuplo.dev/docs

That doesn't show the descriptions of response fields and subfields (a
known shortcoming of Zuplo). However, you can use third-party doc
generator tools with the OpenAPI spec. Here are two examples:

- https://redocly.github.io/redoc/
- https://elements-demo.stoplight.io/

In both of those, enter this URL in the "try it" box to see the docs:

https://api-main-4ba10f3.d2.zuplo.dev/spec.json
