### PR TITLE
Add relationships to Clean Heat RI

### DIFF
--- a/data/RI/incentive_relationships.json
+++ b/data/RI/incentive_relationships.json
@@ -1,8 +1,8 @@
 {
   "exclusions": {
-    "RI-43": [
-      "RI-13"
-    ]
+    "RI-34": ["RI-30", "RI-32"],
+    "RI-35": ["RI-33"],
+    "RI-43": ["RI-13"]
   },
   "prerequisites": {
     "RI-32": {

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -49,29 +49,6 @@
       ],
       "authority_type": "state",
       "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
-      "program_url": "https://cleanheatri.com/",
-      "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollars_per_unit",
-        "number": 1000,
-        "maximum": 10000,
-        "unit": "ton"
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE EV",
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "items": [

--- a/test/snapshots/v1-02903-state-utility-lowincome.json
+++ b/test/snapshots/v1-02903-state-utility-lowincome.json
@@ -149,29 +149,6 @@
         "rebate"
       ],
       "authority_type": "state",
-      "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
-      "program_url": "https://cleanheatri.com/",
-      "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollars_per_unit",
-        "number": 1000,
-        "maximum": 10000,
-        "unit": "ton"
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "Up to $10,000 for installation of an air source heat pump, depending on size. Typical heat pump installations will receive $2,500-$3,000."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
       "authority": "ri-commerce-corp",
       "program": "Rhode Island Commerce Corp. Small-Scale Solar Program",
       "program_url": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf",
@@ -308,27 +285,6 @@
       ],
       "authority_type": "state",
       "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
-      "program_url": "https://cleanheatri.com/",
-      "items": [
-        "heat_pump_water_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1500,
-        "maximum": 1500
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "$750 rebate after the installation of a heat pump water heater. $1,500 for split system heat pump water heaters."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "ri-oer",
       "program": "RI Office of Energy Resources DRIVE EV",
       "program_url": "https://drive.ri.gov/ev-programs/drive-ev",
       "items": [
@@ -367,26 +323,6 @@
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
       "short_description": "Up to $600 back on a qualifying electric heat pump water heater when replacing an existing electric water heater or installing in a new home."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "ri-oer",
-      "program": "RI Office of Energy Resources Clean Heat RI",
-      "program_url": "https://cleanheatri.com/",
-      "items": [
-        "other"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 500
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "Additional $500 for an electrical service upgrade at the same time as installation of a heat pump or heat pump water heater."
     },
     {
       "payment_methods": [


### PR DESCRIPTION
## Description

This is a longstanding ticket that we somehow just never got around
to: having the income-qualified Clean Heat RI incentives exclude the
non-qualified ones.

34 (income-qualified ASHP + electrical upgrade) excludes 30
(non-qualified ASHP) and 32 (non-qualified electrical upgrade).

35 (income-qualified HPWH) excludes 33 (non-qualified HPWH).

RI-31 is a GSHP incentive which has no income-qualified equivalent, so
it's not excluded here.

https://app.asana.com/0/1206661332626418/1206661619324817

## Test Plan

`yarn test`. Snapshot tests cover this case. Query the API with a RI
zip code and low income; make sure the non-income-qualified versions
aren't returned.
