### PR TITLE
Remove AGI, filing_status, ami_qualification from v1 API

### DIFF
--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -206,10 +206,6 @@ function transformItems(
     const transformedItem = {
       ...item,
       eligible,
-
-      // Fill in fields expected for IRA incentive.
-      // TODO: don't require these on APIIncentive
-      ami_qualification: null,
     };
     transformed.push(transformedItem);
   }

--- a/src/schemas/v1/incentive.ts
+++ b/src/schemas/v1/incentive.ts
@@ -1,7 +1,5 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { AuthorityType } from '../../data/authorities';
-import { AmiQualification } from '../../data/ira_incentives';
-import { FilingStatus } from '../../data/tax_brackets';
 import { AmountType, AmountUnit } from '../../data/types/amount';
 import { PaymentMethod } from '../../data/types/incentive-types';
 import { ALL_ITEMS } from '../../data/types/items';
@@ -154,28 +152,6 @@ modifications and additions. Examples:
       type: 'string',
       description: `The date when the incentive stopped, or will stop, being \
 available. Format is the same as for \`start_date\`.`,
-    },
-    ami_qualification: {
-      type: 'string',
-      nullable: true,
-      enum: [...Object.values(AmiQualification), null],
-      deprecated: true,
-    },
-    agi_max_limit: {
-      type: 'number',
-      nullable: true,
-      deprecated: true,
-    },
-    agi_min_limit: {
-      type: 'number',
-      nullable: true,
-      deprecated: true,
-    },
-    filing_status: {
-      type: 'string',
-      nullable: true,
-      enum: [...Object.values(FilingStatus), null],
-      deprecated: true,
     },
     short_description: {
       type: 'string',

--- a/test/snapshots/il-60304-state-utility-lowincome.json
+++ b/test/snapshots/il-60304-state-utility-lowincome.json
@@ -40,7 +40,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Qualified homeowners can work with ILSFA approved vendors to have solar panels installed on their property with no upfront costs."
     },
     {
@@ -64,7 +63,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $4,000 rebates for Illinois residents buying new or used all-electric vehicles. Vehicle must be purchased from a licensed dealer."
     }
   ]

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -41,7 +41,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades."
     },
     {
@@ -65,7 +64,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
     },
     {
@@ -88,7 +86,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
     },
     {
@@ -111,7 +108,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers."
     },
     {
@@ -135,9 +131,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 300000,
-      "filing_status": "joint",
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     }
   ]

--- a/test/snapshots/v1-02903-state-utility-lowincome.json
+++ b/test/snapshots/v1-02903-state-utility-lowincome.json
@@ -55,7 +55,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Weatherization Assistance Program reduces energy costs for households that meet LIHEAP criteria. If you qualify, there's no cost to you."
     },
     {
@@ -77,7 +76,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Depending on your income, 100% of the cost to install an air source heat pump, including up to $3,000 towards related electric service upgrades."
     },
     {
@@ -99,7 +97,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Depending on your income, 100% of the cost to install a heat pump water heater, including up to $3,000 towards related electric service upgrades."
     },
     {
@@ -123,7 +120,6 @@
         "renter"
       ],
       "start_date": "2022-10-24",
-      "ami_qualification": null,
       "short_description": "75% up to $750 back on the final purchase of an e-bike or e-cargo bike for income qualified residents."
     },
     {
@@ -146,7 +142,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $10,000 to install a ground source (geothermal) heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
     },
     {
@@ -170,7 +165,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
     },
     {
@@ -194,7 +188,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "10-25% back on installation costs up to $5,000. Includes electricity-generating solar panels and solar domestic hot water technologies."
     },
     {
@@ -218,7 +211,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$350+ back on qualifying ducted central heat pump, depending on size. Additional funding available for replacing baseboard resistance heating."
     },
     {
@@ -242,7 +234,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$150+ back on qualifying mini-split non-ducted heat pump, depending on size. Additional funding available for replacing baseboard resistance heating."
     },
     {
@@ -265,7 +256,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
     },
     {
@@ -288,7 +278,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Additional $1,500 back after purchase or lease of a new EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers."
     },
     {
@@ -311,7 +300,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Additional $1,500 towards a used EV from a licensed Rhode Island or qualified out-of-state dealership for LIHEAP-qualifiers. First-come, first-served."
     },
     {
@@ -333,7 +321,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters."
     },
     {
@@ -356,7 +343,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $1,000 back after purchase or lease of a used EV from a licensed Rhode Island or qualified out-of-state dealership. First-come, first-served."
     },
     {
@@ -380,7 +366,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $600 back on a qualifying electric heat pump water heater when replacing an existing electric water heater or installing in a new home."
     },
     {
@@ -401,7 +386,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Additional $500 for an electrical service upgrade at the same time as installation of a heat pump or heat pump water heater."
     },
     {
@@ -425,7 +409,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$75 back on ENERGY STAR certified, wireless connection enabled Smart Thermostat."
     },
     {
@@ -446,7 +429,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 back on ENERGY STAR® certified electric clothes dryer purchased in 2023. Rebate requests must be completed within 90 days of purchase."
     }
   ]

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -43,7 +43,6 @@
       ],
       "start_date": "2023-07-01",
       "end_date": "2024-06-30",
-      "ami_qualification": null,
       "short_description": "Income-qualified rebate for purchase or lease of new electric vehicles. $2,000 for battery EVs; $1,500 for plug-in hybrid EVs."
     },
     {
@@ -69,7 +68,6 @@
       ],
       "start_date": "2023-07-01",
       "end_date": "2024-06-30",
-      "ami_qualification": null,
       "short_description": "Income-qualified rebate for purchase of eligible used electric vehicles. $2,000 rebate for battery EVs; $1,500 rebate for plug-in hybrid EVs."
     },
     {
@@ -93,7 +91,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
     },
     {
@@ -117,7 +114,6 @@
       ],
       "start_date": "2022",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
     },
     {
@@ -141,7 +137,6 @@
       ],
       "start_date": "2022",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
     },
     {
@@ -165,9 +160,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 300000,
-      "filing_status": "joint",
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -191,9 +183,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 150000,
-      "filing_status": "joint",
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     },
     {
@@ -218,7 +207,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -241,7 +229,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -267,7 +254,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset."
     },
     {
@@ -290,7 +276,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
     },
     {
@@ -313,7 +298,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "Tax credit of up to $150 for an energy audit. Yearly reset."
     }
   ]

--- a/test/snapshots/v1-80517-estes-park.json
+++ b/test/snapshots/v1-80517-estes-park.json
@@ -43,7 +43,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
@@ -67,7 +66,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $900 off a heat pump water heater UEF 3.3. ENERGY STAR certified with CTA-2045 certified communication control."
     },
     {
@@ -90,7 +88,6 @@
         "renter"
       ],
       "start_date": "2023-01-01",
-      "ami_qualification": null,
       "short_description": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     }
   ]

--- a/test/snapshots/v1-80517-xcel.json
+++ b/test/snapshots/v1-80517-xcel.json
@@ -43,7 +43,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
@@ -64,7 +63,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$800 off qualifying new heat pump water heaters for Xcel customers. Must be installed by registered contractor and may not exceed 80 gallons."
     },
     {
@@ -87,7 +85,6 @@
         "renter"
       ],
       "start_date": "2023-01-01",
-      "ami_qualification": null,
       "short_description": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     }
   ]

--- a/test/snapshots/v1-84106-homeowner-80000-joint-4.json
+++ b/test/snapshots/v1-84106-homeowner-80000-joint-4.json
@@ -34,7 +34,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
     },
     {
@@ -58,7 +57,6 @@
       ],
       "start_date": "2022",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $7,200 on average."
     },
     {
@@ -82,7 +80,6 @@
       ],
       "start_date": "2022",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
     },
     {
@@ -106,9 +103,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 300000,
-      "filing_status": "joint",
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -132,9 +126,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 150000,
-      "filing_status": "joint",
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     },
     {
@@ -159,7 +150,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -182,7 +172,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -208,7 +197,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset."
     },
     {
@@ -231,7 +219,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
     },
     {
@@ -254,7 +241,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
       "short_description": "Tax credit of up to $150 for an energy audit. Yearly reset."
     }
   ]

--- a/test/snapshots/v1-az-85701-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85701-state-utility-lowincome.json
@@ -35,7 +35,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Weatherization improvements for homes for limited-income customers."
     },
     {
@@ -58,7 +57,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2023-12-31",
-      "ami_qualification": null,
       "short_description": "$400 rebate for TEP residential customers who purchase and install an Energy Star HPWH equipped with a wireless, programmable controller."
     }
   ]

--- a/test/snapshots/v1-az-85702-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85702-state-utility-lowincome.json
@@ -35,7 +35,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Assistance available for energy efficient retrofitting to homes of income-qualifying customers."
     },
     {
@@ -57,7 +56,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $900 rebate for retiring an existing, qualified system and installing an Energy Star heat pump/AC purchase via a qualified contractor."
     },
     {
@@ -79,7 +77,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $650 rebate for an Energy Star heat pump/AC purchase and installation through a qualified contractor."
     }
   ]

--- a/test/snapshots/v1-co-81657-state-utility-lowincome.json
+++ b/test/snapshots/v1-co-81657-state-utility-lowincome.json
@@ -49,7 +49,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$600 per heating ton for qualifying Ground Source Heat Pumps."
     },
     {
@@ -72,7 +71,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$2200 for qualifying Cold Climate Air Source Heat Pumps."
     },
     {
@@ -94,7 +92,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$2200 for qualifying Cold Climate Mini Split Heat Pumps."
     },
     {
@@ -117,7 +114,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$1700 for qualifying High Efficiency Air Source Heat Pumps."
     },
     {
@@ -139,7 +135,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$1700 for qualifying Mini Split Heat Pumps."
     },
     {
@@ -160,7 +155,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Free Home Energy Assessment for households with income at 150% of Area Median Income or less."
     },
     {
@@ -183,7 +177,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "At least $999.90 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
@@ -207,7 +200,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "At least $499.95 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
@@ -230,7 +222,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "At least $166.65 discount for ENERGY STAR & AHRI certified system. Available through registered contractors."
     },
     {
@@ -254,7 +245,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for weatherization projects such as air/duct sealing, insulation, and more for income-qualifying households."
     },
     {
@@ -277,7 +267,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air source heat pumps for income-qualifying households."
     },
     {
@@ -299,7 +288,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate air to water heat pumps for income-qualifying households."
     },
     {
@@ -321,7 +309,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for qualifying cold climate ground source heat pumps for income-qualifying households."
     },
     {
@@ -343,7 +330,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for qualifying ductless heat pumps for income-qualifying households."
     },
     {
@@ -365,7 +351,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for heat pump water heaters for income-qualifying households."
     },
     {
@@ -387,7 +372,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for heat pump clothes dryer for income-qualifying households."
     },
     {
@@ -409,7 +393,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for wiring projects related to electrification for income-qualifying households."
     },
     {
@@ -431,7 +414,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for panel upgrades related to electrification for income-qualifying households."
     },
     {
@@ -453,7 +435,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for WiFi-enabled smart thermostats or programmable thermostats for income-qualifying households."
     },
     {
@@ -475,7 +456,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 50% of project costs for induction cooktops and stoves for income-qualifying households."
     },
     {
@@ -499,7 +479,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for weatherization projects such as air/duct sealing, insulation, and more, capped annually at $3,000."
     },
     {
@@ -522,7 +501,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate air source heat pumps, capped annually at $3,000."
     },
     {
@@ -544,7 +522,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate air to water heat pumps, capped annually at $3,000."
     },
     {
@@ -566,7 +543,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for qualifying cold climate ground source heat pumps, capped annually at $3,000."
     },
     {
@@ -588,7 +564,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for qualifying ductless heat pumps, capped annually at $3,000."
     },
     {
@@ -610,7 +585,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for heat pump water heaters, capped annually at $3,000."
     },
     {
@@ -632,7 +606,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for heat pump clothes dryer, capped annually at $3,000."
     },
     {
@@ -654,7 +627,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for wiring projects related to electrification, capped annually at $3,000."
     },
     {
@@ -676,7 +648,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for panel upgrades related to electrification, capped annually at $3,000."
     },
     {
@@ -698,7 +669,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for WiFi-enabled smart thermostats or programmable thermostats, capped annually at $3,000."
     },
     {
@@ -720,7 +690,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates of up to 25% of project costs for induction cooktops and stoves, capped annually at $3,000."
     },
     {
@@ -743,7 +712,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rebates for solar photovoltaic installation: $250/kW from 0-6 kW, and $100/kW from 6-25 kW."
     },
     {
@@ -764,7 +732,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$800 off qualifying new heat pump water heaters for Xcel customers. Must be installed by registered contractor and may not exceed 80 gallons."
     },
     {
@@ -788,7 +755,6 @@
         "renter"
       ],
       "start_date": "2023-01-01",
-      "ami_qualification": null,
       "short_description": "12.9% discount on the equipment price of heat pumps, through Colorado State tax credit and sales tax exemption."
     },
     {
@@ -811,7 +777,6 @@
         "renter"
       ],
       "start_date": "2023-01-01",
-      "ami_qualification": null,
       "short_description": "12.9% discount on the equipment price of heat pump water heaters, through Colorado State tax credit and sales tax exemption."
     },
     {
@@ -834,7 +799,6 @@
         "renter"
       ],
       "start_date": "2023-07-01",
-      "ami_qualification": null,
       "short_description": "State tax credit of $5,000 for the purchase or lease of a new EV (max MSRP: $80,000)."
     },
     {
@@ -858,7 +822,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2029-01-01",
-      "ami_qualification": null,
       "short_description": "Additional state tax credit of $2,500 for Coloradans purchasing or leasing an EV with a max MSRP of $35,000."
     }
   ]

--- a/test/snapshots/v1-ct-06002-state-utility-lowincome.json
+++ b/test/snapshots/v1-ct-06002-state-utility-lowincome.json
@@ -39,7 +39,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "The Home Energy Solutions program provides income-eligible households with no-cost energy assessments and incentives for weatherization services."
     },
     {
@@ -62,7 +61,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$3,000 rebate for a qualifying used electric vehicle for income-qualifying individuals."
     },
     {
@@ -84,7 +82,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$2,250 rebate for a qualifying new electric vehicle."
     },
     {
@@ -106,7 +103,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Bonus $2,000 off a qualifying new electric vehicle for income-eligible individuals."
     },
     {
@@ -131,7 +127,6 @@
       ],
       "start_date": "2023",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$1,500 per ton after-purchase rebate for qualifying ground source heat pumps, up to $15,000."
     },
     {
@@ -157,7 +152,6 @@
       ],
       "start_date": "2023",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$750 per ton after-purchase rebate for qualifying air source heat pumps."
     },
     {
@@ -180,7 +174,6 @@
       ],
       "start_date": "2023",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$650 off eligible Energy Star certified Heat Pump Water Heaters."
     },
     {
@@ -203,7 +196,6 @@
       ],
       "start_date": "2023",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Bonus $500 off ground source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months."
     },
     {
@@ -227,7 +219,6 @@
       ],
       "start_date": "2023",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Bonus $500 off air source heat pump installation if insulation was installed through Energize CT Home Energy Solutions within the prior 12 months."
     }
   ]

--- a/test/snapshots/v1-dc-20303-state-city-lowincome.json
+++ b/test/snapshots/v1-dc-20303-state-city-lowincome.json
@@ -74,7 +74,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "100% of costs covered for switching to heat pump water heaters. Income-qualified residents only."
     },
     {
@@ -98,7 +97,6 @@
       ],
       "start_date": "2023-10-04",
       "end_date": "2024-10-03",
-      "ami_qualification": null,
       "short_description": "100% of costs covered for upgrading electrical panels. Income-qualified residents only."
     },
     {
@@ -126,7 +124,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "100% of costs covered for home weatherization (insulation and air sealing). Income-qualified residents only."
     },
     {
@@ -150,7 +147,6 @@
       ],
       "start_date": "2024-02-23",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "100% of costs covered for income-qualified homeowners to have solar photovoltaic (PV) systems installed by local contractors."
     },
     {
@@ -174,7 +170,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "100% of costs covered for switching to induction cooktops or electric resistance stoves. Income-qualified residents only."
     },
     {
@@ -198,7 +193,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "100% of costs covered for switching to qualified ducted or ductless heating systems. Income-qualified residents only."
     },
     {
@@ -222,7 +216,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "$500 rebate for electric riding lawn mowers."
     },
     {
@@ -246,7 +239,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "$75-$200 rebate for ENERGY STAR® or ENERGY STAR® Most Efficient qualified clothes dryers."
     },
     {
@@ -270,7 +262,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "$75 rebate for electric push lawn mowers."
     },
     {
@@ -294,7 +285,6 @@
       ],
       "start_date": "2023-10-01",
       "end_date": "2024-09-30",
-      "ami_qualification": null,
       "short_description": "$50 rebate for ENERGY STAR® qualified smart thermostats."
     }
   ]

--- a/test/snapshots/v1-ga-30033-utility.json
+++ b/test/snapshots/v1-ga-30033-utility.json
@@ -38,7 +38,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $250 for attic insulation. Addition of R-38 or greater required."
     },
     {
@@ -62,7 +61,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $300 for air sealing. Must be completed by a participating program contractor."
     },
     {
@@ -86,7 +84,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $300 for duct sealing."
     },
     {
@@ -110,7 +107,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $75 for smart thermostats."
     },
     {
@@ -134,7 +130,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $1,000 for ENERGY STAR® certified ground source heat pumps."
     },
     {
@@ -158,7 +153,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $500 for ENERGY STAR® certified heat pump water heaters."
     },
     {
@@ -182,7 +176,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $50 for ENERGY STAR® certified electric vehicle chargers. Must be 208/240 volt level 2 charger with dedicated circuit."
     },
     {
@@ -206,7 +199,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2025-12-31",
-      "ami_qualification": null,
       "short_description": "Rebate for 50% of cost up to $1,000 for ENERGY STAR® certified mini-split heat pumps."
     }
   ]

--- a/test/snapshots/v1-il-60202-city-lowincome.json
+++ b/test/snapshots/v1-il-60202-city-lowincome.json
@@ -35,7 +35,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $20,000 for energy efficiency, and health improvement updates. In most cases, the program will cover the full cost of home improvements."
     },
     {
@@ -56,7 +55,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "New electrical systems. In most cases, the program will cover the full cost of home improvements."
     },
     {
@@ -77,7 +75,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "New electrical systems. In most cases, the program will cover the full cost of home improvements."
     },
     {
@@ -98,7 +95,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Rooftop solar panels. In most cases, the program will cover the full cost of home improvements."
     }
   ]

--- a/test/snapshots/v1-mi-48103-state-utility-lowincome.json
+++ b/test/snapshots/v1-mi-48103-state-utility-lowincome.json
@@ -37,7 +37,6 @@
         "renter"
       ],
       "start_date": "2022-12-01",
-      "ami_qualification": null,
       "short_description": "$1,500 rebate on a purchased or leased new electric vehicle."
     },
     {
@@ -58,7 +57,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$1000 for ductless heat pumps. Must be both 17+ SEER2 and HSPF2 7.5+, and must replace a heat pump or electric heat system."
     },
     {
@@ -81,7 +79,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $850 rebate for air source heat pumps. Rebate value depends on appliance efficiency."
     },
     {
@@ -102,7 +99,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$800 rebate for 16+ EER2 ground source heat pumps."
     },
     {
@@ -124,7 +120,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$500 rebate when you buy or lease an EV, enroll in an eligible Time of Day rate and install a Level 2 charger."
     },
     {
@@ -147,7 +142,6 @@
         "homeowner"
       ],
       "start_date": "2024-01-01",
-      "ami_qualification": null,
       "short_description": "Up to $250 for a qualifying ENERGY STAR heat pump clothes dryer."
     },
     {
@@ -168,7 +162,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$125 for roof & attic insulation. Must insulate a minimum of 500 square feet of attic area."
     },
     {
@@ -189,7 +182,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$125 for above-grade wall insulation. Must insulate a minimum of 250 square feet of attic area."
     },
     {
@@ -210,7 +202,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 for new Wi-Fi enabled thermostat."
     },
     {
@@ -231,7 +222,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 for rim/band joist insulation. Must insulate a minimum of 50 square feet and all accessible rim joist areas."
     },
     {
@@ -252,7 +242,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 for basement wall insulation. Must insulate a minimum of 200 square feet of wall area."
     },
     {
@@ -273,7 +262,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 for crawl space wall insulation. Must insulate a minimum of 100 square feet of wall area."
     },
     {
@@ -294,7 +282,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 for floor insulation. Must insulate a minimum of 100 square feet of wall area."
     },
     {
@@ -315,7 +302,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$25 for kneewall insulation. Must insulate a minimum of 100 square feet of attic area."
     }
   ]

--- a/test/snapshots/v1-mi-48825-city-lowincome.json
+++ b/test/snapshots/v1-mi-48825-city-lowincome.json
@@ -37,7 +37,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $1,500 rebate for an e-bike. Income qualified. Must be UL 2849 certified. Motor must be 750 watts or less. Limit 1."
     },
     {
@@ -59,7 +58,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$1,000 rebate. Must include no less than three elements. Cooktop or range must be at least 24in x 24in LW. Limit 1."
     },
     {
@@ -81,7 +79,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $1,000 rebate for installation of a home EV charger."
     },
     {
@@ -103,7 +100,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $600 rebate for a ducted heat pump system. Minimum 15.2 SEER2."
     },
     {
@@ -125,7 +121,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $500 rebate for a ductless heat pump system. Minimum 25 SEER2."
     },
     {
@@ -148,7 +143,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $150 rebate for electric lawn equipment. Includes rebates for mowers, trimmers, chainsaws and blowers."
     },
     {
@@ -170,7 +164,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$100 rebate on a heat pump clothes dryer. Must be ENERGY STAR certified. Limit 1."
     },
     {
@@ -191,7 +184,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$50 rebate for a Smart Wi-Fi enabled thermostat. Limit 1."
     },
     {
@@ -213,7 +205,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$25 rebate on an electric clothes dryer. Must be ENERGY STAR certified. Limit 1."
     }
   ]

--- a/test/snapshots/v1-nv-89108-state-utility-lowincome.json
+++ b/test/snapshots/v1-nv-89108-state-utility-lowincome.json
@@ -45,7 +45,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Free replacement of electric dryers (10 years or older) when you meet income eligibility requirements."
     },
     {
@@ -67,7 +66,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Receive a free Smart Thermostat valued at $300 with free professional installation."
     },
     {
@@ -90,7 +88,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $2,040 instant rebate from qualifying distributors when you replace your old air condition system with an air source heat pump."
     },
     {
@@ -112,7 +109,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Receive up to $1,360 instant rebate from qualifying distributors when you replace your old air condition system with higher efficiency equipment."
     },
     {
@@ -133,7 +129,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $1,360 discount from qualifying distributors when your replace your old air conditioning system with a ductless heat pump."
     },
     {
@@ -154,7 +149,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$400 rebate for ENERGY STAR certified heat pump water heaters. Redeemable at Lowe's. Limit 1 per customer."
     },
     {
@@ -176,7 +170,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$200 rebate for ENERGY STAR certified heat pump dryers. Redeemable at Home Depot. Limit 1 per customer."
     },
     {
@@ -198,7 +191,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "$50 rebate for ENERGY STAR certified electric dryers. Redeemable at Home Depot. Limit 1 per customer."
     },
     {
@@ -223,7 +215,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "NV Energy provides a rebate of up to $400 for weather stripping, duct sealing, and insulation."
     }
   ]

--- a/test/snapshots/v1-ny-11557-state-utility-lowincome.json
+++ b/test/snapshots/v1-ny-11557-state-utility-lowincome.json
@@ -42,7 +42,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $7,500 in weatherization and health and safety services for income eligible households."
     },
     {
@@ -65,7 +64,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Instant rebate for $500-$2,000 off a new electric vehicle when purchased from a participating dealer. Can be combined with the federal tax credit."
     },
     {
@@ -87,7 +85,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Instant or mail-in rebate for $1,000 off an eligible Energy Star certified heat pump water heater when purchased at a participating retailer."
     },
     {
@@ -110,7 +107,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$450 to $600 off an Energy Star certified air source heat pump when installed by an eligible contractor."
     },
     {
@@ -131,7 +127,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$600 off an Energy Star certified heat pump water heater when installed by a participating contractor."
     },
     {
@@ -152,7 +147,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$600 off an eligible high efficiency cold climate ducted heat pump system, when installed by a participating contractor."
     },
     {
@@ -173,7 +167,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Up to $240 off an Energy Star certified ductless mini-split heat pump system when installed by a participating contractor."
     },
     {
@@ -196,7 +189,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$1,000 to $4,000 in incentives available for seal and insulate packages to improve your home's comfort."
     },
     {
@@ -218,7 +210,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Tax credit for 25% of the cost for a qualifying geothermal energy system, including installation costs, up to $5,000."
     }
   ]

--- a/test/snapshots/v1-or-97001-state-lowincome.json
+++ b/test/snapshots/v1-or-97001-state-lowincome.json
@@ -36,7 +36,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "$500 discount on a ductless heat pump with additional heating source. The heat pump must replace zonal electric as the primary heat source."
     },
     {
@@ -57,7 +56,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$250 discount on qualifying heat pump controls."
     },
     {
@@ -78,7 +76,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Receive $100 off qualifying Google Nest and ecobee Smart Thermostats when you purchase online."
     },
     {
@@ -100,7 +97,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Eligible customers can replace their existing windows with new ones rated U-Value 0.22 or less and earn $1.50 per sq ft."
     },
     {
@@ -122,7 +118,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$1.50 per sq ft of attic insulation for manufactured homes. Income-qualified customers. Existing insulation must be R-18 or less."
     },
     {
@@ -144,7 +139,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$1.50 per sq ft of attic insulation. Income-qualified customers. Existing insulation must be R-18 or less. Must insulate to R-38 or greater."
     },
     {
@@ -166,7 +160,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Eligible customers can replace their existing windows with new ones with a U-Value rating between 0.27 and 0.23 and earn $1 per sq ft."
     },
     {
@@ -188,7 +181,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Earn $0.75 per sq ft for qualifying floor insulation measures in manufactured homes. Income-qualified customers. Must insulate to at least R-22."
     },
     {
@@ -210,7 +202,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$0.75 per sq ft for floor insulation for income-qualified customers. Must insulate to R-30 or greater or fill the accessible floor cavity."
     },
     {
@@ -232,7 +223,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "$0.75 per sq ft of wall insulation for income-qualified customers. Existing wall insulation must be R-4 or less. Must insulate to R-11 or greater."
     },
     {
@@ -254,7 +244,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "PGE and Pacific Power customers are eligible for a $3,000 rebate for an extended capacity heat pump replacing an electric furnace."
     },
     {
@@ -277,7 +266,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "$3,000 rebate for a heat pump for income-qualified customers. Must replace an electric forced-air furnace as the primary heating source."
     },
     {
@@ -299,7 +287,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "$1,800 rebate for a ductless heat pump for income-qualified customers. Must replace electric resistance as the primary heat source."
     },
     {
@@ -321,7 +308,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "$1,000 rebate for a ductless heat pump replacing zonal electric resistance as the primary heat source. Primary unit must be in the main living space."
     },
     {
@@ -343,7 +329,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "$1,000 rebate for an extended capacity central ducted heat pump. Must be listed on Energy Trust’s list and be the primary heat source."
     }
   ]

--- a/test/snapshots/v1-pa-17555-state-lowincome.json
+++ b/test/snapshots/v1-pa-17555-state-lowincome.json
@@ -42,7 +42,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Free energy audit and weatherization services for income-qualified residents. Average value per household is $7,669 depending on results."
     },
     {
@@ -64,7 +63,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Free energy audit and weatherization services for income-qualified residents."
     },
     {
@@ -87,7 +85,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$500 rebate for ENERGY STAR® certified heat pump water heaters."
     },
     {
@@ -111,7 +108,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$75 rebate for ENERGY STAR® certified smart thermostats for income-qualified residents."
     },
     {
@@ -137,7 +133,6 @@
       ],
       "start_date": "2023-07-01",
       "end_date": "2024-06-30",
-      "ami_qualification": null,
       "short_description": "Income-qualified rebate for purchase or lease of new electric vehicles. $3,000 for battery EVs; $2,500 for plug-in hybrid EVs."
     },
     {
@@ -163,7 +158,6 @@
       ],
       "start_date": "2023-07-01",
       "end_date": "2024-06-30",
-      "ami_qualification": null,
       "short_description": "Income-qualified rebate for purchase of eligible used electric vehicles. $3,000 rebate for battery EVs; $2,500 rebate for plug-in hybrid EVs."
     },
     {
@@ -186,7 +180,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$650 rebate for ENERGY STAR® certified geothermal heat pumps."
     },
     {
@@ -211,7 +204,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "Up to $500 rebate for ENERGY STAR® certified air source heat pumps meeting qualifications. Rebate value depends on efficiency."
     },
     {
@@ -234,7 +226,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$400 rebate for ENERGY STAR® certified air-to-water heat pumps."
     },
     {
@@ -257,7 +248,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$200 rebate for ENERGY STAR® certified ductless mini-split AC."
     },
     {
@@ -280,7 +270,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$200 rebate for ENERGY STAR® certified ductless mini-split heat pump."
     },
     {
@@ -304,7 +293,6 @@
       ],
       "start_date": "2021-06-01",
       "end_date": "2026-05-31",
-      "ami_qualification": null,
       "short_description": "$75 rebate for ENERGY STAR® certified clothes dryer for income-qualified residents."
     }
   ]

--- a/test/snapshots/v1-va-22030-state-utility-lowincome.json
+++ b/test/snapshots/v1-va-22030-state-utility-lowincome.json
@@ -37,7 +37,6 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "ami_qualification": null,
       "short_description": "Receive up to a $400 rebate for installing a heat pump water heater above 40 gallons in capacity."
     },
     {
@@ -58,7 +57,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Participate in Dominion Energy's EV charging control events using your level 2 charger and receive a $125 rebate."
     },
     {
@@ -80,7 +78,6 @@
         "homeowner"
       ],
       "start_date": "2019",
-      "ami_qualification": null,
       "short_description": "Dominion Energy customers can receive a $100 rebate on a new electric clothes dryer."
     }
   ]

--- a/test/snapshots/v1-vt-05401-state-utility-lowincome.json
+++ b/test/snapshots/v1-vt-05401-state-utility-lowincome.json
@@ -52,7 +52,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "The State's Weatherization Assistance Program offers free services including energy audits, insulation and air sealing for income-eligible households."
     },
     {
@@ -75,7 +74,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "25% of the upfront cost of a used high-efficiency vehicle, up to $5,000, for low and moderate income car buyers."
     },
     {
@@ -99,7 +97,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Incentive up to $5,000 for a new electric vehicle, or up to $3,000 for a new plug-in hybrid vehicle."
     },
     {
@@ -122,7 +119,6 @@
         "homeowner"
       ],
       "start_date": "2021-11-01",
-      "ami_qualification": null,
       "short_description": "Work with a contractor to install your ducted heat pump and get a $1,000-$2,000 instant discount."
     },
     {
@@ -145,7 +141,6 @@
         "homeowner"
       ],
       "start_date": "2021-11-01",
-      "ami_qualification": null,
       "short_description": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor."
     },
     {
@@ -168,7 +163,6 @@
         "homeowner"
       ],
       "start_date": "2022-10-15",
-      "ami_qualification": null,
       "short_description": "Get a $400 instant discount at participating retailers for a new, high-efficiency stove."
     },
     {
@@ -191,7 +185,6 @@
         "homeowner"
       ],
       "start_date": "2020-06-15",
-      "ami_qualification": null,
       "short_description": "Apply for a rebate and get $25-40 cash back on qualifying ENERGY STAR® models."
     },
     {
@@ -214,7 +207,6 @@
         "homeowner"
       ],
       "start_date": "2018-07-01",
-      "ami_qualification": null,
       "short_description": "Hire a contractor and get a $15-$600 instant rebate on each qualifying high-performance circulator pump at participating distributors."
     },
     {
@@ -236,7 +228,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "100% off a heat pump water heater, up to $5,000, for low-income customers."
     },
     {
@@ -260,7 +251,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Customers may receive a rebate up to $2,500 on qualifying ductless heat pumps, or $500 for a second heat pump."
     },
     {
@@ -283,7 +273,6 @@
         "homeowner"
       ],
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $900 back on qualifying level 2 charger purchased within 60 days of vehicle purchase or lease. May be eligible for discounted EV charging rate."
     },
     {
@@ -306,7 +295,6 @@
         "homeowner"
       ],
       "start_date": "2023-08-01",
-      "ami_qualification": null,
       "short_description": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project cost up to $4,000."
     },
     {
@@ -329,7 +317,6 @@
         "homeowner"
       ],
       "start_date": "2023-08-01",
-      "ami_qualification": null,
       "short_description": "Work with an Efficiency Excellence Network contractor to improve your home's insulation and air sealing and get 75% off project costs up to $9,500."
     },
     {
@@ -353,7 +340,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $100 back for residential push mower or up to $300 back for a ride-on mower and $50 on electric chainsaws and trimmers."
     },
     {
@@ -378,7 +364,6 @@
       ],
       "start_date": "2021-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "BED customers may receive a post purchase rebate up to $12,000 when you install an air-to-water heat pump."
     },
     {
@@ -401,7 +386,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "BED customers may receive a rebate up to $2,500 on qualifying ground source heat pumps, plus an additional $500 for a second ground source heat pump."
     },
     {
@@ -424,7 +408,6 @@
         "homeowner"
       ],
       "start_date": "2019-01-01",
-      "ami_qualification": null,
       "short_description": "Get $6,000 back for installing a wood pellet boiler or furnace."
     },
     {
@@ -448,7 +431,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $5,450 on heat pump installation."
     },
     {
@@ -472,7 +454,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Incentive up to $2,300 for a new electric vehicle, or up to $2,000 for a plug-in hybrid."
     },
     {
@@ -495,7 +476,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Incentive up to $1,300 for a used electric vehicle or plug-in hybrid."
     },
     {
@@ -517,7 +497,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Income-eligible Vermonters qualify for a $200-$1,000 bonus rebate on a ductless heat pump, depending on their utility."
     },
     {
@@ -541,7 +520,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Customers may receive upto $800 rebate for a heat pump water heater."
     },
     {
@@ -565,7 +543,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "An extra $700 for a new all-electric vehicle, or $300 for a plug-in hybrid, for income-qualified customers."
     },
     {
@@ -588,7 +565,6 @@
         "homeowner"
       ],
       "start_date": "2021-12-01",
-      "ami_qualification": null,
       "short_description": "Install integrated controls with a new ductless heat pump in a single family home and get up to $600 back."
     },
     {
@@ -612,7 +588,6 @@
       ],
       "start_date": "2021-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Income-eligible BED customers are eligible for an enhanced rebate of $400 when installing a qualified air-to-water heat pump."
     },
     {
@@ -635,7 +610,6 @@
         "homeowner"
       ],
       "start_date": "2019-07-15",
-      "ami_qualification": null,
       "short_description": "Receive up to $400 cash back on qualifying ENERGY STAR® heat pump clothes dryers."
     },
     {
@@ -659,7 +633,6 @@
       ],
       "start_date": "2023-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Income-eligible BED customers can receive a $400 enhanced rebate for a qualifying ducted heat pump."
     },
     {
@@ -683,7 +656,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Income-eligible customers qualify for a $400 enhanced rebate for a ductless heat pump."
     },
     {
@@ -706,7 +678,6 @@
         "homeowner"
       ],
       "start_date": "2023-10-01",
-      "ami_qualification": null,
       "short_description": "Apply for a rebate and get up to $400 cash back on qualifying ENERGY STAR® heat pump models."
     },
     {
@@ -727,7 +698,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Vermonters with low or moderate household income may qualify for a $200 bonus rebate on a ducted heat pump, depending on their utility."
     },
     {
@@ -751,7 +721,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Income-eligible customers recieve an enhanced bonus rebate of $200 for a heat pump water heater."
     },
     {
@@ -775,7 +744,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $200 back on the purchase of a new electric induction cooktop when replacing a non-electric cooktop."
     },
     {
@@ -798,7 +766,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "An extra $300 for a used all-electric vehicle or plug-in hybrid, for income-qualified customers."
     },
     {
@@ -822,7 +789,6 @@
         "homeowner"
       ],
       "start_date": "2019-09-23",
-      "ami_qualification": null,
       "short_description": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing."
     },
     {
@@ -845,7 +811,6 @@
         "homeowner"
       ],
       "start_date": "2019-01-01",
-      "ami_qualification": null,
       "short_description": "Get up to $100 cash back on qualifying ENERGY STAR® smart thermostats if wholesale discount has not already been received on the purchase."
     },
     {
@@ -868,7 +833,6 @@
         "homeowner"
       ],
       "start_date": "2020-06-15",
-      "ami_qualification": null,
       "short_description": "Apply for a rebate and get up to $100 cash back on qualifying fixtures."
     },
     {
@@ -891,7 +855,6 @@
         "homeowner"
       ],
       "start_date": "2021-04-01",
-      "ami_qualification": null,
       "short_description": "Get $100 back for ENERGY STAR® “Most Efficient” certified models."
     },
     {
@@ -914,7 +877,6 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Receive up to $40 back for residential electric leaf blower (commercial up to $200)."
     }
   ]

--- a/test/snapshots/v1-vt-05845-vec-ev-low-income.json
+++ b/test/snapshots/v1-vt-05845-vec-ev-low-income.json
@@ -49,7 +49,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "25% of the upfront cost of a used high-efficiency vehicle, up to $5,000, for low and moderate income car buyers."
     },
     {
@@ -73,7 +72,6 @@
         "homeowner",
         "renter"
       ],
-      "ami_qualification": null,
       "short_description": "Incentive up to $5,000 for a new electric vehicle, or up to $3,000 for a new plug-in hybrid vehicle."
     },
     {
@@ -98,7 +96,6 @@
         "renter"
       ],
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$500 for purchasing a new all-electric vehicle, or $250 for a plug-in hybrid."
     },
     {
@@ -122,7 +119,6 @@
         "renter"
       ],
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$500 for purchasing a used all-electric vehicle, or $250 for a plug-in hybrid."
     },
     {
@@ -146,7 +142,6 @@
         "renter"
       ],
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "An extra $500 for purchasing a new all-electric vehicle or plug-in hybrid, for income-qualified customers."
     },
     {
@@ -170,9 +165,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 150000,
-      "filing_status": "single",
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -196,9 +188,6 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "ami_qualification": null,
-      "agi_max_limit": 75000,
-      "filing_status": "single",
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     }
   ]

--- a/test/snapshots/v1-vt-addison-co-low-income.json
+++ b/test/snapshots/v1-vt-addison-co-low-income.json
@@ -45,7 +45,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "100% off a heat pump water heater, up to $5,000, for low-income customers."
     }
   ]

--- a/test/snapshots/v1-vt-bennington-co-not-low-income.json
+++ b/test/snapshots/v1-vt-bennington-co-not-low-income.json
@@ -46,7 +46,6 @@
         "homeowner"
       ],
       "start_date": "2020-01-01",
-      "ami_qualification": null,
       "short_description": "90% off a heat pump water heater, up to $4,500, for moderate-income customers."
     }
   ]

--- a/test/snapshots/v1-wi-53703-state-utility-lowincome.json
+++ b/test/snapshots/v1-wi-53703-state-utility-lowincome.json
@@ -35,7 +35,6 @@
       "owner_status": [
         "homeowner"
       ],
-      "ami_qualification": null,
       "short_description": "Instant discounts starting at $300 for ENERGY STAR® certified electric heat pump water heaters."
     },
     {
@@ -58,7 +57,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "Up to $1,125 rebate for ENERGY STAR® Qualified Air Sealing, assessment required. For income-qualified customers."
     },
     {
@@ -82,7 +80,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "$1,000 rebate for air source heat pumps replacing natural gas or electric resistance."
     },
     {
@@ -106,7 +103,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "$750 rebate for certified geothermal heat pumps without natural gas service or $1000 with natural gas service."
     },
     {
@@ -129,7 +125,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "Up to $675 rebate for attic insulation. For income-qualified customers."
     },
     {
@@ -153,7 +148,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "Up to $500 rebate for residential solar PV systems, additional $500 for rural areas."
     },
     {
@@ -176,7 +170,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "Up to $450 rebate for wall insulation."
     },
     {
@@ -200,7 +193,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "$400 rebate for air source heat pumps replacing propane, oil, existing heat pump, etc."
     },
     {
@@ -223,7 +215,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "Up to $225 rebate for foundation insulation. For income-qualified customers."
     },
     {
@@ -247,7 +238,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "ami_qualification": null,
       "short_description": "$200 rebate for DIY attic insulation and air sealing, must meet R42 insulation level."
     },
     {
@@ -270,7 +260,6 @@
       ],
       "start_date": "2024-01-01",
       "end_date": "2024-05-31",
-      "ami_qualification": null,
       "short_description": "Up to $75 rebate for duct sealing & insulation."
     },
     {
@@ -293,7 +282,6 @@
         "homeowner"
       ],
       "start_date": "2024-01-01",
-      "ami_qualification": null,
       "short_description": "$50 rebate for qualified smart thermostats. Available as instant discounts in the online marketplace or as rebates."
     }
   ]


### PR DESCRIPTION
## Description

Following up on #500 to remove the fields from the API definition.
(That previous PR was to remove them from the JSON data.) The embed
and PEP already ignore these fields in API responses.

## Test Plan

`yarn test`
