### PR TITLE
Fix bug with filtering items in IRA incentives

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -68,13 +68,12 @@ function calculateFederalIncentivesAndSavings(
   for (const incentive of IRA_INCENTIVES) {
     let eligible = true;
 
-    // IRA incentives are required to have only one item
-    const item = incentive.items[0];
-
-    // Don't include an incentive at all if the query is filtering by item and
-    // this doesn't match.
-    if (items && !items.includes(item)) {
-      continue;
+    if (items) {
+      if (incentive.items.every(item => !items.includes(item))) {
+        // Don't include an incentive at all if the query is filtering by item
+        // and this incentive's items don't overlap
+        continue;
+      }
     }
 
     if (
@@ -131,12 +130,15 @@ function calculateFederalIncentivesAndSavings(
     // 5) Add the Rooftop Solar Credit amount
     //
     const amount = { ...incentive.amount };
-    if (item === 'rooftop_solar_installation' && !isNaN(solarSystemCost)) {
+    if (
+      incentive.items.includes('rooftop_solar_installation') &&
+      !isNaN(solarSystemCost)
+    ) {
       amount.representative = roundCents(solarSystemCost * amount.number!);
     }
 
     // EV charger credit has some special eligibility rules
-    if (item === 'electric_vehicle_charger') {
+    if (incentive.items.includes('electric_vehicle_charger')) {
       eligible = amiAndEvCreditEligibility.evCreditEligible;
     }
 

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -132,6 +132,30 @@
       "start_date": "2023",
       "end_date": "2032",
       "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
+    },
+    {
+      "payment_methods": [
+        "tax_credit"
+      ],
+      "authority_type": "federal",
+      "program": "Federal Energy Efficient Home Improvement Credit (25C)",
+      "program_url": "https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit",
+      "more_info_url": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
+      "items": [
+        "air_to_water_heat_pump",
+        "ducted_heat_pump",
+        "ductless_heat_pump"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 2000
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2023",
+      "end_date": "2032",
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     }
   ]
 }


### PR DESCRIPTION
## Description

Reported in #525

The assumption that `items` is a singleton for IRA incentives was
broken a while ago. This meant that some IRA incentives were
incorrectly getting filtered out, because only `items[0]` was being
checked for overlap with `request.items`, rather than all of them.

The first-party calculator wasn't affected by this, because it passes
all the items in every query.

## Test Plan

`yarn test`. This case was being exercised by an existing snapshot
test. The bug was introduced in 77d0ff6c7 and I dutifully updated the
snapshot there, but didn't notice the problem.
