### PR TITLE
Fix Denver healthy homes titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ scripts/income_limits/config.json
 secrets/
 venv/
 __pycache__/
+.idea/

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -12796,8 +12796,8 @@
     ],
     "program": "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 0
+      "type": "percent",
+      "number": 1
     },
     "owner_status": [
       "homeowner",
@@ -12820,8 +12820,8 @@
     ],
     "program": "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 0
+      "type": "percent",
+      "number": 1
     },
     "owner_status": [
       "homeowner",
@@ -12844,8 +12844,8 @@
     ],
     "program": "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 0
+      "type": "percent",
+      "number": 1
     },
     "owner_status": [
       "homeowner",
@@ -12868,8 +12868,8 @@
     ],
     "program": "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 0
+      "type": "percent",
+      "number": 1
     },
     "owner_status": [
       "homeowner",
@@ -12892,8 +12892,8 @@
     ],
     "program": "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 0
+      "type": "percent",
+      "number": 1
     },
     "owner_status": [
       "homeowner",
@@ -12916,8 +12916,8 @@
     ],
     "program": "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram",
     "amount": {
-      "type": "dollar_amount",
-      "number": 0
+      "type": "percent",
+      "number": 1
     },
     "owner_status": [
       "homeowner",


### PR DESCRIPTION
## Description

The titles on the embed for the Denver healthy homes incentives was set to "$0 off an electric/induction stove". I updated the sheet to a 100% discount to instead show "100% of cost of an electric/induction stove".

## Test

* `yarn test`
* Tested changes with local embed instance