### PR TITLE
Clarify how to pass "items"; allow comma-separated values

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import { API_INCENTIVE_SCHEMA } from './schemas/v1/incentive';
 // These are the options described here:
 // https://fastify.dev/docs/latest/Reference/Server
 export const options = {
-  querystringParser: (str: string) => qs.parse(str, { allowDots: true }),
+  querystringParser: (str: string) => qs.parse(str, { comma: true }),
   disableRequestLogging: true,
 };
 

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -44,7 +44,13 @@ absent, no incentives offered by utilities will be returned.`,
     items: {
       type: 'array',
       description: `Which types of product or service to fetch incentives for. \
-If absent, include incentives for all products and services.`,
+If absent, include incentives for all products and services. Pass multiple \
+values either comma-separated \
+(\`items=new_electric_vehicle,used_electric_vehicle\`), or as the same GET \
+parameter multiple times \
+(\`items=new_electric_vehicle&items=used_electric_vehicle\`), or using empty \
+square bracket notation \
+(\`items[]=new_electric_vehicle&items[]=used_electric_vehicle\`).`,
       items: {
         type: 'string',
         enum: ALL_ITEMS,


### PR DESCRIPTION
## Description

We've seen some confusion from API clients about how to pass multiple
values to this param, so clarify it in the param docs, and add the
ability to pass comma-separated values.

Removing `allowDots` from the qs config is OK because there are no
nested objects in query parameters anymore (since we flattened v1's
`location` parameter).

Will follow up by syncing the spec into Zuplo to publish the docs.

## Test Plan

Curl `http://localhost:3000/api/v1/calculator` with the usual required
params, plus each of these:

- `?items=new_electric_vehicle&items=used_electric_vehicle`
- `?items[]=new_electric_vehicle&items[]=used_electric_vehicle`
- `?items=new_electric_vehicle,used_electric_vehicle`

Look in the server logs to make sure they were all parsed correctly
into a two-item array of items.

(Also it turns out `qs` lets you mix and match these styles, but I
don't think it's worth explaining that, or even saying we support it.)
