### PR TITLE
New low-income threshold type for AMI percentage; use in WI

### DIFF
--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1864,7 +1864,9 @@
         "WI-30"
       ],
       "source_url": "https://focusonenergy.com/income-qualified",
-      "percentage": 80
+      "thresholds": {
+        "percentage": 80
+      }
     }
   }
 }

--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1857,23 +1857,14 @@
   },
   "WI": {
     "wi-focus-on-energy": {
-      "type": "hhsize",
+      "type": "ami-percentage",
       "incentives": [
         "WI-26",
         "WI-28",
         "WI-30"
       ],
       "source_url": "https://focusonenergy.com/income-qualified",
-      "thresholds": {
-        "1": 66300,
-        "2": 75750,
-        "3": 85200,
-        "4": 94650,
-        "5": 102250,
-        "6": 109800,
-        "7": 117400,
-        "8": 124950
-      }
+      "percentage": 80
     }
   }
 }

--- a/src/data/low_income_thresholds.ts
+++ b/src/data/low_income_thresholds.ts
@@ -119,6 +119,19 @@ export const AUTHORITY_INFO_SCHEMA = {
       },
       required: ['type', 'thresholds'],
     },
+    {
+      properties: {
+        type: {
+          type: 'string',
+          const: 'ami-percentage',
+        },
+        percentage: {
+          type: 'number',
+          enum: [80, 150],
+        },
+      },
+      required: ['type', 'percentage'],
+    },
   ],
 } as const;
 

--- a/src/data/low_income_thresholds.ts
+++ b/src/data/low_income_thresholds.ts
@@ -125,12 +125,19 @@ export const AUTHORITY_INFO_SCHEMA = {
           type: 'string',
           const: 'ami-percentage',
         },
-        percentage: {
-          type: 'number',
-          enum: [80, 150],
+        thresholds: {
+          type: 'object',
+          properties: {
+            percentage: {
+              type: 'number',
+              enum: [80, 150],
+            },
+          },
+          required: ['percentage'],
+          additionalProperties: false,
         },
       },
-      required: ['type', 'percentage'],
+      required: ['type', 'thresholds'],
     },
   ],
 } as const;

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -320,6 +320,7 @@ export default function calculateIncentives(
       allStateIncentives,
       stateIncentiveRelationships,
       stateAuthorities,
+      amiAndEvCreditEligibility,
     );
     incentives.push(...state.stateIncentives);
     savings = addSavings(savings, state.savings);

--- a/src/lib/low-income.ts
+++ b/src/lib/low-income.ts
@@ -35,7 +35,7 @@ export function isLowIncome(
     const [min, max] = thresholds.thresholds[tax_filing];
     return household_income >= min && household_income <= max;
   } else if (thresholds.type === 'ami-percentage') {
-    const percentage = thresholds.percentage;
+    const percentage: 80 | 150 = thresholds.thresholds.percentage;
     const threshold =
       percentage === 80
         ? amiAndEvCreditEligibility.computedAMI80

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -15,6 +15,7 @@ import { AmountType } from '../data/types/amount';
 import { APICoverage } from '../data/types/coverage';
 import { OwnerStatus } from '../data/types/owner-status';
 import { APISavings, zeroSavings } from '../schemas/v1/savings';
+import { AMIAndEVCreditEligibility } from './ami-evcredit-calculation';
 import {
   CombinedValue,
   RelationshipMaps,
@@ -63,6 +64,7 @@ export function calculateStateIncentivesAndSavings(
   incentives: StateIncentive[],
   incentiveRelationships: IncentiveRelationships,
   stateAuthorities: AuthoritiesByType,
+  amiAndEvCreditEligibility: AMIAndEVCreditEligibility,
 ): {
   stateIncentives: CalculatedIncentive[];
   savings: APISavings;
@@ -101,7 +103,9 @@ export function calculateStateIncentivesAndSavings(
         // The incentive is income-qualified but we don't know the thresholds;
         // be conservative and exclude it.
         eligible = false;
-      } else if (!isLowIncome(request, thresholds, location)) {
+      } else if (
+        !isLowIncome(request, thresholds, location, amiAndEvCreditEligibility)
+      ) {
         eligible = false;
       }
     }

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -22,6 +22,12 @@ const LOCATION: ResolvedLocation = {
   countyFips: '44007',
 };
 
+const AMIS = {
+  computedAMI80: 89900,
+  computedAMI150: 168600,
+  evCreditEligible: false,
+};
+
 // This is a basic test to set up supplying test data to the calculator logic.
 // This checks incentive eligibility with no relationship logic included.
 test('basic test for supplying test incentive data to calculation logic', async t => {
@@ -39,6 +45,7 @@ test('basic test for supplying test incentive data to calculation logic', async 
     TEST_INCENTIVES,
     {},
     {},
+    AMIS,
   );
   t.ok(data);
   // This user is eligible for all of the incentives.
@@ -64,6 +71,7 @@ test('test calculation with no incentives', async t => {
     [],
     TEST_INCENTIVE_RELATIONSHIPS,
     {},
+    AMIS,
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 0);
@@ -93,6 +101,7 @@ test('test incentive relationship logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS,
     {},
+    AMIS,
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
@@ -130,6 +139,7 @@ test('test more complex incentive relationship logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_2,
     {},
+    AMIS,
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
@@ -170,6 +180,7 @@ test('test incentive relationship and combined max value logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
     {},
+    AMIS,
   );
   t.ok(data);
   t.equal(data.stateIncentives.length, 6);
@@ -212,6 +223,7 @@ test('test incentive relationship and permanent ineligibility criteria', async t
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
     {},
+    AMIS,
   );
 
   t.ok(data);
@@ -252,6 +264,7 @@ test('test nested incentive relationship logic', async t => {
     TEST_INCENTIVES,
     TEST_NESTED_INCENTIVE_RELATIONSHIPS,
     {},
+    AMIS,
   );
   t.ok(data);
   for (const incentive of data.stateIncentives) {
@@ -282,6 +295,7 @@ test('test combined maximum savings logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
     {},
+    AMIS,
   );
   t.ok(data);
   // Check that the user is eligible for B, E, and F.

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -554,6 +554,7 @@ test('correct filtering of county incentives', async t => {
     [incentive],
     {},
     authorities,
+    { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldFind);
   t.equal(shouldFind.stateIncentives.length, 1);
@@ -564,6 +565,7 @@ test('correct filtering of county incentives', async t => {
     [incentive],
     {},
     authorities,
+    { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldNotFind);
   t.equal(shouldNotFind.stateIncentives.length, 0);
@@ -617,6 +619,7 @@ test('correct filtering of city incentives', async t => {
     [incentive],
     {},
     authorities,
+    { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldFind);
   t.equal(shouldFind.stateIncentives.length, 1);
@@ -627,6 +630,7 @@ test('correct filtering of city incentives', async t => {
     [incentive],
     {},
     authorities,
+    { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldNotFindWithPartialMatch);
   t.equal(shouldNotFindWithPartialMatch.stateIncentives.length, 0);
@@ -686,6 +690,7 @@ test('correctly evaluates savings when state tax liability is lower than max sav
     [incentive],
     {},
     authorities,
+    { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
 
   t.ok(result);

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -513,6 +513,31 @@ test('WI low income response with state and utility filtering is valid and corre
   );
 });
 
+test('WI low income threshold', async t => {
+  // AMI for hhsize = 1 here is $48,500.
+  const baseQuery = {
+    zip: '53910',
+    owner_status: 'homeowner',
+    household_size: 1,
+    tax_filing: 'single',
+    authority_types: ['utility', 'other'],
+    utility: 'wi-adams-columbia-electric-cooperative',
+    items: ['air_sealing'],
+    // TODO: Remove when WI is fully launched.
+    include_beta_states: true,
+  };
+  await validateResponse(
+    t,
+    { ...baseQuery, household_income: 48000 },
+    './test/snapshots/v1-wi-53910-lowincome.json',
+  );
+  await validateResponse(
+    t,
+    { ...baseQuery, household_income: 50000 },
+    './test/snapshots/v1-wi-53910-not-lowincome.json',
+  );
+});
+
 const BAD_QUERIES = [
   // bad location:
   {

--- a/test/snapshots/v1-wi-53910-lowincome.json
+++ b/test/snapshots/v1-wi-53910-lowincome.json
@@ -1,0 +1,68 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "wi-focus-on-energy": {
+      "name": "Focus On Energy"
+    }
+  },
+  "coverage": {
+    "state": "WI",
+    "utility": "wi-adams-columbia-electric-cooperative"
+  },
+  "location": {
+    "state": "WI",
+    "city": "Adams"
+  },
+  "data_partners": {},
+  "incentives": [
+    {
+      "payment_methods": [
+        "pos_rebate"
+      ],
+      "authority_type": "other",
+      "authority": "wi-focus-on-energy",
+      "program": "Insulation & Air Sealing Rebates",
+      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
+      "items": [
+        "air_sealing"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1125
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-05-31",
+      "short_description": "Up to $1,125 rebate for ENERGY STAR® Qualified Air Sealing, assessment required. For income-qualified customers."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "other",
+      "authority": "wi-focus-on-energy",
+      "program": "DIY Insulation & Air Sealing Rebates",
+      "program_url": "https://focusonenergy.com/residential/diy",
+      "items": [
+        "attic_or_roof_insulation",
+        "air_sealing"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 200
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "short_description": "$200 rebate for DIY attic insulation and air sealing, must meet R42 insulation level."
+    }
+  ]
+}

--- a/test/snapshots/v1-wi-53910-not-lowincome.json
+++ b/test/snapshots/v1-wi-53910-not-lowincome.json
@@ -1,0 +1,68 @@
+{
+  "is_under_80_ami": false,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {
+    "wi-focus-on-energy": {
+      "name": "Focus On Energy"
+    }
+  },
+  "coverage": {
+    "state": "WI",
+    "utility": "wi-adams-columbia-electric-cooperative"
+  },
+  "location": {
+    "state": "WI",
+    "city": "Adams"
+  },
+  "data_partners": {},
+  "incentives": [
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "other",
+      "authority": "wi-focus-on-energy",
+      "program": "Insulation & Air Sealing Rebates",
+      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
+      "items": [
+        "air_sealing"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 675
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-05-31",
+      "short_description": "Up to $675 rebate for ENERGY STAR® Qualified Air Sealing, assessment required."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "other",
+      "authority": "wi-focus-on-energy",
+      "program": "DIY Insulation & Air Sealing Rebates",
+      "program_url": "https://focusonenergy.com/residential/diy",
+      "items": [
+        "attic_or_roof_insulation",
+        "air_sealing"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 200
+      },
+      "owner_status": [
+        "homeowner",
+        "renter"
+      ],
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "short_description": "$200 rebate for DIY attic insulation and air sealing, must meet R42 insulation level."
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Focus on Energy's income-qualified incentives are now based on AMI,
rather than per-state thresholds like last year. Fortunately, we
already have up-to-date AMI data at hand, so just plumb it in to the
low-income calculation.

I confirmed that the numbers on their site match the numbers in our
AMI database in a few randomly selected counties.

## Test Plan

`yarn test` with new snapshot test (which fails on the old income thresholds).
