### PR TITLE
update incentive_relationship_schema

### DIFF
--- a/src/data/state_incentive_relationships.ts
+++ b/src/data/state_incentive_relationships.ts
@@ -9,7 +9,7 @@ export const anyOrAllSchema = {
 
 export const prerequisiteSchema = {
   $id: 'IncentivePrerequisites',
-  oneOf: [
+  anyOf: [
     { type: 'string' },
     {
       type: 'object',


### PR DESCRIPTION
To make exporting the incentive relationship easier I have added the explicit type of prereq incentive relationship to each property in the prerequisite object. Transforming 
```
  "prerequisites": {
    "CO-541": "CO-455",
    "CO-542": "CO-457"
  }
``` 

to 
```
  "prerequisites": {
    "CO-541": {
      "allof": [
        "CO-455"
      ]
    },
    "CO-542": {
      "allof": [
        "CO-457"
      ]
    }
  },
```

For more examples see: https://github.com/rewiringamerica/api.rewiringamerica.org/pull/531

This change should be backwards compatible with the existing spreadsheet-to-json scripts, but requires relaxing of the incentives relationship schema from `oneOf to anyOf`. 

