### PR TITLE
Move the detailed amount field docs up a level

### DIFF
--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -84,11 +84,8 @@ from this incentive.
 
 This format does not capture the full range of possible incentive structures, \
 which can be very complex and dependent on a wide range of factors. It is a \
-simplification in many cases.`,
-      properties: {
-        type: {
-          type: 'string',
-          description: `The structure of the amount.
+simplification in many cases. There are three amount structures, distinguished \
+by the \`type\` field:
 
 - \`dollar_amount\`: a flat amount. This value is also used as a catchall for \
 amount structures that don't fit into the other categories; in such cases, the \
@@ -97,6 +94,10 @@ aim is to at least capture the maximum value the incentive can have.
 equipment.
 - \`percent\`: an amount that is a percentage of the cost of the product or \
 service.`,
+      properties: {
+        type: {
+          type: 'string',
+          description: 'The structure of the amount.',
           enum: Object.values(AmountType),
         },
         number: {


### PR DESCRIPTION
## Description

I'm working on a script that code-generates a Markdown file of
response formats, for Zuplo docs. One challenge is dealing with deeply
nested object structures. I've got it rendering the docs for object
structures as a table if possible, but it's only possible if none of
the object's fields have descriptions with newlines. (You can't have
multiline values in table cells in Markdown, or at least not the
subset of Markdown that Zuplo supports.)

So, to allow rendering the `amount` structure as a table, I'm moving
the multiline part of the docs up to the top level of the structure,
rather than being on the `type` field.

## Test Plan

Generate the spec from this, use my in-progress script to render it
into Markdown. Make sure the table rendered for `amount` looks correct.
