### PR TITLE
Remove expired State of Arizona rooftop solar incentive

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -795,29 +795,6 @@
     }
   },
   {
-    "id": "AZ-41",
-    "authority_type": "state",
-    "authority": "az-state-of-arizona",
-    "payment_methods": [
-      "tax_credit"
-    ],
-    "items": [
-      "rooftop_solar_installation"
-    ],
-    "program": "az_stateOfArizona_creditForSolarEnergyDevices",
-    "amount": {
-      "type": "percent",
-      "number": 0.25,
-      "maximum": 1000
-    },
-    "owner_status": [
-      "homeowner"
-    ],
-    "short_description": {
-      "en": "Tax credit for up to 25% of the cost of a residential solar system, up to $1,000."
-    }
-  },
-  {
     "id": "AZ-42",
     "authority_type": "utility",
     "authority": "az-columbus-electric-cooperative",

--- a/test/snapshots/v1-az-85701-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85701-state-utility-lowincome.json
@@ -5,9 +5,6 @@
   "authorities": {
     "az-tucson-electric-power": {
       "name": "Tucson Electric Power"
-    },
-    "az-state-of-arizona": {
-      "name": "State of Arizona"
     }
   },
   "coverage": {
@@ -187,27 +184,6 @@
         "homeowner"
       ],
       "short_description": "Up to $35 rebate for qualified smart thermostat."
-    },
-    {
-      "payment_methods": [
-        "tax_credit"
-      ],
-      "authority_type": "state",
-      "authority": "az-state-of-arizona",
-      "program": "Credit for Solar Energy Devices",
-      "program_url": "https://azdor.gov/forms/tax-credits-forms/credit-solar-energy-devices",
-      "items": [
-        "rooftop_solar_installation"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 0.25,
-        "maximum": 1000
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "Tax credit for up to 25% of the cost of a residential solar system, up to $1,000."
     }
   ]
 }

--- a/test/snapshots/v1-az-85702-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85702-state-utility-lowincome.json
@@ -5,9 +5,6 @@
   "authorities": {
     "az-uni-source-energy-services": {
       "name": "UniSource Energy Services"
-    },
-    "az-state-of-arizona": {
-      "name": "State of Arizona"
     }
   },
   "coverage": {
@@ -123,27 +120,6 @@
         "homeowner"
       ],
       "short_description": "Up to $150 rebate on duct sealing, varies based on actual leakage reduced."
-    },
-    {
-      "payment_methods": [
-        "tax_credit"
-      ],
-      "authority_type": "state",
-      "authority": "az-state-of-arizona",
-      "program": "Credit for Solar Energy Devices",
-      "program_url": "https://azdor.gov/forms/tax-credits-forms/credit-solar-energy-devices",
-      "items": [
-        "rooftop_solar_installation"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 0.25,
-        "maximum": 1000
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "Tax credit for up to 25% of the cost of a residential solar system, up to $1,000."
     }
   ]
 }


### PR DESCRIPTION
"We just confirmed internally and unfortunately ADOR's solar panel credit was not renewed, so it would have to be removed from the result." -AZ Office of Resiliency