### PR TITLE
Remove "ducted" from GMP heat pump rebate

### DIFF
--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -230,8 +230,8 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Income-eligible GMP customers qualify for a $2,200 bonus rebate on a ducted heat pump.",
-      "es": "Los clientes de GMP que cumplen con el nivel de ingresos tienen derecho a un reembolso de $2,200 para una bomba de calor con ductos."
+      "en": "Income-eligible GMP customers qualify for a $2,200 bonus rebate on a heat pump.",
+      "es": "Los clientes de GMP que cumplen con el nivel de ingresos tienen derecho a un reembolso de $2,200 para una bomba de calor."
     },
     "low_income": "vt-default"
   },


### PR DESCRIPTION
## Description

I think it should never have been in there? The rebate has always been
for both ducted and ductless AFAIK.

## Test Plan

yarn test
