### PR TITLE
Change most instances of STATES_PLUS_DC to STATES_AND_TERRITORIES; clean up states endpoint spec

### DIFF
--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
 import { API_IMAGE_SCHEMA } from '../schemas/v1/image';
-import { STATES_PLUS_DC } from './types/states';
+import { STATES_AND_TERRITORIES } from './types/states';
 
 /**
  * An authority is a government agency, utility, or other organization that
@@ -66,7 +66,7 @@ export const SCHEMA = {
   type: 'object',
   propertyNames: {
     type: 'string',
-    enum: STATES_PLUS_DC,
+    enum: STATES_AND_TERRITORIES,
   },
   additionalProperties: {
     type: 'object',
@@ -88,7 +88,7 @@ export type AuthoritiesByState = FromSchema<typeof SCHEMA>;
 
 export const AUTHORITIES_BY_STATE: AuthoritiesByState = (() => {
   const result: AuthoritiesByState = {};
-  for (const state of STATES_PLUS_DC) {
+  for (const state of STATES_AND_TERRITORIES) {
     const filepath = `./data/${state}/authorities.json`;
     if (fs.existsSync(filepath)) {
       result[state] = JSON.parse(fs.readFileSync(filepath, 'utf-8'));

--- a/src/data/data_partners.ts
+++ b/src/data/data_partners.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
 import { API_IMAGE_SCHEMA } from '../schemas/v1/image';
-import { STATES_PLUS_DC } from './types/states';
+import { STATES_AND_TERRITORIES } from './types/states';
 
 /**
  * A data partner is a partner organization that has helped gather
@@ -36,7 +36,7 @@ export const SCHEMA = {
   type: 'object',
   propertyNames: {
     type: 'string',
-    enum: STATES_PLUS_DC,
+    enum: STATES_AND_TERRITORIES,
   },
   additionalProperties: dataPartnerMapSchema,
   required: [],

--- a/src/data/geo_groups.ts
+++ b/src/data/geo_groups.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
-import { STATES_PLUS_DC } from './types/states';
+import { STATES_AND_TERRITORIES } from './types/states';
 
 const GEO_GROUP_SCHEMA = {
   type: 'object',
@@ -25,7 +25,7 @@ export const GEO_GROUPS_SCHEMA = {
   type: 'object',
   propertyNames: {
     type: 'string',
-    enum: STATES_PLUS_DC,
+    enum: STATES_AND_TERRITORIES,
   },
   additionalProperties: {
     type: 'object',

--- a/src/data/state_incentive_relationships.ts
+++ b/src/data/state_incentive_relationships.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
-import { STATES_PLUS_DC } from './types/states';
+import { STATES_AND_TERRITORIES } from './types/states';
 
 export const anyOrAllSchema = {
   type: 'array',
@@ -70,7 +70,7 @@ export type IncentiveRelationshipsMap = {
 export const INCENTIVE_RELATIONSHIPS_BY_STATE: IncentiveRelationshipsMap =
   (() => {
     const result: IncentiveRelationshipsMap = {};
-    for (const state of STATES_PLUS_DC) {
+    for (const state of STATES_AND_TERRITORIES) {
       const filepath = `./data/${state}/incentive_relationships.json`;
       if (fs.existsSync(filepath)) {
         result[state] = JSON.parse(fs.readFileSync(filepath, 'utf-8'));

--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -60,6 +60,8 @@ export const TERRITORIES = [
   'AS',
 ] as const;
 
+export const STATES_AND_TERRITORIES = [...STATES_PLUS_DC, ...TERRITORIES];
+
 export const BETA_STATES: string[] = [
   'AZ',
   'CT',

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -2,7 +2,7 @@ import { StateStatus } from '../data/types/state-status';
 import {
   BETA_STATES,
   LAUNCHED_STATES,
-  STATES_PLUS_DC,
+  STATES_AND_TERRITORIES,
 } from '../data/types/states';
 
 export const isStateIncluded = (
@@ -22,5 +22,5 @@ const getStatus = (state: string) => {
 };
 
 export const statesWithStatus = Object.fromEntries(
-  STATES_PLUS_DC.map(state => [state, { status: getStatus(state) }]),
+  STATES_AND_TERRITORIES.map(state => [state, { status: getStatus(state) }]),
 );

--- a/src/schemas/v1/states-endpoint.ts
+++ b/src/schemas/v1/states-endpoint.ts
@@ -1,36 +1,37 @@
 import { StateStatus } from '../../data/types/state-status';
-import { STATES_PLUS_DC } from '../../data/types/states';
 
 export const API_STATES_RESPONSE_SCHEMA = {
   $id: 'APIStatesResponse',
   type: 'object',
-  properties: Object.fromEntries(
-    STATES_PLUS_DC.map(state => [
-      state,
-      {
-        type: 'object',
-        properties: {
-          status: { type: 'string', enum: Object.values(StateStatus) },
-        },
-        required: ['status'],
-        additionalProperties: false,
-      },
-    ]),
-  ),
-  additionalProperties: false,
-};
+  additionalProperties: {
+    type: 'object',
+    properties: {
+      status: { type: 'string', enum: Object.values(StateStatus) },
+    },
+    required: ['status'],
+    additionalProperties: false,
+  },
+} as const;
 
 export const API_STATES_SCHEMA = {
   summary: 'Get state rollout status',
-  description: `For each state (and Washington, DC), return the development \
-status of its state-, utility-, and local-level incentive data. (Note that \
-federal-level incentive data is available regardless of location.)
+  description: `For each state and territory (and Washington, DC), return the \
+development status of its state-, utility-, and local-level incentive data. \
+(Note that federal-level incentive data is available regardless of location.)
 
-\`none\` means that state, local, and utility (SLU) incentives \
-for the state are not in the API at all. \`beta\` means that SLU incentives \
-have not been fully vetted, and will be returned from \`/api/v1/calculator\` \
-only if the \`include_beta_states\` request parameter is true. \`launched\` \
-means that SLU incentives are fully vetted and returned in the API.`,
+The response's keys are two-letter state or territory codes, as [defined by \
+the US Postal Service](https://pe.usps.com/text/pub28/28apb.htm). The response \
+includes all 50 states, Washington DC, and the territories of Puerto Rico, \
+Guam, American Samoa, the US Virgin Islands, and the Northern Mariana Islands.
+
+In each key's value, the possible \`status\` properties are:
+
+- \`none\`: state, local, and utility (SLU) incentives for the state are not \
+in the API at all.
+- \`beta\`: SLU incentives have not been fully vetted, and will be returned \
+from \`/api/v1/calculator\` only if the \`include_beta_states\` request \
+parameter is true.
+- \`launched\`: SLU incentives are fully vetted and returned in the API.`,
   operationId: 'getStateStatus',
   response: {
     200: {

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -6,7 +6,7 @@ import { StateStatus } from '../../src/data/types/state-status';
 import {
   BETA_STATES,
   LAUNCHED_STATES,
-  STATES_PLUS_DC,
+  STATES_AND_TERRITORIES,
 } from '../../src/data/types/states';
 import { API_CALCULATOR_RESPONSE_SCHEMA } from '../../src/schemas/v1/calculator-endpoint';
 import { API_INCENTIVE_SCHEMA } from '../../src/schemas/v1/incentive';
@@ -838,7 +838,7 @@ test('/states', async t => {
     t.strictSame(statesResponse[state].status, StateStatus.Beta);
   });
 
-  STATES_PLUS_DC.filter(
+  STATES_AND_TERRITORIES.filter(
     state => !LAUNCHED_STATES.includes(state) && !BETA_STATES.includes(state),
   ).forEach(state => {
     t.strictSame(statesResponse[state].status, StateStatus.None);


### PR DESCRIPTION
## Description

At this point we should be treating states, DC, and territories as
equivalent by default. There are a couple of exceptions:

- The territories are listed separately because the tax calculation
  needs to special-case them as zero federal income tax.

- States plus DC are listed separately because two data files
  (ira_state_savings and solar_prices) only have entries for states
  and DC. The former is only relevant for v0, and the latter is only
  used to estimate solar system cost (and the result is not surfaced
  anywhere in our current frontends), so it doesn't seem worth the
  effort to try to fill in the equivalent data for the territories.
  Those are the only uses of `STATES_PLUS_DC` remaining.

While I'm at it, change the `/v1/states` endpoint spec to not list out
all the states explicitly. Instead, explain in the description what
the keys are, and just document the `{ status: "..." }` struct once.

## Test Plan

`yarn test`.
