### PR TITLE
Fix cmf50 -> cfm50

### DIFF
--- a/src/data/types/amount.ts
+++ b/src/data/types/amount.ts
@@ -11,7 +11,7 @@ export enum AmountUnit {
   Kilowatt = 'kilowatt',
   Watt = 'watt',
   Btuh10k = 'btuh10k',
-  CMF50 = 'cmf50',
+  CFM50 = 'cfm50',
   SquareFoot = 'square_foot',
   KilowattHour = 'kilowatt_hour',
 }


### PR DESCRIPTION
## Description

It's "cubic feet per minute at 50 pascals". No incentives were using
this, and the embed frontend and PEp aren't either, so we can just go
ahead and do this.

## Test Plan

`yarn test`
