### PR TITLE
Add optional "description" fields to a few types

### DIFF
--- a/src/data/geo_groups.ts
+++ b/src/data/geo_groups.ts
@@ -5,6 +5,7 @@ import { STATES_AND_TERRITORIES } from './types/states';
 const GEO_GROUP_SCHEMA = {
   type: 'object',
   properties: {
+    description: { type: 'string' },
     utilities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     cities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     counties: { type: 'array', items: { type: 'string' }, minItems: 1 },

--- a/src/data/low_income_thresholds.ts
+++ b/src/data/low_income_thresholds.ts
@@ -54,6 +54,7 @@ export const RANGE_SCHEMA = {
 export const AUTHORITY_INFO_SCHEMA = {
   type: 'object',
   properties: {
+    description: { type: 'string' },
     source_url: { type: 'string' },
     incentives: {
       type: 'array',

--- a/src/data/state_incentive_relationships.ts
+++ b/src/data/state_incentive_relationships.ts
@@ -2,24 +2,30 @@ import fs from 'fs';
 import { FromSchema } from 'json-schema-to-ts';
 import { STATES_AND_TERRITORIES } from './types/states';
 
-export const anyOrAllSchema = {
-  type: 'array',
-  items: { $ref: 'IncentivePrerequisites' },
-} as const;
-
 export const prerequisiteSchema = {
-  $id: 'IncentivePrerequisites',
   oneOf: [
     { type: 'string' },
     {
       type: 'object',
-      properties: { anyOf: anyOrAllSchema },
+      properties: {
+        anyOf: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        description: { type: 'string' },
+      },
       required: ['anyOf'],
       additionalProperties: false,
     },
     {
       type: 'object',
-      properties: { allOf: anyOrAllSchema },
+      properties: {
+        allOf: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        description: { type: 'string' },
+      },
       required: ['allOf'],
       additionalProperties: false,
     },
@@ -27,8 +33,26 @@ export const prerequisiteSchema = {
 } as const;
 
 const exclusionSchema = {
-  type: 'array',
-  items: { type: 'string' },
+  oneOf: [
+    {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        description: {
+          type: 'string',
+        },
+      },
+      additionalProperties: false,
+      required: ['ids'],
+    },
+  ],
 } as const;
 
 export const INCENTIVE_RELATIONSHIPS_SCHEMA = {
@@ -49,6 +73,7 @@ export const INCENTIVE_RELATIONSHIPS_SCHEMA = {
         properties: {
           ids: { type: 'array', items: { type: 'string' } },
           max_value: { type: 'number' },
+          description: { type: 'string' },
         },
         required: ['ids', 'max_value'],
       },

--- a/src/data/types/program.ts
+++ b/src/data/types/program.ts
@@ -8,6 +8,7 @@ export const PROGRAM_SCHEMA = {
     url: {
       $ref: 'LocalizableString',
     },
+    description: { type: 'string' },
   },
   required: ['name', 'url'],
 } as const;

--- a/src/lib/incentive-relationship-calculation.ts
+++ b/src/lib/incentive-relationship-calculation.ts
@@ -82,9 +82,12 @@ export function buildExclusionMaps(
   const supersedesMap = new Map<string, Set<string>>();
   const supersededByMap = new Map<string, Set<string>>();
   if (incentiveRelationships.exclusions !== undefined) {
-    for (const [incentiveId, supersededIds] of Object.entries(
+    for (const [incentiveId, supersededIdsOrObject] of Object.entries(
       incentiveRelationships.exclusions,
     )) {
+      const supersededIds = Array.isArray(supersededIdsOrObject)
+        ? supersededIdsOrObject
+        : supersededIdsOrObject.ids;
       supersedesMap.set(incentiveId, new Set(supersededIds));
 
       for (const supersededId of supersededIds) {

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -327,13 +327,17 @@ test('state incentive relationships only reference real IDs', async tap => {
           }
         }
         if (data.exclusions !== undefined) {
-          for (const [incentiveId, supersededIds] of Object.entries(
+          for (const [incentiveId, supersededIdsOrObject] of Object.entries(
             data.exclusions,
           )) {
             tap.ok(
               incentivesForState.has(incentiveId),
               `ID ${incentiveId} (in exclusions map) does not exist`,
             );
+
+            const supersededIds = Array.isArray(supersededIdsOrObject)
+              ? supersededIdsOrObject
+              : supersededIdsOrObject.ids;
             for (const id of supersededIds) {
               tap.ok(
                 incentivesForState.has(id),


### PR DESCRIPTION
## Description

Since none of the existing prereq relationships uses recursive
anyOf/allOf relationships, and it's super hard to support in a
relational format, I removed support for that. Now prereq
relationships are just `allOf: [list of strings]` or `anyOf: [list of
strings]` or just a single string.

Adding the field to exclusion relationships meant I had to add an
option to expand the list of IDs to an object, with an `ids` key (the
list of IDs) and the description.

## Test Plan

`yarn test`

Import from my local incentive admin with changes applied to export
descriptions in these positions, and make sure tests still pass here.
