### PR TITLE
Move authority and authority_type onto program instead of incentive

### DIFF
--- a/data/AZ/incentives.json
+++ b/data/AZ/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "AZ-2",
-    "authority_type": "utility",
-    "authority": "az-mohave-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -26,8 +24,6 @@
   },
   {
     "id": "AZ-3",
-    "authority_type": "utility",
-    "authority": "az-mohave-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -51,8 +47,6 @@
   },
   {
     "id": "AZ-5",
-    "authority_type": "utility",
-    "authority": "az-mohave-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -76,8 +70,6 @@
   },
   {
     "id": "AZ-6",
-    "authority_type": "utility",
-    "authority": "az-mohave-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -100,8 +92,6 @@
   },
   {
     "id": "AZ-7",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -124,8 +114,6 @@
   },
   {
     "id": "AZ-8",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -147,8 +135,6 @@
   },
   {
     "id": "AZ-9",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -170,8 +156,6 @@
   },
   {
     "id": "AZ-10",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -193,8 +177,6 @@
   },
   {
     "id": "AZ-11",
-    "authority_type": "utility",
-    "authority": "az-sulphur-springs-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -216,8 +198,6 @@
   },
   {
     "id": "AZ-12",
-    "authority_type": "utility",
-    "authority": "az-sulphur-springs-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -239,8 +219,6 @@
   },
   {
     "id": "AZ-13",
-    "authority_type": "utility",
-    "authority": "az-sulphur-springs-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -262,8 +240,6 @@
   },
   {
     "id": "AZ-14",
-    "authority_type": "utility",
-    "authority": "az-sulphur-springs-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -285,8 +261,6 @@
   },
   {
     "id": "AZ-15",
-    "authority_type": "utility",
-    "authority": "az-sulphur-springs-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -308,8 +282,6 @@
   },
   {
     "id": "AZ-17",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -332,8 +304,6 @@
   },
   {
     "id": "AZ-18",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "assistance_program"
     ],
@@ -356,8 +326,6 @@
   },
   {
     "id": "AZ-19",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "rebate"
     ],
@@ -381,8 +349,6 @@
   },
   {
     "id": "AZ-21",
-    "authority_type": "utility",
-    "authority": "az-uni-source-energy-services",
     "payment_methods": [
       "assistance_program"
     ],
@@ -405,8 +371,6 @@
   },
   {
     "id": "AZ-23",
-    "authority_type": "utility",
-    "authority": "az-uni-source-energy-services",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -429,8 +393,6 @@
   },
   {
     "id": "AZ-25",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -452,8 +414,6 @@
   },
   {
     "id": "AZ-26",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "account_credit"
     ],
@@ -475,8 +435,6 @@
   },
   {
     "id": "AZ-27",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -498,8 +456,6 @@
   },
   {
     "id": "AZ-28",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -521,8 +477,6 @@
   },
   {
     "id": "AZ-29",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -544,8 +498,6 @@
   },
   {
     "id": "AZ-30",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -567,8 +519,6 @@
   },
   {
     "id": "AZ-31",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -590,8 +540,6 @@
   },
   {
     "id": "AZ-32",
-    "authority_type": "utility",
-    "authority": "az-salt-river-project",
     "payment_methods": [
       "rebate"
     ],
@@ -612,8 +560,6 @@
   },
   {
     "id": "AZ-33",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -635,8 +581,6 @@
   },
   {
     "id": "AZ-34",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -658,8 +602,6 @@
   },
   {
     "id": "AZ-35",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -681,8 +623,6 @@
   },
   {
     "id": "AZ-36",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -704,8 +644,6 @@
   },
   {
     "id": "AZ-37",
-    "authority_type": "utility",
-    "authority": "az-tucson-electric-power",
     "payment_methods": [
       "rebate"
     ],
@@ -727,8 +665,6 @@
   },
   {
     "id": "AZ-38",
-    "authority_type": "utility",
-    "authority": "az-uni-source-energy-services",
     "payment_methods": [
       "rebate"
     ],
@@ -750,8 +686,6 @@
   },
   {
     "id": "AZ-39",
-    "authority_type": "utility",
-    "authority": "az-uni-source-energy-services",
     "payment_methods": [
       "rebate"
     ],
@@ -773,8 +707,6 @@
   },
   {
     "id": "AZ-40",
-    "authority_type": "utility",
-    "authority": "az-uni-source-energy-services",
     "payment_methods": [
       "rebate"
     ],
@@ -796,8 +728,6 @@
   },
   {
     "id": "AZ-42",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -818,8 +748,6 @@
   },
   {
     "id": "AZ-43",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -842,8 +770,6 @@
   },
   {
     "id": "AZ-44",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -866,8 +792,6 @@
   },
   {
     "id": "AZ-45",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -888,8 +812,6 @@
   },
   {
     "id": "AZ-46",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -911,8 +833,6 @@
   },
   {
     "id": "AZ-47",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -934,8 +854,6 @@
   },
   {
     "id": "AZ-48",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -957,8 +875,6 @@
   },
   {
     "id": "AZ-49",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -980,8 +896,6 @@
   },
   {
     "id": "AZ-50",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1003,8 +917,6 @@
   },
   {
     "id": "AZ-51",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1026,8 +938,6 @@
   },
   {
     "id": "AZ-52",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1048,8 +958,6 @@
   },
   {
     "id": "AZ-53",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1070,8 +978,6 @@
   },
   {
     "id": "AZ-54",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1092,8 +998,6 @@
   },
   {
     "id": "AZ-55",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1116,8 +1020,6 @@
   },
   {
     "id": "AZ-56",
-    "authority_type": "utility",
-    "authority": "az-columbus-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1139,8 +1041,6 @@
   },
   {
     "id": "AZ-57",
-    "authority_type": "utility",
-    "authority": "az-dixie-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1162,8 +1062,6 @@
   },
   {
     "id": "AZ-58",
-    "authority_type": "utility",
-    "authority": "az-dixie-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1185,8 +1083,6 @@
   },
   {
     "id": "AZ-59",
-    "authority_type": "utility",
-    "authority": "az-dixie-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1209,8 +1105,6 @@
   },
   {
     "id": "AZ-60",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1232,8 +1126,6 @@
   },
   {
     "id": "AZ-61",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1255,8 +1147,6 @@
   },
   {
     "id": "AZ-62",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1278,8 +1168,6 @@
   },
   {
     "id": "AZ-63",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "account_credit"
     ],
@@ -1301,8 +1189,6 @@
   },
   {
     "id": "AZ-64",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1324,8 +1210,6 @@
   },
   {
     "id": "AZ-65",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1348,8 +1232,6 @@
   },
   {
     "id": "AZ-66",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1372,8 +1254,6 @@
   },
   {
     "id": "AZ-67",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1394,8 +1274,6 @@
   },
   {
     "id": "AZ-68",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1417,8 +1295,6 @@
   },
   {
     "id": "AZ-69",
-    "authority_type": "utility",
-    "authority": "az-electrical-district-no-3-pinal-county",
     "payment_methods": [
       "rebate"
     ],
@@ -1440,8 +1316,6 @@
   },
   {
     "id": "AZ-70",
-    "authority_type": "utility",
-    "authority": "az-garkane-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1463,8 +1337,6 @@
   },
   {
     "id": "AZ-71",
-    "authority_type": "utility",
-    "authority": "az-garkane-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1485,8 +1357,6 @@
   },
   {
     "id": "AZ-72",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1507,8 +1377,6 @@
   },
   {
     "id": "AZ-73",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "rebate"
     ],
@@ -1529,8 +1397,6 @@
   },
   {
     "id": "AZ-74",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "rebate"
     ],
@@ -1551,8 +1417,6 @@
   },
   {
     "id": "AZ-75",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "rebate"
     ],
@@ -1573,8 +1437,6 @@
   },
   {
     "id": "AZ-76",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "rebate"
     ],
@@ -1595,8 +1457,6 @@
   },
   {
     "id": "AZ-77",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "rebate"
     ],
@@ -1618,8 +1478,6 @@
   },
   {
     "id": "AZ-78",
-    "authority_type": "utility",
-    "authority": "az-arizona-public-service",
     "payment_methods": [
       "rebate"
     ],
@@ -1641,8 +1499,6 @@
   },
   {
     "id": "AZ-79",
-    "authority_type": "state",
-    "authority": "az-wildfire",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1666,8 +1522,6 @@
   },
   {
     "id": "AZ-80",
-    "authority_type": "state",
-    "authority": "az-wildfire",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1691,8 +1545,6 @@
   },
   {
     "id": "AZ-81",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1716,8 +1568,6 @@
   },
   {
     "id": "AZ-82",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1741,8 +1591,6 @@
   },
   {
     "id": "AZ-83",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1767,8 +1615,6 @@
   },
   {
     "id": "AZ-84",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1793,8 +1639,6 @@
   },
   {
     "id": "AZ-85",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1818,8 +1662,6 @@
   },
   {
     "id": "AZ-86",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1843,8 +1685,6 @@
   },
   {
     "id": "AZ-87",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1868,8 +1708,6 @@
   },
   {
     "id": "AZ-88",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1893,8 +1731,6 @@
   },
   {
     "id": "AZ-89",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1918,8 +1754,6 @@
   },
   {
     "id": "AZ-90",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1943,8 +1777,6 @@
   },
   {
     "id": "AZ-91",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1968,8 +1800,6 @@
   },
   {
     "id": "AZ-92",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -1993,8 +1823,6 @@
   },
   {
     "id": "AZ-93",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],
@@ -2018,8 +1846,6 @@
   },
   {
     "id": "AZ-94",
-    "authority_type": "state",
-    "authority": "az-efficiency-arizona",
     "payment_methods": [
       "rebate"
     ],

--- a/data/AZ/programs.json
+++ b/data/AZ/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.aps.com/en/Residential/Save-Money-and-Energy/Your-Energy-Your-Options/Rebates"
-    }
+    },
+    "authority": "az-arizona-public-service",
+    "authority_type": "utility"
   },
   "az_columbusElectricCooperative_applianceAndRecyclingRebates": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.columbusco-op.org/rebates"
-    }
+    },
+    "authority": "az-columbus-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_columbusElectricCooperative_heatPumpRebates": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.columbusco-op.org/rebates"
-    }
+    },
+    "authority": "az-columbus-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_columbusElectricCooperative_incentiveForENERGYSTARRatedSplitSystemAir-Conditioners": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://www.columbusco-op.org/rebates"
-    }
+    },
+    "authority": "az-columbus-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_columbusElectricCooperative_incentiveForEvaporativeCooler": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://www.columbusco-op.org/rebates"
-    }
+    },
+    "authority": "az-columbus-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_columbusElectricCooperative_incentiveForWholeHouseFans": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.columbusco-op.org/rebates"
-    }
+    },
+    "authority": "az-columbus-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_columbusElectricCooperative_outdoorPowerEqupimentElectrificationRebates": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.columbusco-op.org/rebates"
-    }
+    },
+    "authority": "az-columbus-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_dixiePower_heatPumpRebate": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.dixiepower.com/services/rebates/"
-    }
+    },
+    "authority": "az-dixie-power",
+    "authority_type": "utility"
   },
   "az_dixiePower_rebateFor400AmpServices": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://www.dixiepower.com/services/rebates/"
-    }
+    },
+    "authority": "az-dixie-power",
+    "authority_type": "utility"
   },
   "az_dixiePower_smartThermostatRebate": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://www.dixiepower.com/services/rebates/"
-    }
+    },
+    "authority": "az-dixie-power",
+    "authority_type": "utility"
   },
   "az_electricalDistrictNo3PinalCounty_residentialRebates": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://www.ed3online.org/energy-services/residential-rebates"
-    }
+    },
+    "authority": "az-electrical-district-no-3-pinal-county",
+    "authority_type": "utility"
   },
   "az_garkaneEnergyCooperative_energyEfficientRebates": {
     "name": {
@@ -93,23 +115,9 @@
     },
     "url": {
       "en": "https://www.garkaneenergy.com/energy-efficient-rebates"
-    }
-  },
-  "az_mohaveElectricCooperative_mohaveChargedRebates": {
-    "name": {
-      "en": "Mohave Charged Rebates"
     },
-    "url": {
-      "en": "https://www.mohaveelectric.com/energy-solutions/rebates/mohave-charged-rebates/"
-    }
-  },
-  "az_mohaveElectricCooperative_mohaveCommercialLightingRebate": {
-    "name": {
-      "en": "Mohave Commercial Lighting Rebate"
-    },
-    "url": {
-      "en": "https://www.mohaveelectric.com/energy-solutions/rebates/commercial-lighting-rebate/"
-    }
+    "authority": "az-garkane-energy-cooperative",
+    "authority_type": "utility"
   },
   "az_mohaveElectricCooperative_mohaveHeatBatteryRebate": {
     "name": {
@@ -117,7 +125,9 @@
     },
     "url": {
       "en": "https://www.mohaveelectric.com/energy-solutions/rebates/mohave-charged-rebates/"
-    }
+    },
+    "authority": "az-mohave-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_mohaveElectricCooperative_mohaveHeatPumpRebate": {
     "name": {
@@ -125,7 +135,9 @@
     },
     "url": {
       "en": "https://www.mohaveelectric.com/energy-solutions/rebates/heat-pump-rebate/"
-    }
+    },
+    "authority": "az-mohave-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_mohaveElectricCooperative_sunWattsRenewableEnergyAndRebateProgram": {
     "name": {
@@ -133,7 +145,9 @@
     },
     "url": {
       "en": "https://www.mohaveelectric.com/energy-solutions/renewable-energy/sunwatts-renewable-energy-program/"
-    }
+    },
+    "authority": "az-mohave-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_air-ConditioningRebate": {
     "name": {
@@ -141,7 +155,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/air-conditioner"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_demandManagementSystemRebate": {
     "name": {
@@ -149,7 +165,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/demand-management-solar"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_ductTestAndRepairRebate": {
     "name": {
@@ -157,7 +175,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/duct-test-repair"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_heatPumpWaterHeaterRebate": {
     "name": {
@@ -165,7 +185,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/heat-pump-water-heater"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_homeElectricVehicleChargerRebate": {
     "name": {
@@ -173,7 +195,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/ev-charger"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_homeEnergyAudit": {
     "name": {
@@ -181,7 +205,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/home-energy-savings-audit"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_insulationRebate": {
     "name": {
@@ -189,7 +215,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/insulation"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_shadeScreenAndWindowFilmRebate": {
     "name": {
@@ -197,7 +225,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/shade-screen"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_smartThermostatRebates": {
     "name": {
@@ -205,7 +235,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/smart-thermostat"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_sRPCoolRoofRebate": {
     "name": {
@@ -213,7 +245,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/cool-roof"
-    }
+    },
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_saltRiverProject_windowReplacementRebate": {
     "name": {
@@ -221,15 +255,9 @@
     },
     "url": {
       "en": "https://www.srpnet.com/energy-savings-rebates/home/rebates/window-replacement"
-    }
-  },
-  "az_stateOfArizona_creditForSolarEnergyDevices": {
-    "name": {
-      "en": "Credit for Solar Energy Devices"
     },
-    "url": {
-      "en": "https://azdor.gov/forms/tax-credits-forms/credit-solar-energy-devices"
-    }
+    "authority": "az-salt-river-project",
+    "authority_type": "utility"
   },
   "az_sulphurSpringsValleyElectricCooperative_heatPumpRebates": {
     "name": {
@@ -237,7 +265,9 @@
     },
     "url": {
       "en": "https://www.ssvec.org/programs/rebates.php"
-    }
+    },
+    "authority": "az-sulphur-springs-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_sulphurSpringsValleyElectricCooperative_hotWaterHeaterRebate": {
     "name": {
@@ -245,7 +275,9 @@
     },
     "url": {
       "en": "https://www.ssvec.org/programs/rebates.php"
-    }
+    },
+    "authority": "az-sulphur-springs-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "az_tucsonElectricPower_efficientHomeProgram": {
     "name": {
@@ -253,7 +285,9 @@
     },
     "url": {
       "en": "https://www.tep.com/efficient-home-program/"
-    }
+    },
+    "authority": "az-tucson-electric-power",
+    "authority_type": "utility"
   },
   "az_tucsonElectricPower_efficientHomeWaterHeating": {
     "name": {
@@ -261,15 +295,9 @@
     },
     "url": {
       "en": "https://www.tep.com/efficient-home-water-heating/"
-    }
-  },
-  "az_tucsonElectricPower_eVChargerRebates": {
-    "name": {
-      "en": "EV Charger Rebates"
     },
-    "url": {
-      "en": "https://www.tep.com/electric-vehicles/#/find/nearest?fuel=ELEC&location=tucson,%20az&ev_levels=all"
-    }
+    "authority": "az-tucson-electric-power",
+    "authority_type": "utility"
   },
   "az_tucsonElectricPower_smartThermostatRebate": {
     "name": {
@@ -277,7 +305,9 @@
     },
     "url": {
       "en": "https://www.tep.com/smart-thermostat-rebate/"
-    }
+    },
+    "authority": "az-tucson-electric-power",
+    "authority_type": "utility"
   },
   "az_tucsonElectricPower_weatherizationAssistance": {
     "name": {
@@ -285,7 +315,9 @@
     },
     "url": {
       "en": "https://www.tep.com/weatherization-assistance/"
-    }
+    },
+    "authority": "az-tucson-electric-power",
+    "authority_type": "utility"
   },
   "az_uniSourceEnergyServices_efficientHomeProgram": {
     "name": {
@@ -293,7 +325,9 @@
     },
     "url": {
       "en": "https://www.uesaz.com/efficient-home-program/"
-    }
+    },
+    "authority": "az-uni-source-energy-services",
+    "authority_type": "utility"
   },
   "az_uniSourceEnergyServices_weatherizationAssistance": {
     "name": {
@@ -301,7 +335,9 @@
     },
     "url": {
       "en": "https://www.uesaz.com/weatherization-assistance/"
-    }
+    },
+    "authority": "az-uni-source-energy-services",
+    "authority_type": "utility"
   },
   "az_wildfire_hEARProgram": {
     "name": {
@@ -309,7 +345,9 @@
     },
     "url": {
       "en": "https://efficiencyarizona.com/"
-    }
+    },
+    "authority": "az-wildfire",
+    "authority_type": "state"
   },
   "az_efficiencyArizona_hEARProgram": {
     "name": {
@@ -317,6 +355,8 @@
     },
     "url": {
       "en": "https://efficiencyarizona.com/"
-    }
+    },
+    "authority": "az-efficiency-arizona",
+    "authority_type": "state"
   }
 }

--- a/data/CO/incentives.json
+++ b/data/CO/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "CO-1",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -27,8 +25,6 @@
   },
   {
     "id": "CO-2",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -54,8 +50,6 @@
   },
   {
     "id": "CO-3",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -81,8 +75,6 @@
   },
   {
     "id": "CO-4",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -108,8 +100,6 @@
   },
   {
     "id": "CO-5",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -135,8 +125,6 @@
   },
   {
     "id": "CO-6",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -162,8 +150,6 @@
   },
   {
     "id": "CO-7",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -188,8 +174,6 @@
   },
   {
     "id": "CO-8",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -214,8 +198,6 @@
   },
   {
     "id": "CO-9",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -240,8 +222,6 @@
   },
   {
     "id": "CO-10",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -268,8 +248,6 @@
   },
   {
     "id": "CO-11",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -296,8 +274,6 @@
   },
   {
     "id": "CO-12",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -324,8 +300,6 @@
   },
   {
     "id": "CO-13",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -352,8 +326,6 @@
   },
   {
     "id": "CO-14",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -380,8 +352,6 @@
   },
   {
     "id": "CO-15",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -408,8 +378,6 @@
   },
   {
     "id": "CO-16",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -434,8 +402,6 @@
   },
   {
     "id": "CO-17",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -462,8 +428,6 @@
   },
   {
     "id": "CO-18",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -490,8 +454,6 @@
   },
   {
     "id": "CO-19",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -518,8 +480,6 @@
   },
   {
     "id": "CO-20",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -544,8 +504,6 @@
   },
   {
     "id": "CO-21",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -570,8 +528,6 @@
   },
   {
     "id": "CO-22",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -596,8 +552,6 @@
   },
   {
     "id": "CO-23",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -622,8 +576,6 @@
   },
   {
     "id": "CO-24",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -649,8 +601,6 @@
   },
   {
     "id": "CO-25",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -677,8 +627,6 @@
   },
   {
     "id": "CO-26",
-    "authority_type": "utility",
-    "authority": "co-black-hills-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -705,8 +653,6 @@
   },
   {
     "id": "CO-27",
-    "authority_type": "utility",
-    "authority": "co-colorado-springs-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -731,8 +677,6 @@
   },
   {
     "id": "CO-28",
-    "authority_type": "utility",
-    "authority": "co-colorado-springs-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -758,8 +702,6 @@
   },
   {
     "id": "CO-29",
-    "authority_type": "utility",
-    "authority": "co-colorado-springs-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -785,8 +727,6 @@
   },
   {
     "id": "CO-30",
-    "authority_type": "utility",
-    "authority": "co-colorado-springs-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -811,8 +751,6 @@
   },
   {
     "id": "CO-545",
-    "authority_type": "utility",
-    "authority": "co-colorado-springs-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -837,8 +775,6 @@
   },
   {
     "id": "CO-31",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -863,8 +799,6 @@
   },
   {
     "id": "CO-32",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -889,8 +823,6 @@
   },
   {
     "id": "CO-33",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -914,8 +846,6 @@
   },
   {
     "id": "CO-34",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -939,8 +869,6 @@
   },
   {
     "id": "CO-35",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -964,8 +892,6 @@
   },
   {
     "id": "CO-36",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -989,8 +915,6 @@
   },
   {
     "id": "CO-37",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1014,8 +938,6 @@
   },
   {
     "id": "CO-38",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1039,8 +961,6 @@
   },
   {
     "id": "CO-39",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1064,8 +984,6 @@
   },
   {
     "id": "CO-40",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1089,8 +1007,6 @@
   },
   {
     "id": "CO-41",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1114,8 +1030,6 @@
   },
   {
     "id": "CO-42",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1139,8 +1053,6 @@
   },
   {
     "id": "CO-43",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1164,8 +1076,6 @@
   },
   {
     "id": "CO-44",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1189,8 +1099,6 @@
   },
   {
     "id": "CO-45",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1214,8 +1122,6 @@
   },
   {
     "id": "CO-46",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1240,8 +1146,6 @@
   },
   {
     "id": "CO-47",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1266,8 +1170,6 @@
   },
   {
     "id": "CO-48",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1291,8 +1193,6 @@
   },
   {
     "id": "CO-81",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1319,8 +1219,6 @@
   },
   {
     "id": "CO-82",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1346,8 +1244,6 @@
   },
   {
     "id": "CO-83",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1373,8 +1269,6 @@
   },
   {
     "id": "CO-84",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1401,8 +1295,6 @@
   },
   {
     "id": "CO-86",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1429,8 +1321,6 @@
   },
   {
     "id": "CO-87",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1456,8 +1346,6 @@
   },
   {
     "id": "CO-88",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1484,8 +1372,6 @@
   },
   {
     "id": "CO-552",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1512,8 +1398,6 @@
   },
   {
     "id": "CO-557",
-    "authority_type": "other",
-    "authority": "co-platte-river-power-authority",
     "eligible_geo_group": "co-group-platte-river-power-authority",
     "payment_methods": [
       "rebate"
@@ -1540,8 +1424,6 @@
   },
   {
     "id": "CO-89",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1565,8 +1447,6 @@
   },
   {
     "id": "CO-90",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1590,8 +1470,6 @@
   },
   {
     "id": "CO-91",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1613,8 +1491,6 @@
   },
   {
     "id": "CO-92",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1638,8 +1514,6 @@
   },
   {
     "id": "CO-93",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1663,8 +1537,6 @@
   },
   {
     "id": "CO-94",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1688,8 +1560,6 @@
   },
   {
     "id": "CO-95",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1713,8 +1583,6 @@
   },
   {
     "id": "CO-96",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1738,8 +1606,6 @@
   },
   {
     "id": "CO-97",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1763,8 +1629,6 @@
   },
   {
     "id": "CO-98",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1788,8 +1652,6 @@
   },
   {
     "id": "CO-99",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1812,8 +1674,6 @@
   },
   {
     "id": "CO-100",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1838,8 +1698,6 @@
   },
   {
     "id": "CO-101",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1864,8 +1722,6 @@
   },
   {
     "id": "CO-102",
-    "authority_type": "utility",
-    "authority": "co-empire-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1889,8 +1745,6 @@
   },
   {
     "id": "CO-103",
-    "authority_type": "state",
-    "authority": "co-energy-outreach-colorado",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1914,8 +1768,6 @@
   },
   {
     "id": "CO-104",
-    "authority_type": "utility",
-    "authority": "co-fort-collins-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -1939,8 +1791,6 @@
   },
   {
     "id": "CO-105",
-    "authority_type": "utility",
-    "authority": "co-fort-collins-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -1964,8 +1814,6 @@
   },
   {
     "id": "CO-106",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -1987,8 +1835,6 @@
   },
   {
     "id": "CO-107",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2010,8 +1856,6 @@
   },
   {
     "id": "CO-108",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2033,8 +1877,6 @@
   },
   {
     "id": "CO-109",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2057,8 +1899,6 @@
   },
   {
     "id": "CO-110",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2082,8 +1922,6 @@
   },
   {
     "id": "CO-111",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2107,8 +1945,6 @@
   },
   {
     "id": "CO-112",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2132,8 +1968,6 @@
   },
   {
     "id": "CO-113",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2156,8 +1990,6 @@
   },
   {
     "id": "CO-114",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2179,8 +2011,6 @@
   },
   {
     "id": "CO-115",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2202,8 +2032,6 @@
   },
   {
     "id": "CO-116",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2226,8 +2054,6 @@
   },
   {
     "id": "CO-117",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2250,8 +2076,6 @@
   },
   {
     "id": "CO-118",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2274,8 +2098,6 @@
   },
   {
     "id": "CO-119",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2300,8 +2122,6 @@
   },
   {
     "id": "CO-120",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2326,8 +2146,6 @@
   },
   {
     "id": "CO-121",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2352,8 +2170,6 @@
   },
   {
     "id": "CO-122",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2378,8 +2194,6 @@
   },
   {
     "id": "CO-123",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2404,8 +2218,6 @@
   },
   {
     "id": "CO-124",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2429,8 +2241,6 @@
   },
   {
     "id": "CO-125",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2453,8 +2263,6 @@
   },
   {
     "id": "CO-126",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2476,8 +2284,6 @@
   },
   {
     "id": "CO-127",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2502,8 +2308,6 @@
   },
   {
     "id": "CO-128",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2527,8 +2331,6 @@
   },
   {
     "id": "CO-129",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2552,8 +2354,6 @@
   },
   {
     "id": "CO-130",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2577,8 +2377,6 @@
   },
   {
     "id": "CO-131",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2602,8 +2400,6 @@
   },
   {
     "id": "CO-132",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2627,8 +2423,6 @@
   },
   {
     "id": "CO-133",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2652,8 +2446,6 @@
   },
   {
     "id": "CO-134",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2677,8 +2469,6 @@
   },
   {
     "id": "CO-135",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2702,8 +2492,6 @@
   },
   {
     "id": "CO-136",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2727,8 +2515,6 @@
   },
   {
     "id": "CO-137",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2750,8 +2536,6 @@
   },
   {
     "id": "CO-138",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2772,8 +2556,6 @@
   },
   {
     "id": "CO-139",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2795,8 +2577,6 @@
   },
   {
     "id": "CO-140",
-    "authority_type": "utility",
-    "authority": "co-gunnison-county-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -2818,8 +2598,6 @@
   },
   {
     "id": "CO-141",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2841,8 +2619,6 @@
   },
   {
     "id": "CO-142",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2864,8 +2640,6 @@
   },
   {
     "id": "CO-143",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2887,8 +2661,6 @@
   },
   {
     "id": "CO-144",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2912,8 +2684,6 @@
   },
   {
     "id": "CO-145",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2935,8 +2705,6 @@
   },
   {
     "id": "CO-146",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2958,8 +2726,6 @@
   },
   {
     "id": "CO-147",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -2981,8 +2747,6 @@
   },
   {
     "id": "CO-148",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -3004,8 +2768,6 @@
   },
   {
     "id": "CO-149",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -3029,8 +2791,6 @@
   },
   {
     "id": "CO-150",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -3052,8 +2812,6 @@
   },
   {
     "id": "CO-151",
-    "authority_type": "utility",
-    "authority": "co-holy-cross-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -3077,8 +2835,6 @@
   },
   {
     "id": "CO-152",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3103,8 +2859,6 @@
   },
   {
     "id": "CO-153",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3129,8 +2883,6 @@
   },
   {
     "id": "CO-154",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3153,8 +2905,6 @@
   },
   {
     "id": "CO-155",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3177,8 +2927,6 @@
   },
   {
     "id": "CO-156",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3202,8 +2950,6 @@
   },
   {
     "id": "CO-157",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3225,8 +2971,6 @@
   },
   {
     "id": "CO-158",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3249,8 +2993,6 @@
   },
   {
     "id": "CO-159",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3273,8 +3015,6 @@
   },
   {
     "id": "CO-160",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3297,8 +3037,6 @@
   },
   {
     "id": "CO-161",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3321,8 +3059,6 @@
   },
   {
     "id": "CO-163",
-    "authority_type": "utility",
-    "authority": "co-la-plata-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -3345,8 +3081,6 @@
   },
   {
     "id": "CO-164",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3370,8 +3104,6 @@
   },
   {
     "id": "CO-165",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3393,8 +3125,6 @@
   },
   {
     "id": "CO-166",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3416,8 +3146,6 @@
   },
   {
     "id": "CO-167",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3439,8 +3167,6 @@
   },
   {
     "id": "CO-168",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3462,8 +3188,6 @@
   },
   {
     "id": "CO-169",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3489,8 +3213,6 @@
   },
   {
     "id": "CO-170",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3512,8 +3234,6 @@
   },
   {
     "id": "CO-171",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3536,8 +3256,6 @@
   },
   {
     "id": "CO-172",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3561,8 +3279,6 @@
   },
   {
     "id": "CO-173",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3587,8 +3303,6 @@
   },
   {
     "id": "CO-174",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3613,8 +3327,6 @@
   },
   {
     "id": "CO-175",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3636,8 +3348,6 @@
   },
   {
     "id": "CO-176",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3659,8 +3369,6 @@
   },
   {
     "id": "CO-177",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3684,8 +3392,6 @@
   },
   {
     "id": "CO-178",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3709,8 +3415,6 @@
   },
   {
     "id": "CO-179",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3734,8 +3438,6 @@
   },
   {
     "id": "CO-180",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3759,8 +3461,6 @@
   },
   {
     "id": "CO-181",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3784,8 +3484,6 @@
   },
   {
     "id": "CO-182",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3810,8 +3508,6 @@
   },
   {
     "id": "CO-183",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3834,8 +3530,6 @@
   },
   {
     "id": "CO-184",
-    "authority_type": "utility",
-    "authority": "co-morgan-county-rea",
     "payment_methods": [
       "rebate"
     ],
@@ -3858,8 +3552,6 @@
   },
   {
     "id": "CO-185",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -3882,8 +3574,6 @@
   },
   {
     "id": "CO-186",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -3906,8 +3596,6 @@
   },
   {
     "id": "CO-187",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -3932,8 +3620,6 @@
   },
   {
     "id": "CO-188",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -3957,8 +3643,6 @@
   },
   {
     "id": "CO-189",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -3983,8 +3667,6 @@
   },
   {
     "id": "CO-190",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4008,8 +3690,6 @@
   },
   {
     "id": "CO-191",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4034,8 +3714,6 @@
   },
   {
     "id": "CO-192",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4061,8 +3739,6 @@
   },
   {
     "id": "CO-193",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4088,8 +3764,6 @@
   },
   {
     "id": "CO-194",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4112,8 +3786,6 @@
   },
   {
     "id": "CO-195",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4136,8 +3808,6 @@
   },
   {
     "id": "CO-196",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4162,8 +3832,6 @@
   },
   {
     "id": "CO-197",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4188,8 +3856,6 @@
   },
   {
     "id": "CO-198",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4215,8 +3881,6 @@
   },
   {
     "id": "CO-199",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4241,8 +3905,6 @@
   },
   {
     "id": "CO-200",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4267,8 +3929,6 @@
   },
   {
     "id": "CO-201",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4294,8 +3954,6 @@
   },
   {
     "id": "CO-202",
-    "authority_type": "utility",
-    "authority": "co-mountain-view-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -4319,8 +3977,6 @@
   },
   {
     "id": "CO-203",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4344,8 +4000,6 @@
   },
   {
     "id": "CO-204",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4369,8 +4023,6 @@
   },
   {
     "id": "CO-205",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4395,8 +4047,6 @@
   },
   {
     "id": "CO-206",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4419,8 +4069,6 @@
   },
   {
     "id": "CO-207",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4443,8 +4091,6 @@
   },
   {
     "id": "CO-208",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4467,8 +4113,6 @@
   },
   {
     "id": "CO-209",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4491,8 +4135,6 @@
   },
   {
     "id": "CO-210",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4517,8 +4159,6 @@
   },
   {
     "id": "CO-211",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4543,8 +4183,6 @@
   },
   {
     "id": "CO-212",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4569,8 +4207,6 @@
   },
   {
     "id": "CO-213",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4595,8 +4231,6 @@
   },
   {
     "id": "CO-214",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4621,8 +4255,6 @@
   },
   {
     "id": "CO-215",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4647,8 +4279,6 @@
   },
   {
     "id": "CO-216",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4673,8 +4303,6 @@
   },
   {
     "id": "CO-217",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4699,8 +4327,6 @@
   },
   {
     "id": "CO-218",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4725,8 +4351,6 @@
   },
   {
     "id": "CO-219",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4751,8 +4375,6 @@
   },
   {
     "id": "CO-220",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4777,8 +4399,6 @@
   },
   {
     "id": "CO-221",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4802,8 +4422,6 @@
   },
   {
     "id": "CO-222",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4827,8 +4445,6 @@
   },
   {
     "id": "CO-223",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4852,8 +4468,6 @@
   },
   {
     "id": "CO-224",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4876,8 +4490,6 @@
   },
   {
     "id": "CO-225",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4900,8 +4512,6 @@
   },
   {
     "id": "CO-226",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4924,8 +4534,6 @@
   },
   {
     "id": "CO-227",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4948,8 +4556,6 @@
   },
   {
     "id": "CO-228",
-    "authority_type": "utility",
-    "authority": "co-poudre-valley-rea",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -4972,8 +4578,6 @@
   },
   {
     "id": "CO-229",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -4997,8 +4601,6 @@
   },
   {
     "id": "CO-230",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5022,8 +4624,6 @@
   },
   {
     "id": "CO-231",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5047,8 +4647,6 @@
   },
   {
     "id": "CO-232",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5074,8 +4672,6 @@
   },
   {
     "id": "CO-233",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5101,8 +4697,6 @@
   },
   {
     "id": "CO-234",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5128,8 +4722,6 @@
   },
   {
     "id": "CO-235",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5155,8 +4747,6 @@
   },
   {
     "id": "CO-236",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5182,8 +4772,6 @@
   },
   {
     "id": "CO-237",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5209,8 +4797,6 @@
   },
   {
     "id": "CO-238",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5236,8 +4822,6 @@
   },
   {
     "id": "CO-239",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5261,8 +4845,6 @@
   },
   {
     "id": "CO-240",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5286,8 +4868,6 @@
   },
   {
     "id": "CO-241",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5312,8 +4892,6 @@
   },
   {
     "id": "CO-242",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5338,8 +4916,6 @@
   },
   {
     "id": "CO-243",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5364,8 +4940,6 @@
   },
   {
     "id": "CO-244",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5390,8 +4964,6 @@
   },
   {
     "id": "CO-245",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5416,8 +4988,6 @@
   },
   {
     "id": "CO-246",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5443,8 +5013,6 @@
   },
   {
     "id": "CO-247",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5470,8 +5038,6 @@
   },
   {
     "id": "CO-248",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5497,8 +5063,6 @@
   },
   {
     "id": "CO-250",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5523,8 +5087,6 @@
   },
   {
     "id": "CO-251",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5549,8 +5111,6 @@
   },
   {
     "id": "CO-252",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5575,8 +5135,6 @@
   },
   {
     "id": "CO-253",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5601,8 +5159,6 @@
   },
   {
     "id": "CO-254",
-    "authority_type": "utility",
-    "authority": "co-san-isabel-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -5628,8 +5184,6 @@
   },
   {
     "id": "CO-255",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5655,8 +5209,6 @@
   },
   {
     "id": "CO-256",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5679,8 +5231,6 @@
   },
   {
     "id": "CO-257",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5703,8 +5253,6 @@
   },
   {
     "id": "CO-258",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5726,8 +5274,6 @@
   },
   {
     "id": "CO-259",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5749,8 +5295,6 @@
   },
   {
     "id": "CO-260",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5772,8 +5316,6 @@
   },
   {
     "id": "CO-261",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5795,8 +5337,6 @@
   },
   {
     "id": "CO-262",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5818,8 +5358,6 @@
   },
   {
     "id": "CO-263",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -5843,8 +5381,6 @@
   },
   {
     "id": "CO-264",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5867,8 +5403,6 @@
   },
   {
     "id": "CO-265",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5892,8 +5426,6 @@
   },
   {
     "id": "CO-266",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5917,8 +5449,6 @@
   },
   {
     "id": "CO-267",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5942,8 +5472,6 @@
   },
   {
     "id": "CO-268",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5967,8 +5495,6 @@
   },
   {
     "id": "CO-269",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -5992,8 +5518,6 @@
   },
   {
     "id": "CO-270",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6017,8 +5541,6 @@
   },
   {
     "id": "CO-271",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6041,8 +5563,6 @@
   },
   {
     "id": "CO-272",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6066,8 +5586,6 @@
   },
   {
     "id": "CO-273",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6091,8 +5609,6 @@
   },
   {
     "id": "CO-274",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6116,8 +5632,6 @@
   },
   {
     "id": "CO-275",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6141,8 +5655,6 @@
   },
   {
     "id": "CO-276",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6166,8 +5678,6 @@
   },
   {
     "id": "CO-277",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6191,8 +5701,6 @@
   },
   {
     "id": "CO-278",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6215,8 +5723,6 @@
   },
   {
     "id": "CO-279",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -6239,8 +5745,6 @@
   },
   {
     "id": "CO-559",
-    "authority_type": "utility",
-    "authority": "co-san-miguel-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6264,8 +5768,6 @@
   },
   {
     "id": "CO-280",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6287,8 +5789,6 @@
   },
   {
     "id": "CO-281",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6310,8 +5810,6 @@
   },
   {
     "id": "CO-282",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6335,8 +5833,6 @@
   },
   {
     "id": "CO-283",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6359,8 +5855,6 @@
   },
   {
     "id": "CO-284",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6383,8 +5877,6 @@
   },
   {
     "id": "CO-285",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6408,8 +5900,6 @@
   },
   {
     "id": "CO-286",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6433,8 +5923,6 @@
   },
   {
     "id": "CO-287",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6457,8 +5945,6 @@
   },
   {
     "id": "CO-288",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6480,8 +5966,6 @@
   },
   {
     "id": "CO-289",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6505,8 +5989,6 @@
   },
   {
     "id": "CO-290",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6529,8 +6011,6 @@
   },
   {
     "id": "CO-291",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6554,8 +6034,6 @@
   },
   {
     "id": "CO-292",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6577,8 +6055,6 @@
   },
   {
     "id": "CO-293",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6600,8 +6076,6 @@
   },
   {
     "id": "CO-294",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6625,8 +6099,6 @@
   },
   {
     "id": "CO-295",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6651,8 +6123,6 @@
   },
   {
     "id": "CO-296",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6676,8 +6146,6 @@
   },
   {
     "id": "CO-297",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6701,8 +6169,6 @@
   },
   {
     "id": "CO-298",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6726,8 +6192,6 @@
   },
   {
     "id": "CO-299",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6751,8 +6215,6 @@
   },
   {
     "id": "CO-300",
-    "authority_type": "utility",
-    "authority": "co-southeast-colorado-power-association",
     "payment_methods": [
       "rebate"
     ],
@@ -6775,8 +6237,6 @@
   },
   {
     "id": "CO-305",
-    "authority_type": "utility",
-    "authority": "co-united-power",
     "payment_methods": [
       "account_credit"
     ],
@@ -6799,8 +6259,6 @@
   },
   {
     "id": "CO-306",
-    "authority_type": "utility",
-    "authority": "co-united-power",
     "payment_methods": [
       "account_credit"
     ],
@@ -6823,8 +6281,6 @@
   },
   {
     "id": "CO-307",
-    "authority_type": "utility",
-    "authority": "co-united-power",
     "payment_methods": [
       "account_credit"
     ],
@@ -6847,8 +6303,6 @@
   },
   {
     "id": "CO-308",
-    "authority_type": "utility",
-    "authority": "co-united-power",
     "payment_methods": [
       "account_credit"
     ],
@@ -6870,8 +6324,6 @@
   },
   {
     "id": "CO-309",
-    "authority_type": "utility",
-    "authority": "co-united-power",
     "payment_methods": [
       "account_credit"
     ],
@@ -6893,8 +6345,6 @@
   },
   {
     "id": "CO-310",
-    "authority_type": "utility",
-    "authority": "co-united-power",
     "payment_methods": [
       "account_credit"
     ],
@@ -6916,8 +6366,6 @@
   },
   {
     "id": "CO-311",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -6942,8 +6390,6 @@
   },
   {
     "id": "CO-312",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -6968,8 +6414,6 @@
   },
   {
     "id": "CO-313",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -6994,8 +6438,6 @@
   },
   {
     "id": "CO-314",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7019,8 +6461,6 @@
   },
   {
     "id": "CO-315",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -7044,8 +6484,6 @@
   },
   {
     "id": "CO-316",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7069,8 +6507,6 @@
   },
   {
     "id": "CO-317",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7095,8 +6531,6 @@
   },
   {
     "id": "CO-318",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7120,8 +6554,6 @@
   },
   {
     "id": "CO-319",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7145,8 +6577,6 @@
   },
   {
     "id": "CO-558",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7171,8 +6601,6 @@
   },
   {
     "id": "CO-546",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7196,8 +6624,6 @@
   },
   {
     "id": "CO-547",
-    "authority_type": "state",
-    "authority": "co-colorado-energy-office",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -7221,8 +6647,6 @@
   },
   {
     "id": "CO-320",
-    "authority_type": "state",
-    "authority": "co-state-of-colorado",
     "payment_methods": [
       "tax_credit"
     ],
@@ -7248,8 +6672,6 @@
   },
   {
     "id": "CO-322",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7273,8 +6695,6 @@
   },
   {
     "id": "CO-323",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7299,8 +6719,6 @@
   },
   {
     "id": "CO-324",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7325,8 +6743,6 @@
   },
   {
     "id": "CO-325",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7350,8 +6766,6 @@
   },
   {
     "id": "CO-326",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7376,8 +6790,6 @@
   },
   {
     "id": "CO-327",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7402,8 +6814,6 @@
   },
   {
     "id": "CO-328",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7427,8 +6837,6 @@
   },
   {
     "id": "CO-329",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7452,8 +6860,6 @@
   },
   {
     "id": "CO-330",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7477,8 +6883,6 @@
   },
   {
     "id": "CO-331",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7504,8 +6908,6 @@
   },
   {
     "id": "CO-332",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7529,8 +6931,6 @@
   },
   {
     "id": "CO-333",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7555,8 +6955,6 @@
   },
   {
     "id": "CO-334",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7580,8 +6978,6 @@
   },
   {
     "id": "CO-335",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7605,8 +7001,6 @@
   },
   {
     "id": "CO-336",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7632,8 +7026,6 @@
   },
   {
     "id": "CO-337",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7659,8 +7051,6 @@
   },
   {
     "id": "CO-338",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7685,8 +7075,6 @@
   },
   {
     "id": "CO-339",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7710,8 +7098,6 @@
   },
   {
     "id": "CO-340",
-    "authority_type": "city",
-    "authority": "co-city-of-boulder",
     "payment_methods": [
       "rebate"
     ],
@@ -7733,8 +7119,6 @@
   },
   {
     "id": "CO-341",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7760,8 +7144,6 @@
   },
   {
     "id": "CO-342",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7787,8 +7169,6 @@
   },
   {
     "id": "CO-343",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7814,8 +7194,6 @@
   },
   {
     "id": "CO-345",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7841,8 +7219,6 @@
   },
   {
     "id": "CO-346",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7868,8 +7244,6 @@
   },
   {
     "id": "CO-347",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7896,8 +7270,6 @@
   },
   {
     "id": "CO-348",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7923,8 +7295,6 @@
   },
   {
     "id": "CO-349",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7952,8 +7322,6 @@
   },
   {
     "id": "CO-350",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -7979,8 +7347,6 @@
   },
   {
     "id": "CO-351",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8005,8 +7371,6 @@
   },
   {
     "id": "CO-352",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8032,8 +7396,6 @@
   },
   {
     "id": "CO-353",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8059,8 +7421,6 @@
   },
   {
     "id": "CO-354",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8085,8 +7445,6 @@
   },
   {
     "id": "CO-355",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8112,8 +7470,6 @@
   },
   {
     "id": "CO-356",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8139,8 +7495,6 @@
   },
   {
     "id": "CO-357",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8165,8 +7519,6 @@
   },
   {
     "id": "CO-358",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8191,8 +7543,6 @@
   },
   {
     "id": "CO-359",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8217,8 +7567,6 @@
   },
   {
     "id": "CO-360",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8244,8 +7592,6 @@
   },
   {
     "id": "CO-361",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8271,8 +7617,6 @@
   },
   {
     "id": "CO-362",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8298,8 +7642,6 @@
   },
   {
     "id": "CO-363",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8324,8 +7666,6 @@
   },
   {
     "id": "CO-364",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8351,8 +7691,6 @@
   },
   {
     "id": "CO-365",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8377,8 +7715,6 @@
   },
   {
     "id": "CO-366",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8403,8 +7739,6 @@
   },
   {
     "id": "CO-367",
-    "authority_type": "county",
-    "authority": "co-boulder-county",
     "payment_methods": [
       "rebate"
     ],
@@ -8429,8 +7763,6 @@
   },
   {
     "id": "CO-368",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8453,8 +7785,6 @@
   },
   {
     "id": "CO-369",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8477,8 +7807,6 @@
   },
   {
     "id": "CO-370",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8502,8 +7830,6 @@
   },
   {
     "id": "CO-371",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8528,8 +7854,6 @@
   },
   {
     "id": "CO-372",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8553,8 +7877,6 @@
   },
   {
     "id": "CO-373",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8577,8 +7899,6 @@
   },
   {
     "id": "CO-374",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8601,8 +7921,6 @@
   },
   {
     "id": "CO-375",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8627,8 +7945,6 @@
   },
   {
     "id": "CO-376",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8654,8 +7970,6 @@
   },
   {
     "id": "CO-377",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8678,8 +7992,6 @@
   },
   {
     "id": "CO-378",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8702,8 +8014,6 @@
   },
   {
     "id": "CO-379",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8726,8 +8036,6 @@
   },
   {
     "id": "CO-380",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8750,8 +8058,6 @@
   },
   {
     "id": "CO-381",
-    "authority_type": "utility",
-    "authority": "co-glenwood-springs-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -8774,8 +8080,6 @@
   },
   {
     "id": "CO-382",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8801,8 +8105,6 @@
   },
   {
     "id": "CO-383",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8828,8 +8130,6 @@
   },
   {
     "id": "CO-384",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8855,8 +8155,6 @@
   },
   {
     "id": "CO-385",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8882,8 +8180,6 @@
   },
   {
     "id": "CO-386",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8909,8 +8205,6 @@
   },
   {
     "id": "CO-387",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8936,8 +8230,6 @@
   },
   {
     "id": "CO-388",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8963,8 +8255,6 @@
   },
   {
     "id": "CO-389",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -8988,8 +8278,6 @@
   },
   {
     "id": "CO-390",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9014,8 +8302,6 @@
   },
   {
     "id": "CO-391",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9040,8 +8326,6 @@
   },
   {
     "id": "CO-392",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9065,8 +8349,6 @@
   },
   {
     "id": "CO-393",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9093,8 +8375,6 @@
   },
   {
     "id": "CO-394",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9121,8 +8401,6 @@
   },
   {
     "id": "CO-395",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9148,8 +8426,6 @@
   },
   {
     "id": "CO-396",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9173,8 +8449,6 @@
   },
   {
     "id": "CO-397",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9199,8 +8473,6 @@
   },
   {
     "id": "CO-398",
-    "authority_type": "utility",
-    "authority": "co-highline-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9225,8 +8497,6 @@
   },
   {
     "id": "CO-399",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9248,8 +8518,6 @@
   },
   {
     "id": "CO-400",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9272,8 +8540,6 @@
   },
   {
     "id": "CO-401",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9296,8 +8562,6 @@
   },
   {
     "id": "CO-402",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9321,8 +8585,6 @@
   },
   {
     "id": "CO-403",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9346,8 +8608,6 @@
   },
   {
     "id": "CO-404",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9371,8 +8631,6 @@
   },
   {
     "id": "CO-405",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9396,8 +8654,6 @@
   },
   {
     "id": "CO-406",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9421,8 +8677,6 @@
   },
   {
     "id": "CO-407",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9445,8 +8699,6 @@
   },
   {
     "id": "CO-408",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9469,8 +8721,6 @@
   },
   {
     "id": "CO-409",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9492,8 +8742,6 @@
   },
   {
     "id": "CO-410",
-    "authority_type": "utility",
-    "authority": "co-kc-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -9515,8 +8763,6 @@
   },
   {
     "id": "CO-411",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9540,8 +8786,6 @@
   },
   {
     "id": "CO-412",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9565,8 +8809,6 @@
   },
   {
     "id": "CO-413",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9590,8 +8832,6 @@
   },
   {
     "id": "CO-414",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9615,8 +8855,6 @@
   },
   {
     "id": "CO-415",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9639,8 +8877,6 @@
   },
   {
     "id": "CO-416",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9663,8 +8899,6 @@
   },
   {
     "id": "CO-417",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9688,8 +8922,6 @@
   },
   {
     "id": "CO-418",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9711,8 +8943,6 @@
   },
   {
     "id": "CO-419",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9734,8 +8964,6 @@
   },
   {
     "id": "CO-420",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9757,8 +8985,6 @@
   },
   {
     "id": "CO-421",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9780,8 +9006,6 @@
   },
   {
     "id": "CO-422",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9803,8 +9027,6 @@
   },
   {
     "id": "CO-423",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9828,8 +9050,6 @@
   },
   {
     "id": "CO-424",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9853,8 +9073,6 @@
   },
   {
     "id": "CO-425",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9878,8 +9096,6 @@
   },
   {
     "id": "CO-426",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9902,8 +9118,6 @@
   },
   {
     "id": "CO-427",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9926,8 +9140,6 @@
   },
   {
     "id": "CO-428",
-    "authority_type": "utility",
-    "authority": "co-mountain-parks-electric",
     "payment_methods": [
       "account_credit"
     ],
@@ -9949,8 +9161,6 @@
   },
   {
     "id": "CO-429",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -9974,8 +9184,6 @@
   },
   {
     "id": "CO-430",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -9997,8 +9205,6 @@
   },
   {
     "id": "CO-431",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10020,8 +9226,6 @@
   },
   {
     "id": "CO-432",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10043,8 +9247,6 @@
   },
   {
     "id": "CO-433",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10066,8 +9268,6 @@
   },
   {
     "id": "CO-434",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10093,8 +9293,6 @@
   },
   {
     "id": "CO-435",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10116,8 +9314,6 @@
   },
   {
     "id": "CO-436",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10140,8 +9336,6 @@
   },
   {
     "id": "CO-437",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10165,8 +9359,6 @@
   },
   {
     "id": "CO-438",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10191,8 +9383,6 @@
   },
   {
     "id": "CO-439",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10217,8 +9407,6 @@
   },
   {
     "id": "CO-440",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10240,8 +9428,6 @@
   },
   {
     "id": "CO-441",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10263,8 +9449,6 @@
   },
   {
     "id": "CO-442",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10288,8 +9472,6 @@
   },
   {
     "id": "CO-443",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10313,8 +9495,6 @@
   },
   {
     "id": "CO-444",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10338,8 +9518,6 @@
   },
   {
     "id": "CO-445",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10363,8 +9541,6 @@
   },
   {
     "id": "CO-446",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10388,8 +9564,6 @@
   },
   {
     "id": "CO-447",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10414,8 +9588,6 @@
   },
   {
     "id": "CO-448",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10438,8 +9610,6 @@
   },
   {
     "id": "CO-449",
-    "authority_type": "utility",
-    "authority": "co-san-luis-valley-rec",
     "payment_methods": [
       "rebate"
     ],
@@ -10462,8 +9632,6 @@
   },
   {
     "id": "CO-450",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10485,8 +9653,6 @@
   },
   {
     "id": "CO-451",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10508,8 +9674,6 @@
   },
   {
     "id": "CO-452",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10531,8 +9695,6 @@
   },
   {
     "id": "CO-453",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10554,8 +9716,6 @@
   },
   {
     "id": "CO-454",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10577,8 +9737,6 @@
   },
   {
     "id": "CO-455",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10600,8 +9758,6 @@
   },
   {
     "id": "CO-541",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10624,8 +9780,6 @@
   },
   {
     "id": "CO-456",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10648,8 +9802,6 @@
   },
   {
     "id": "CO-457",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10672,8 +9824,6 @@
   },
   {
     "id": "CO-542",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10696,8 +9846,6 @@
   },
   {
     "id": "CO-458",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "account_credit"
     ],
@@ -10719,8 +9867,6 @@
   },
   {
     "id": "CO-459",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10744,8 +9890,6 @@
   },
   {
     "id": "CO-460",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10769,8 +9913,6 @@
   },
   {
     "id": "CO-461",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10794,8 +9936,6 @@
   },
   {
     "id": "CO-462",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10819,8 +9959,6 @@
   },
   {
     "id": "CO-463",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10844,8 +9982,6 @@
   },
   {
     "id": "CO-464",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10869,8 +10005,6 @@
   },
   {
     "id": "CO-465",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10894,8 +10028,6 @@
   },
   {
     "id": "CO-466",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10917,8 +10049,6 @@
   },
   {
     "id": "CO-467",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10941,8 +10071,6 @@
   },
   {
     "id": "CO-468",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -10965,8 +10093,6 @@
   },
   {
     "id": "CO-469",
-    "authority_type": "city",
-    "authority": "co-town-of-avon",
     "payment_methods": [
       "rebate"
     ],
@@ -10988,8 +10114,6 @@
   },
   {
     "id": "CO-470",
-    "authority_type": "city",
-    "authority": "co-town-of-avon",
     "payment_methods": [
       "rebate"
     ],
@@ -11012,8 +10136,6 @@
   },
   {
     "id": "CO-471",
-    "authority_type": "city",
-    "authority": "co-town-of-avon",
     "payment_methods": [
       "rebate"
     ],
@@ -11035,8 +10157,6 @@
   },
   {
     "id": "CO-472",
-    "authority_type": "city",
-    "authority": "co-town-of-eagle",
     "payment_methods": [
       "rebate"
     ],
@@ -11059,8 +10179,6 @@
   },
   {
     "id": "CO-473",
-    "authority_type": "city",
-    "authority": "co-town-of-eagle",
     "payment_methods": [
       "rebate"
     ],
@@ -11083,8 +10201,6 @@
   },
   {
     "id": "CO-474",
-    "authority_type": "city",
-    "authority": "co-town-of-eagle",
     "payment_methods": [
       "rebate"
     ],
@@ -11106,8 +10222,6 @@
   },
   {
     "id": "CO-475",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11130,8 +10244,6 @@
   },
   {
     "id": "CO-476",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11153,8 +10265,6 @@
   },
   {
     "id": "CO-477",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11177,8 +10287,6 @@
   },
   {
     "id": "CO-478",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11200,8 +10308,6 @@
   },
   {
     "id": "CO-479",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11223,8 +10329,6 @@
   },
   {
     "id": "CO-480",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11246,8 +10350,6 @@
   },
   {
     "id": "CO-481",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11269,8 +10371,6 @@
   },
   {
     "id": "CO-482",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11292,8 +10392,6 @@
   },
   {
     "id": "CO-483",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11315,8 +10413,6 @@
   },
   {
     "id": "CO-484",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11338,8 +10434,6 @@
   },
   {
     "id": "CO-485",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11361,8 +10455,6 @@
   },
   {
     "id": "CO-486",
-    "authority_type": "city",
-    "authority": "co-town-of-erie",
     "payment_methods": [
       "rebate"
     ],
@@ -11384,8 +10476,6 @@
   },
   {
     "id": "CO-487",
-    "authority_type": "city",
-    "authority": "co-town-of-vail",
     "payment_methods": [
       "rebate"
     ],
@@ -11408,8 +10498,6 @@
   },
   {
     "id": "CO-488",
-    "authority_type": "city",
-    "authority": "co-town-of-vail",
     "payment_methods": [
       "rebate"
     ],
@@ -11432,8 +10520,6 @@
   },
   {
     "id": "CO-489",
-    "authority_type": "city",
-    "authority": "co-town-of-vail",
     "payment_methods": [
       "rebate"
     ],
@@ -11455,8 +10541,6 @@
   },
   {
     "id": "CO-490",
-    "authority_type": "city",
-    "authority": "co-town-of-vail",
     "payment_methods": [
       "rebate"
     ],
@@ -11480,8 +10564,6 @@
   },
   {
     "id": "CO-491",
-    "authority_type": "city",
-    "authority": "co-town-of-vail",
     "payment_methods": [
       "rebate"
     ],
@@ -11504,8 +10586,6 @@
   },
   {
     "id": "CO-492",
-    "authority_type": "city",
-    "authority": "co-town-of-vail",
     "payment_methods": [
       "rebate"
     ],
@@ -11528,8 +10608,6 @@
   },
   {
     "id": "CO-493",
-    "authority_type": "county",
-    "authority": "co-unincorporated-eagle-county",
     "payment_methods": [
       "rebate"
     ],
@@ -11553,8 +10631,6 @@
   },
   {
     "id": "CO-494",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "assistance_program"
@@ -11578,8 +10654,6 @@
   },
   {
     "id": "CO-495",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11605,8 +10679,6 @@
   },
   {
     "id": "CO-496",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11631,8 +10703,6 @@
   },
   {
     "id": "CO-497",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11656,8 +10726,6 @@
   },
   {
     "id": "CO-498",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11681,8 +10749,6 @@
   },
   {
     "id": "CO-499",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11706,8 +10772,6 @@
   },
   {
     "id": "CO-500",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11731,8 +10795,6 @@
   },
   {
     "id": "CO-501",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11756,8 +10818,6 @@
   },
   {
     "id": "CO-502",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11781,8 +10841,6 @@
   },
   {
     "id": "CO-503",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11806,8 +10864,6 @@
   },
   {
     "id": "CO-504",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11831,8 +10887,6 @@
   },
   {
     "id": "CO-505",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11856,8 +10910,6 @@
   },
   {
     "id": "CO-506",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11884,8 +10936,6 @@
   },
   {
     "id": "CO-507",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11911,8 +10961,6 @@
   },
   {
     "id": "CO-508",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11937,8 +10985,6 @@
   },
   {
     "id": "CO-509",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11963,8 +11009,6 @@
   },
   {
     "id": "CO-510",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -11989,8 +11033,6 @@
   },
   {
     "id": "CO-511",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12015,8 +11057,6 @@
   },
   {
     "id": "CO-512",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12041,8 +11081,6 @@
   },
   {
     "id": "CO-513",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12067,8 +11105,6 @@
   },
   {
     "id": "CO-514",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12093,8 +11129,6 @@
   },
   {
     "id": "CO-515",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12119,8 +11153,6 @@
   },
   {
     "id": "CO-516",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12145,8 +11177,6 @@
   },
   {
     "id": "CO-517",
-    "authority_type": "other",
-    "authority": "co-walking-mountains",
     "eligible_geo_group": "co-group-walking-mountains",
     "payment_methods": [
       "rebate"
@@ -12171,8 +11201,6 @@
   },
   {
     "id": "CO-518",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12194,8 +11222,6 @@
   },
   {
     "id": "CO-519",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12217,8 +11243,6 @@
   },
   {
     "id": "CO-520",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12242,8 +11266,6 @@
   },
   {
     "id": "CO-521",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12267,8 +11289,6 @@
   },
   {
     "id": "CO-522",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12292,8 +11312,6 @@
   },
   {
     "id": "CO-523",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12317,8 +11335,6 @@
   },
   {
     "id": "CO-524",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12342,8 +11358,6 @@
   },
   {
     "id": "CO-525",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12367,8 +11381,6 @@
   },
   {
     "id": "CO-526",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12392,8 +11404,6 @@
   },
   {
     "id": "CO-527",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12416,8 +11426,6 @@
   },
   {
     "id": "CO-528",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12440,8 +11448,6 @@
   },
   {
     "id": "CO-529",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12464,8 +11470,6 @@
   },
   {
     "id": "CO-530",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12488,8 +11492,6 @@
   },
   {
     "id": "CO-531",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12511,8 +11513,6 @@
   },
   {
     "id": "CO-532",
-    "authority_type": "utility",
-    "authority": "co-white-river-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12535,8 +11535,6 @@
   },
   {
     "id": "CO-533",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12559,8 +11557,6 @@
   },
   {
     "id": "CO-534",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12585,8 +11581,6 @@
   },
   {
     "id": "CO-535",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12611,8 +11605,6 @@
   },
   {
     "id": "CO-536",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12634,8 +11626,6 @@
   },
   {
     "id": "CO-537",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12659,8 +11649,6 @@
   },
   {
     "id": "CO-539",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12683,8 +11671,6 @@
   },
   {
     "id": "CO-540",
-    "authority_type": "utility",
-    "authority": "co-y-w-electric-association",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12708,8 +11694,6 @@
   },
   {
     "id": "CO-543",
-    "authority_type": "utility",
-    "authority": "co-sangre-de-cristo-electric-association",
     "payment_methods": [
       "rebate"
     ],
@@ -12737,8 +11721,6 @@
   },
   {
     "id": "CO-544",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -12759,8 +11741,6 @@
   },
   {
     "id": "CO-560",
-    "authority_type": "state",
-    "authority": "co-state-of-colorado",
     "payment_methods": [
       "tax_credit"
     ],
@@ -12785,8 +11765,6 @@
   },
   {
     "id": "CO-561",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "assistance_program"
     ],
@@ -12810,8 +11788,6 @@
   },
   {
     "id": "CO-562",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "assistance_program"
     ],
@@ -12834,8 +11810,6 @@
   },
   {
     "id": "CO-563",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "assistance_program"
     ],
@@ -12858,8 +11832,6 @@
   },
   {
     "id": "CO-564",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "assistance_program"
     ],
@@ -12882,8 +11854,6 @@
   },
   {
     "id": "CO-565",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "assistance_program"
     ],
@@ -12906,8 +11876,6 @@
   },
   {
     "id": "CO-566",
-    "authority_type": "county",
-    "authority": "co-city-and-county-of-denver",
     "payment_methods": [
       "assistance_program"
     ],
@@ -12930,8 +11898,6 @@
   },
   {
     "id": "CO-567",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -12954,8 +11920,6 @@
   },
   {
     "id": "CO-568",
-    "authority_type": "utility",
-    "authority": "co-xcel-energy",
     "payment_methods": [
       "pos_rebate"
     ],

--- a/data/CO/programs.json
+++ b/data/CO/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.blackhillsenergy.com/efficiency-and-savings/residential-rebates/colorado-electric-residential-rebates"
-    }
+    },
+    "authority": "co-black-hills-energy",
+    "authority_type": "utility"
   },
   "co_blackHillsEnergy_electrificationPilotProgram": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.blackhillsenergy.com/efficiency-and-savings/residential-rebates/colorado-electric-residential-rebates"
-    }
+    },
+    "authority": "co-black-hills-energy",
+    "authority_type": "utility"
   },
   "co_blackHillsEnergy_readyEVProgram": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.blackhillsenergy.com/efficiency-and-savings/residential-rebates/colorado-electric-residential-rebates"
-    }
+    },
+    "authority": "co-black-hills-energy",
+    "authority_type": "utility"
   },
   "co_boulderCounty_energySmart": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://energysmartyes.com/rebates-financing/boco-rebates/"
-    }
+    },
+    "authority": "co-boulder-county",
+    "authority_type": "county"
   },
   "co_boulderCounty_energySmartManufacturedHomesRebates": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://assets-partners.bouldercounty.gov/wp-content/uploads/sites/2/2023/08/Manufactured-Homes-Eligible-Measures-List-2023.pdf"
-    }
+    },
+    "authority": "co-boulder-county",
+    "authority_type": "county"
   },
   "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-E-BikeAndE-CargoBikeRebateVouchers": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Climate-Action-Sustainability-Resiliency/Sustainable-Transportation/Electric-Bikes-E-Bikes-Rebates"
-    }
+    },
+    "authority": "co-city-and-county-of-denver",
+    "authority_type": "county"
   },
   "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-HomeEnergyRebates": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Climate-Action-Sustainability-Resiliency/Cutting-Denvers-Carbon-Pollution/High-Performance-Buildings-and-Homes/Electrify-Your-Home"
-    }
+    },
+    "authority": "co-city-and-county-of-denver",
+    "authority_type": "county"
   },
   "co_cityAndCountyOfDenver_denverClimateActionRebateProgram-RebatesForRenewables": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Climate-Action-Sustainability-Resiliency/Cutting-Denvers-Carbon-Pollution/High-Performance-Buildings-and-Homes/Electrify-Your-Home/Home-Solar/Rebates-for-Renewables"
-    }
+    },
+    "authority": "co-city-and-county-of-denver",
+    "authority_type": "county"
   },
   "co_cityAndCountyOfDenver_denver'SHealthyHomesProgram": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Climate-Action-Sustainability-Resiliency/Cutting-Denvers-Carbon-Pollution/High-Performance-Buildings-and-Homes/Electrify-Your-Home/Healthy-Homes-Program"
-    }
+    },
+    "authority": "co-city-and-county-of-denver",
+    "authority_type": "county"
   },
   "co_cityOfBoulder_residentialRebates": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://energysmartyes.com/rebates-financing/city-of-boulder/"
-    }
+    },
+    "authority": "co-city-of-boulder",
+    "authority_type": "city"
   },
   "co_cityOfBoulder_solarTaxRebates": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://bouldercolorado.gov/services/solar-tax-rebates"
-    }
+    },
+    "authority": "co-city-of-boulder",
+    "authority_type": "city"
   },
   "co_coloradoEnergyOffice_coloradoHeatPumpTaxCredits": {
     "name": {
@@ -93,7 +115,9 @@
     },
     "url": {
       "en": "https://energyoffice.colorado.gov/hptc"
-    }
+    },
+    "authority": "co-colorado-energy-office",
+    "authority_type": "state"
   },
   "co_coloradoEnergyOffice_electricVehicleTaxCredits": {
     "name": {
@@ -101,7 +125,9 @@
     },
     "url": {
       "en": "https://energyoffice.colorado.gov/transportation/grants-incentives/electric-vehicle-tax-credits"
-    }
+    },
+    "authority": "co-colorado-energy-office",
+    "authority_type": "state"
   },
   "co_coloradoEnergyOffice_vehicleExchangeColorado(VXC)Program": {
     "name": {
@@ -109,7 +135,9 @@
     },
     "url": {
       "en": "https://energyoffice.colorado.gov/vehicle-exchange-colorado"
-    }
+    },
+    "authority": "co-colorado-energy-office",
+    "authority_type": "state"
   },
   "co_coloradoSpringsUtilities_residentialEfficiencyRebateProgram": {
     "name": {
@@ -117,7 +145,9 @@
     },
     "url": {
       "en": "https://www.csu.org/Pages/ResidentialRebates.aspx"
-    }
+    },
+    "authority": "co-colorado-springs-utilities",
+    "authority_type": "utility"
   },
   "co_empireElectricAssociation_energyEfficiencyProductsProgram": {
     "name": {
@@ -125,7 +155,9 @@
     },
     "url": {
       "en": "https://www.eea.coop/residential-energy-efficiency-program"
-    }
+    },
+    "authority": "co-empire-electric-association",
+    "authority_type": "utility"
   },
   "co_energyOutreachColorado_weatherizationAssistanceProgram": {
     "name": {
@@ -133,23 +165,9 @@
     },
     "url": {
       "en": "https://socgov02.my.site.com/ceoweatherization/s/"
-    }
-  },
-  "co_estesParkPowerAndCommunications_efficiencyWorks": {
-    "name": {
-      "en": "Efficiency Works"
     },
-    "url": {
-      "en": "https://efficiencyworks.org/homes/rebates/#secrebates"
-    }
-  },
-  "co_fortCollinsUtilities_efficiencyWorks": {
-    "name": {
-      "en": "Efficiency Works"
-    },
-    "url": {
-      "en": "https://efficiencyworks.org/homes/rebates/#secrebates"
-    }
+    "authority": "co-energy-outreach-colorado",
+    "authority_type": "state"
   },
   "co_fortCollinsUtilities_solarRebates": {
     "name": {
@@ -157,7 +175,9 @@
     },
     "url": {
       "en": "https://www.fcgov.com/utilities/residential/renewables/solar-rebates"
-    }
+    },
+    "authority": "co-fort-collins-utilities",
+    "authority_type": "utility"
   },
   "co_fortCollinsUtilities_solarRebates-ResidentialBatteryStorageProgram": {
     "name": {
@@ -165,7 +185,9 @@
     },
     "url": {
       "en": "https://www.fcgov.com/utilities/residential-battery-storage-program"
-    }
+    },
+    "authority": "co-fort-collins-utilities",
+    "authority_type": "utility"
   },
   "co_glenwoodSpringsElectric_sustainabilityProgram2023ElectricRebates": {
     "name": {
@@ -173,7 +195,9 @@
     },
     "url": {
       "en": "https://garfieldcleanenergy.org/gwse-rebates/"
-    }
+    },
+    "authority": "co-glenwood-springs-electric",
+    "authority_type": "utility"
   },
   "co_gunnisonCountyElectricAssociation_rebates": {
     "name": {
@@ -181,7 +205,9 @@
     },
     "url": {
       "en": "https://www.gcea.coop/energy-efficiency/rebates/"
-    }
+    },
+    "authority": "co-gunnison-county-electric-association",
+    "authority_type": "utility"
   },
   "co_highlineElectricAssociation_rebateProgram": {
     "name": {
@@ -189,7 +215,9 @@
     },
     "url": {
       "en": "https://www.hea.coop/rebates"
-    }
+    },
+    "authority": "co-highline-electric-association",
+    "authority_type": "utility"
   },
   "co_holyCrossEnergy_residentialRebates": {
     "name": {
@@ -197,7 +225,9 @@
     },
     "url": {
       "en": "https://www.holycross.com/rebates/"
-    }
+    },
+    "authority": "co-holy-cross-energy",
+    "authority_type": "utility"
   },
   "co_kCElectricAssociation_rebates": {
     "name": {
@@ -205,7 +235,9 @@
     },
     "url": {
       "en": "https://www.kcelectric.coop/rebates"
-    }
+    },
+    "authority": "co-kc-electric-association",
+    "authority_type": "utility"
   },
   "co_laPlataElectricAssociation_electrifyAndSave": {
     "name": {
@@ -213,23 +245,9 @@
     },
     "url": {
       "en": "https://lpea.coop/electrify"
-    }
-  },
-  "co_longmontPowerAndCommunications_efficiencyWorks": {
-    "name": {
-      "en": "Efficiency Works"
     },
-    "url": {
-      "en": "https://efficiencyworks.org/homes/rebates/#secrebates"
-    }
-  },
-  "co_lovelandWaterAndPower_efficiencyWorks": {
-    "name": {
-      "en": "Efficiency Works"
-    },
-    "url": {
-      "en": "https://efficiencyworks.org/homes/rebates/#secrebates"
-    }
+    "authority": "co-la-plata-electric-association",
+    "authority_type": "utility"
   },
   "co_morganCountyREA_tri-StateG&T": {
     "name": {
@@ -237,7 +255,9 @@
     },
     "url": {
       "en": "https://www.mcrea.org/energy-efficiency-rebates"
-    }
+    },
+    "authority": "co-morgan-county-rea",
+    "authority_type": "utility"
   },
   "co_mountainParksElectric_rebates": {
     "name": {
@@ -245,7 +265,9 @@
     },
     "url": {
       "en": "https://www.mpei.com/rebates"
-    }
+    },
+    "authority": "co-mountain-parks-electric",
+    "authority_type": "utility"
   },
   "co_mountainViewElectricAssociation_rebates": {
     "name": {
@@ -253,7 +275,9 @@
     },
     "url": {
       "en": "https://www.mvea.coop/save-energy-money/rebates/"
-    }
+    },
+    "authority": "co-mountain-view-electric-association",
+    "authority_type": "utility"
   },
   "co_platteRiverPowerAuthority_efficiencyWorks": {
     "name": {
@@ -261,7 +285,9 @@
     },
     "url": {
       "en": "https://efficiencyworks.org/homes/rebates/#secrebates"
-    }
+    },
+    "authority": "co-platte-river-power-authority",
+    "authority_type": "other"
   },
   "co_poudreValleyREA_rebatesForResidentialCustomers": {
     "name": {
@@ -269,7 +295,9 @@
     },
     "url": {
       "en": "https://pvrea.coop/for-members/residential-services/rebates/"
-    }
+    },
+    "authority": "co-poudre-valley-rea",
+    "authority_type": "utility"
   },
   "co_sangreDeCristoElectricAssociation_rebates": {
     "name": {
@@ -277,7 +305,9 @@
     },
     "url": {
       "en": "https://www.myelectric.coop/energy-efficiency/energy-efficiency-credit-programs/"
-    }
+    },
+    "authority": "co-sangre-de-cristo-electric-association",
+    "authority_type": "utility"
   },
   "co_sangreDeCristoElectricAssociation_saveEnergy&Money": {
     "name": {
@@ -285,7 +315,9 @@
     },
     "url": {
       "en": "https://www.myelectric.coop/energy-efficiency/energy-efficiency-credit-programs/"
-    }
+    },
+    "authority": "co-sangre-de-cristo-electric-association",
+    "authority_type": "utility"
   },
   "co_sanIsabelElectric_sanIsabelElectric": {
     "name": {
@@ -293,7 +325,9 @@
     },
     "url": {
       "en": "https://siea.com/rebates/"
-    }
+    },
+    "authority": "co-san-isabel-electric",
+    "authority_type": "utility"
   },
   "co_sanLuisValleyREC_energyEfficiencyRebateProgram": {
     "name": {
@@ -301,7 +335,9 @@
     },
     "url": {
       "en": "https://slvrec.com/rebates"
-    }
+    },
+    "authority": "co-san-luis-valley-rec",
+    "authority_type": "utility"
   },
   "co_sanMiguelPowerAssociation_residentialAndCommercialRebates": {
     "name": {
@@ -309,7 +345,9 @@
     },
     "url": {
       "en": "https://www.smpa.com/energy#berebates"
-    }
+    },
+    "authority": "co-san-miguel-power-association",
+    "authority_type": "utility"
   },
   "co_sanMiguelPowerAssociation_sMPARenewableRebates": {
     "name": {
@@ -317,7 +355,9 @@
     },
     "url": {
       "en": "https://www.smpa.com/content/renewable-rebates"
-    }
+    },
+    "authority": "co-san-miguel-power-association",
+    "authority_type": "utility"
   },
   "co_southeastColoradoPowerAssociation_tri-StateG&T": {
     "name": {
@@ -325,7 +365,9 @@
     },
     "url": {
       "en": "https://www.secpa.com/rebates"
-    }
+    },
+    "authority": "co-southeast-colorado-power-association",
+    "authority_type": "utility"
   },
   "co_stateOfColorado_coloradoHeatPumpIncentives": {
     "name": {
@@ -333,15 +375,9 @@
     },
     "url": {
       "en": "https://energysmartcolorado.org/tax-credits-incentives/"
-    }
-  },
-  "co_stateOfColorado_taxCredits": {
-    "name": {
-      "en": "Colorado Tax Credits"
     },
-    "url": {
-      "en": "https://energysmartcolorado.org/tax-credits-incentives/"
-    }
+    "authority": "co-state-of-colorado",
+    "authority_type": "state"
   },
   "co_townOfAvon_energyEfficiencyProgram": {
     "name": {
@@ -349,7 +385,9 @@
     },
     "url": {
       "en": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/"
-    }
+    },
+    "authority": "co-town-of-avon",
+    "authority_type": "city"
   },
   "co_townOfEagle_energyEfficiencyProgram": {
     "name": {
@@ -357,7 +395,9 @@
     },
     "url": {
       "en": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/"
-    }
+    },
+    "authority": "co-town-of-eagle",
+    "authority_type": "city"
   },
   "co_townOfErie_rebates": {
     "name": {
@@ -365,7 +405,9 @@
     },
     "url": {
       "en": "https://www.erieco.gov/2242/Energy-Efficiency-Rebates"
-    }
+    },
+    "authority": "co-town-of-erie",
+    "authority_type": "city"
   },
   "co_townOfVail_energyEfficiencyProgram": {
     "name": {
@@ -373,15 +415,9 @@
     },
     "url": {
       "en": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/"
-    }
-  },
-  "co_tri-StateG&T_tri-StateG&T": {
-    "name": {
-      "en": "United Power Heat Pump Rebates"
     },
-    "url": {
-      "en": "https://www.unitedpower.com/heat-pumps"
-    }
+    "authority": "co-town-of-vail",
+    "authority_type": "city"
   },
   "co_unincorporatedEagleCounty_energyEfficiencyProgram": {
     "name": {
@@ -389,7 +425,9 @@
     },
     "url": {
       "en": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/"
-    }
+    },
+    "authority": "co-unincorporated-eagle-county",
+    "authority_type": "county"
   },
   "co_unitedPower_tri-StateG&T": {
     "name": {
@@ -397,7 +435,9 @@
     },
     "url": {
       "en": "https://www.unitedpower.com/rebates"
-    }
+    },
+    "authority": "co-united-power",
+    "authority_type": "utility"
   },
   "co_walkingMountains_low-ModerateIncomeProgram": {
     "name": {
@@ -405,7 +445,9 @@
     },
     "url": {
       "en": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/"
-    }
+    },
+    "authority": "co-walking-mountains",
+    "authority_type": "other"
   },
   "co_walkingMountains_rebates&Incentives": {
     "name": {
@@ -413,7 +455,9 @@
     },
     "url": {
       "en": "https://www.walkingmountains.org/sustainability-hub/energy-efficiency-programs/rebates-incentives/"
-    }
+    },
+    "authority": "co-walking-mountains",
+    "authority_type": "other"
   },
   "co_whiteRiverElectricAssociation_rebates": {
     "name": {
@@ -421,7 +465,9 @@
     },
     "url": {
       "en": "https://www.wrea.org/rebates"
-    }
+    },
+    "authority": "co-white-river-electric-association",
+    "authority_type": "utility"
   },
   "co_xcelEnergy_eVRebate": {
     "name": {
@@ -429,7 +475,9 @@
     },
     "url": {
       "en": "https://ev.xcelenergy.com/ev-rebate-co"
-    }
+    },
+    "authority": "co-xcel-energy",
+    "authority_type": "utility"
   },
   "co_xcelEnergy_heatPumpRebates": {
     "name": {
@@ -437,7 +485,9 @@
     },
     "url": {
       "en": "https://co.my.xcelenergy.com/s/residential/heating-cooling/heat-pumps"
-    }
+    },
+    "authority": "co-xcel-energy",
+    "authority_type": "utility"
   },
   "co_xcelEnergy_heatPumpWaterHeaterRebates": {
     "name": {
@@ -445,7 +495,9 @@
     },
     "url": {
       "en": "https://co.my.xcelenergy.com/s/residential/home-rebates/water-heaters"
-    }
+    },
+    "authority": "co-xcel-energy",
+    "authority_type": "utility"
   },
   "co_y-WElectricAssociation_rebateProgram": {
     "name": {
@@ -453,6 +505,8 @@
     },
     "url": {
       "en": "https://www.ywelectric.coop/rebate-program-information"
-    }
+    },
+    "authority": "co-y-w-electric-association",
+    "authority_type": "utility"
   }
 }

--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "CT-1",
-    "authority_type": "utility",
-    "authority": "ct-eversource",
     "payment_methods": [
       "assistance_program"
     ],
@@ -26,8 +24,6 @@
   },
   {
     "id": "CT-2",
-    "authority_type": "utility",
-    "authority": "ct-eversource",
     "payment_methods": [
       "rebate"
     ],
@@ -53,8 +49,6 @@
   },
   {
     "id": "CT-3",
-    "authority_type": "utility",
-    "authority": "ct-eversource",
     "payment_methods": [
       "rebate"
     ],
@@ -78,8 +72,6 @@
   },
   {
     "id": "CT-4",
-    "authority_type": "utility",
-    "authority": "ct-united-illuminating",
     "payment_methods": [
       "assistance_program"
     ],
@@ -103,8 +95,6 @@
   },
   {
     "id": "CT-5",
-    "authority_type": "utility",
-    "authority": "ct-groton-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -131,8 +121,6 @@
   },
   {
     "id": "CT-6",
-    "authority_type": "utility",
-    "authority": "ct-groton-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -156,8 +144,6 @@
   },
   {
     "id": "CT-7",
-    "authority_type": "utility",
-    "authority": "ct-groton-utilities",
     "payment_methods": [
       "assistance_program"
     ],
@@ -179,8 +165,6 @@
   },
   {
     "id": "CT-8",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -204,8 +188,6 @@
   },
   {
     "id": "CT-9",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -231,8 +213,6 @@
   },
   {
     "id": "CT-10",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -258,8 +238,6 @@
   },
   {
     "id": "CT-11",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -286,8 +264,6 @@
   },
   {
     "id": "CT-12",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -315,8 +291,6 @@
   },
   {
     "id": "CT-13",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -340,8 +314,6 @@
   },
   {
     "id": "CT-15",
-    "authority_type": "utility",
-    "authority": "ct-united-illuminating",
     "payment_methods": [
       "rebate"
     ],
@@ -368,8 +340,6 @@
   },
   {
     "id": "CT-16",
-    "authority_type": "utility",
-    "authority": "ct-united-illuminating",
     "payment_methods": [
       "rebate"
     ],
@@ -395,8 +365,6 @@
   },
   {
     "id": "CT-17",
-    "authority_type": "utility",
-    "authority": "ct-united-illuminating",
     "payment_methods": [
       "rebate"
     ],
@@ -420,8 +388,6 @@
   },
   {
     "id": "CT-20",
-    "authority_type": "utility",
-    "authority": "ct-eversource",
     "payment_methods": [
       "rebate"
     ],
@@ -448,8 +414,6 @@
   },
   {
     "id": "CT-25",
-    "authority_type": "utility",
-    "authority": "ct-eversource",
     "payment_methods": [
       "rebate"
     ],
@@ -473,8 +437,6 @@
   },
   {
     "id": "CT-26",
-    "authority_type": "utility",
-    "authority": "ct-eversource",
     "payment_methods": [
       "rebate"
     ],
@@ -499,8 +461,6 @@
   },
   {
     "id": "CT-27",
-    "authority_type": "utility",
-    "authority": "ct-united-illuminating",
     "payment_methods": [
       "rebate"
     ],
@@ -525,8 +485,6 @@
   },
   {
     "id": "CT-28",
-    "authority_type": "utility",
-    "authority": "ct-united-illuminating",
     "payment_methods": [
       "rebate"
     ],
@@ -550,8 +508,6 @@
   },
   {
     "id": "CT-29",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -576,8 +532,6 @@
   },
   {
     "id": "CT-30",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -602,8 +556,6 @@
   },
   {
     "id": "CT-31",
-    "authority_type": "utility",
-    "authority": "ct-norwich-public-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -627,8 +579,6 @@
   },
   {
     "id": "CT-32",
-    "authority_type": "state",
-    "authority": "ct-deep",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -651,8 +601,6 @@
   },
   {
     "id": "CT-33",
-    "authority_type": "state",
-    "authority": "ct-deep",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -676,8 +624,6 @@
   },
   {
     "id": "CT-34",
-    "authority_type": "state",
-    "authority": "ct-deep",
     "payment_methods": [
       "pos_rebate",
       "rebate"

--- a/data/CT/incentives.json
+++ b/data/CT/incentives.json
@@ -9,7 +9,7 @@
     "items": [
       "other_weatherization"
     ],
-    "program": "ct_energizeCtHomeEnergySolutions",
+    "program": "ct_eversource_energizeCtHomeEnergySolutions",
     "amount": {
       "type": "percent",
       "number": 1
@@ -34,7 +34,7 @@
     "items": [
       "geothermal_heating_installation"
     ],
-    "program": "ct_residentialGroundSourceHeatPumpIncentive",
+    "program": "ct_eversource_residentialGroundSourceHeatPumpIncentive",
     "amount": {
       "type": "dollars_per_unit",
       "number": 1500,
@@ -61,7 +61,7 @@
     "items": [
       "heat_pump_water_heater"
     ],
-    "program": "ct_residentialHeatPumpWaterHeaterIncentive",
+    "program": "ct_eversource_residentialHeatPumpWaterHeaterIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 650
@@ -86,7 +86,7 @@
     "items": [
       "other_weatherization"
     ],
-    "program": "ct_energizeCtHomeEnergySolutions",
+    "program": "ct_unitedIlluminating_energizeCtHomeEnergySolutions",
     "amount": {
       "type": "percent",
       "number": 1
@@ -349,7 +349,7 @@
       "ducted_heat_pump",
       "ductless_heat_pump"
     ],
-    "program": "ct_residentialAirSourceHeatPumpIncentive",
+    "program": "ct_unitedIlluminating_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollars_per_unit",
       "number": 750,
@@ -376,7 +376,7 @@
     "items": [
       "geothermal_heating_installation"
     ],
-    "program": "ct_residentialGroundSourceHeatPumpIncentive",
+    "program": "ct_unitedIlluminating_residentialGroundSourceHeatPumpIncentive",
     "amount": {
       "type": "dollars_per_unit",
       "number": 1500,
@@ -403,7 +403,7 @@
     "items": [
       "heat_pump_water_heater"
     ],
-    "program": "ct_residentialHeatPumpWaterHeaterIncentive",
+    "program": "ct_unitedIlluminating_residentialHeatPumpWaterHeaterIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 650
@@ -429,7 +429,7 @@
       "ducted_heat_pump",
       "ductless_heat_pump"
     ],
-    "program": "ct_residentialAirSourceHeatPumpIncentive",
+    "program": "ct_eversource_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollars_per_unit",
       "number": 750,
@@ -456,7 +456,7 @@
     "items": [
       "geothermal_heating_installation"
     ],
-    "program": "ct_residentialGroundSourceHeatPumpIncentive",
+    "program": "ct_eversource_residentialGroundSourceHeatPumpIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 500
@@ -482,7 +482,7 @@
       "ducted_heat_pump",
       "ductless_heat_pump"
     ],
-    "program": "ct_residentialAirSourceHeatPumpIncentive",
+    "program": "ct_eversource_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 500
@@ -508,7 +508,7 @@
       "ducted_heat_pump",
       "ductless_heat_pump"
     ],
-    "program": "ct_residentialAirSourceHeatPumpIncentive",
+    "program": "ct_unitedIlluminating_residentialAirSourceHeatPumpIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 500
@@ -533,7 +533,7 @@
     "items": [
       "geothermal_heating_installation"
     ],
-    "program": "ct_residentialGroundSourceHeatPumpIncentive",
+    "program": "ct_unitedIlluminating_residentialGroundSourceHeatPumpIncentive",
     "amount": {
       "type": "dollar_amount",
       "number": 500

--- a/data/CT/programs.json
+++ b/data/CT/programs.json
@@ -1,4 +1,20 @@
 {
+  "ct_eversource_energizeCtHomeEnergySolutions": {
+    "name": {
+      "en": "Energize CT Home Energy Solutions"
+    },
+    "url": {
+      "en": "https://energizect.com/energy-evaluations/income-eligible-options"
+    }
+  },
+  "ct_unitedIlluminating_energizeCtHomeEnergySolutions": {
+    "name": {
+      "en": "Energize CT Home Energy Solutions"
+    },
+    "url": {
+      "en": "https://energizect.com/energy-evaluations/income-eligible-options"
+    }
+  },
   "ct_atticInsulationRebate": {
     "name": {
       "en": "Groton Utilities Attic Insulation Rebate"
@@ -47,23 +63,7 @@
       "en": "https://norwichpublicutilities.com/residential/electric-vehicle-charging-rebate-program"
     }
   },
-  "ct_energizeCtHomeEnergySolutions": {
-    "name": {
-      "en": "Energize CT Home Energy Solutions"
-    },
-    "url": {
-      "en": "https://energizect.com/energy-evaluations/income-eligible-options"
-    }
-  },
-  "ct_residentialAirSourceHeatPumpIncentive": {
-    "name": {
-      "en": "Energize CT Residential Air Source Heat Pump Incentive"
-    },
-    "url": {
-      "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source"
-    }
-  },
-  "ct_residentialGroundSourceHeatPumpIncentive": {
+  "ct_eversource_residentialGroundSourceHeatPumpIncentive": {
     "name": {
       "en": "Energize CT Residential Ground Source Heat Pump Incentive"
     },
@@ -71,7 +71,39 @@
       "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential"
     }
   },
-  "ct_residentialHeatPumpWaterHeaterIncentive": {
+  "ct_unitedIlluminating_residentialGroundSourceHeatPumpIncentive": {
+    "name": {
+      "en": "Energize CT Residential Ground Source Heat Pump Incentive"
+    },
+    "url": {
+      "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential"
+    }
+  },
+  "ct_eversource_residentialAirSourceHeatPumpIncentive": {
+    "name": {
+      "en": "Energize CT Residential Air Source Heat Pump Incentive"
+    },
+    "url": {
+      "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source"
+    }
+  },
+  "ct_unitedIlluminating_residentialAirSourceHeatPumpIncentive": {
+    "name": {
+      "en": "Energize CT Residential Air Source Heat Pump Incentive"
+    },
+    "url": {
+      "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source"
+    }
+  },
+  "ct_eversource_residentialHeatPumpWaterHeaterIncentive": {
+    "name": {
+      "en": "Energize CT Residential Heat Pump Water Heater Incentive"
+    },
+    "url": {
+      "en": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump"
+    }
+  },
+  "ct_unitedIlluminating_residentialHeatPumpWaterHeaterIncentive": {
     "name": {
       "en": "Energize CT Residential Heat Pump Water Heater Incentive"
     },

--- a/data/CT/programs.json
+++ b/data/CT/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://energizect.com/energy-evaluations/income-eligible-options"
-    }
+    },
+    "authority": "ct-eversource",
+    "authority_type": "utility"
   },
   "ct_unitedIlluminating_energizeCtHomeEnergySolutions": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://energizect.com/energy-evaluations/income-eligible-options"
-    }
+    },
+    "authority": "ct-united-illuminating",
+    "authority_type": "utility"
   },
   "ct_atticInsulationRebate": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://grotonutilities.com/240/Attic-Insulation-Rebate"
-    }
+    },
+    "authority": "ct-groton-utilities",
+    "authority_type": "utility"
   },
   "ct_cheapr": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://portal.ct.gov/DEEP/Air/Mobile-Sources/CHEAPR/CHEAPR---Home"
-    }
+    },
+    "authority": "ct-deep",
+    "authority_type": "state"
   },
   "ct_coolChoiceProgram": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://norwichpublicutilities.com/residential/efficiency-programs-rebates/#nav-anchor-to-4"
-    }
+    },
+    "authority": "ct-norwich-public-utilities",
+    "authority_type": "utility"
   },
   "ct_coolingAndHeatingIncentivePilotProgram": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://norwichpublicutilities.com/residential/chipp"
-    }
+    },
+    "authority": "ct-norwich-public-utilities",
+    "authority_type": "utility"
   },
   "ct_electricApplianceRebateProgram": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://norwichpublicutilities.com/residential/efficiency-programs-rebates/#nav-anchor-to-2"
-    }
+    },
+    "authority": "ct-norwich-public-utilities",
+    "authority_type": "utility"
   },
   "ct_electricVehicleAndChargingRebateProgram": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://norwichpublicutilities.com/residential/electric-vehicle-charging-rebate-program"
-    }
+    },
+    "authority": "ct-norwich-public-utilities",
+    "authority_type": "utility"
   },
   "ct_eversource_residentialGroundSourceHeatPumpIncentive": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential"
-    }
+    },
+    "authority": "ct-eversource",
+    "authority_type": "utility"
   },
   "ct_unitedIlluminating_residentialGroundSourceHeatPumpIncentive": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/ground-source-residential"
-    }
+    },
+    "authority": "ct-united-illuminating",
+    "authority_type": "utility"
   },
   "ct_eversource_residentialAirSourceHeatPumpIncentive": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source"
-    }
+    },
+    "authority": "ct-eversource",
+    "authority_type": "utility"
   },
   "ct_unitedIlluminating_residentialAirSourceHeatPumpIncentive": {
     "name": {
@@ -93,7 +115,9 @@
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/heating-cooling/heat-pumps/residential-air-source"
-    }
+    },
+    "authority": "ct-united-illuminating",
+    "authority_type": "utility"
   },
   "ct_eversource_residentialHeatPumpWaterHeaterIncentive": {
     "name": {
@@ -101,7 +125,9 @@
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump"
-    }
+    },
+    "authority": "ct-eversource",
+    "authority_type": "utility"
   },
   "ct_unitedIlluminating_residentialHeatPumpWaterHeaterIncentive": {
     "name": {
@@ -109,7 +135,9 @@
     },
     "url": {
       "en": "https://energizect.com/rebates-incentives/residential-water-heater/heat-pump"
-    }
+    },
+    "authority": "ct-united-illuminating",
+    "authority_type": "utility"
   },
   "ct_residentialHeatPumpWaterHeaterRebate": {
     "name": {
@@ -117,7 +145,9 @@
     },
     "url": {
       "en": "https://grotonutilities.com/243/Residential-Heat-Pump-Water-Heater-Rebat"
-    }
+    },
+    "authority": "ct-groton-utilities",
+    "authority_type": "utility"
   },
   "ct_residentialHomeEnergySavingsProgram": {
     "name": {
@@ -125,7 +155,9 @@
     },
     "url": {
       "en": "https://grotonutilities.com/237/Resident-Home-Energy-Savings-Program"
-    }
+    },
+    "authority": "ct-groton-utilities",
+    "authority_type": "utility"
   },
   "ct_wallOrAtticInsulationProgram": {
     "name": {
@@ -133,6 +165,8 @@
     },
     "url": {
       "en": "https://norwichpublicutilities.com/residential/efficiency-programs-rebates/#nav-anchor-to-3"
-    }
+    },
+    "authority": "ct-norwich-public-utilities",
+    "authority_type": "utility"
   }
 }

--- a/data/DC/incentives.json
+++ b/data/DC/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "DC-2",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "rebate"
     ],
@@ -28,8 +26,6 @@
   },
   {
     "id": "DC-4",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "rebate"
     ],
@@ -54,8 +50,6 @@
   },
   {
     "id": "DC-5",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "rebate"
     ],
@@ -80,8 +74,6 @@
   },
   {
     "id": "DC-7",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "rebate"
     ],
@@ -106,8 +98,6 @@
   },
   {
     "id": "DC-16",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "assistance_program"
     ],
@@ -133,8 +123,6 @@
   },
   {
     "id": "DC-19",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "assistance_program"
     ],
@@ -160,8 +148,6 @@
   },
   {
     "id": "DC-21",
-    "authority_type": "state",
-    "authority": "dc-dc-department-of-energy-and-environment",
     "payment_methods": [
       "assistance_program"
     ],
@@ -192,8 +178,6 @@
   },
   {
     "id": "DC-24",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "assistance_program"
     ],
@@ -219,8 +203,6 @@
   },
   {
     "id": "DC-27",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "assistance_program"
     ],
@@ -246,8 +228,6 @@
   },
   {
     "id": "DC-28",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "assistance_program"
     ],
@@ -273,8 +253,6 @@
   },
   {
     "id": "DC-29",
-    "authority_type": "city",
-    "authority": "dc-dc-sustainable-energy-utility",
     "payment_methods": [
       "rebate"
     ],

--- a/data/DC/programs.json
+++ b/data/DC/programs.json
@@ -1,27 +1,13 @@
 {
-  "dc_dCDepartmentOfEnergyAndEnvironment_LowIncomeHomeEnergyAssistanceProgram(LIHEAP)": {
-    "name": {
-      "en": " Low Income Home Energy Assistance Program (LIHEAP)"
-    },
-    "url": {
-      "en": "https://doee.dc.gov/liheap"
-    }
-  },
-  "dc_dCDepartmentOfEnergyAndEnvironment_solarForAll-CommunitySolar": {
-    "name": {
-      "en": "Solar for All - Community Solar"
-    },
-    "url": {
-      "en": "https://doee.dc.gov/solarforall"
-    }
-  },
   "dc_dCDepartmentOfEnergyAndEnvironment_weatherizationAssistanceProgram": {
     "name": {
       "en": "Weatherization Assistance Program"
     },
     "url": {
       "en": "https://doee.dc.gov/service/wap"
-    }
+    },
+    "authority": "dc-dc-department-of-energy-and-environment",
+    "authority_type": "state"
   },
   "dc_dCSustainableEnergyUtility_affordableHomeElectrificationProgram": {
     "name": {
@@ -29,7 +15,9 @@
     },
     "url": {
       "en": "https://www.dcseu.com/affordable-home-electrification"
-    }
+    },
+    "authority": "dc-dc-sustainable-energy-utility",
+    "authority_type": "city"
   },
   "dc_dCSustainableEnergyUtility_dCResidentialRebates": {
     "name": {
@@ -37,7 +25,9 @@
     },
     "url": {
       "en": "https://www.dcseu.com/homes/appliance-rebates"
-    }
+    },
+    "authority": "dc-dc-sustainable-energy-utility",
+    "authority_type": "city"
   },
   "dc_dCSustainableEnergyUtility_solarForAllSingle-FamilyProgram": {
     "name": {
@@ -45,6 +35,8 @@
     },
     "url": {
       "en": "https://www.dcseu.com/solar-for-all"
-    }
+    },
+    "authority": "dc-dc-sustainable-energy-utility",
+    "authority_type": "city"
   }
 }

--- a/data/GA/incentives.json
+++ b/data/GA/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "GA-1",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -27,8 +25,6 @@
   },
   {
     "id": "GA-2",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -53,8 +49,6 @@
   },
   {
     "id": "GA-3",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -79,8 +73,6 @@
   },
   {
     "id": "GA-4",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -105,8 +97,6 @@
   },
   {
     "id": "GA-5",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -131,8 +121,6 @@
   },
   {
     "id": "GA-6",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -157,8 +145,6 @@
   },
   {
     "id": "GA-7",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],
@@ -183,8 +169,6 @@
   },
   {
     "id": "GA-8",
-    "authority_type": "utility",
-    "authority": "ga-jefferson-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -209,8 +193,6 @@
   },
   {
     "id": "GA-9",
-    "authority_type": "utility",
-    "authority": "ga-georgia-power",
     "payment_methods": [
       "rebate"
     ],

--- a/data/GA/programs.json
+++ b/data/GA/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.georgiapower.com/residential/save-money-and-energy/products-programs/home-energy-efficiency-programs/home-energy-improvementprogram.html"
-    }
+    },
+    "authority": "ga-georgia-power",
+    "authority_type": "utility"
   },
   "ga_jeffersonEnergyCooperative_heatPumpRebateProgram": {
     "name": {
@@ -13,6 +15,8 @@
     },
     "url": {
       "en": "https://www.jec.coop/member-services/products/"
-    }
+    },
+    "authority": "ga-jefferson-energy-cooperative",
+    "authority_type": "utility"
   }
 }

--- a/data/IL/incentives.json
+++ b/data/IL/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "IL-1",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "pos_rebate",
       "rebate"
@@ -26,8 +24,6 @@
   },
   {
     "id": "IL-2",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "rebate"
     ],
@@ -50,8 +46,6 @@
   },
   {
     "id": "IL-3",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "pos_rebate",
       "rebate"
@@ -74,8 +68,6 @@
   },
   {
     "id": "IL-4",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "pos_rebate",
       "rebate"
@@ -99,8 +91,6 @@
   },
   {
     "id": "IL-5",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -123,8 +113,6 @@
   },
   {
     "id": "IL-6",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "assistance_program"
     ],
@@ -147,8 +135,6 @@
   },
   {
     "id": "IL-7",
-    "authority_type": "utility",
-    "authority": "il-commonwealth-edison",
     "payment_methods": [
       "rebate"
     ],
@@ -172,8 +158,6 @@
   },
   {
     "id": "IL-8",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -195,8 +179,6 @@
   },
   {
     "id": "IL-10",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -220,8 +202,6 @@
   },
   {
     "id": "IL-11",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -246,8 +226,6 @@
   },
   {
     "id": "IL-12",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -272,8 +250,6 @@
   },
   {
     "id": "IL-13",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -297,8 +273,6 @@
   },
   {
     "id": "IL-14",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -321,8 +295,6 @@
   },
   {
     "id": "IL-15",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -345,8 +317,6 @@
   },
   {
     "id": "IL-16",
-    "authority_type": "state",
-    "authority": "il-state-of-illinois",
     "payment_methods": [
       "assistance_program"
     ],
@@ -372,8 +342,6 @@
   },
   {
     "id": "IL-17",
-    "authority_type": "state",
-    "authority": "il-state-of-illinois",
     "payment_methods": [
       "rebate"
     ],
@@ -399,8 +367,6 @@
   },
   {
     "id": "IL-18",
-    "authority_type": "utility",
-    "authority": "il-corn-belt-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -424,8 +390,6 @@
   },
   {
     "id": "IL-19",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -450,8 +414,6 @@
   },
   {
     "id": "IL-20",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -477,8 +439,6 @@
   },
   {
     "id": "IL-21",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -503,8 +463,6 @@
   },
   {
     "id": "IL-22",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -531,8 +489,6 @@
   },
   {
     "id": "IL-23",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -557,8 +513,6 @@
   },
   {
     "id": "IL-24",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -584,8 +538,6 @@
   },
   {
     "id": "IL-25",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -612,8 +564,6 @@
   },
   {
     "id": "IL-26",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -638,8 +588,6 @@
   },
   {
     "id": "IL-27",
-    "authority_type": "utility",
-    "authority": "il-jo-carroll-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -665,8 +613,6 @@
   },
   {
     "id": "IL-28",
-    "authority_type": "utility",
-    "authority": "il-mid-american-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -692,8 +638,6 @@
   },
   {
     "id": "IL-29",
-    "authority_type": "utility",
-    "authority": "il-mid-american-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -718,8 +662,6 @@
   },
   {
     "id": "IL-30",
-    "authority_type": "utility",
-    "authority": "il-mid-american-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -745,8 +687,6 @@
   },
   {
     "id": "IL-31",
-    "authority_type": "utility",
-    "authority": "il-mid-american-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -771,8 +711,6 @@
   },
   {
     "id": "IL-32",
-    "authority_type": "utility",
-    "authority": "il-mid-american-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -797,8 +735,6 @@
   },
   {
     "id": "IL-33",
-    "authority_type": "state",
-    "authority": "il-illinois-solar-for-all",
     "payment_methods": [
       "assistance_program"
     ],
@@ -823,8 +759,6 @@
   },
   {
     "id": "IL-34",
-    "authority_type": "utility",
-    "authority": "il-ameren-illinois",
     "payment_methods": [
       "rebate"
     ],
@@ -847,8 +781,6 @@
   },
   {
     "id": "IL-35",
-    "authority_type": "utility",
-    "authority": "il-ameren-illinois",
     "payment_methods": [
       "rebate"
     ],
@@ -870,8 +802,6 @@
   },
   {
     "id": "IL-36",
-    "authority_type": "utility",
-    "authority": "il-ameren-illinois",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -893,8 +823,6 @@
   },
   {
     "id": "IL-37",
-    "authority_type": "utility",
-    "authority": "il-ameren-illinois",
     "payment_methods": [
       "rebate"
     ],
@@ -916,8 +844,6 @@
   },
   {
     "id": "IL-38",
-    "authority_type": "utility",
-    "authority": "il-ameren-illinois",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -939,8 +865,6 @@
   },
   {
     "id": "IL-39",
-    "authority_type": "utility",
-    "authority": "il-ameren-illinois",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -962,8 +886,6 @@
   },
   {
     "id": "IL-40",
-    "authority_type": "city",
-    "authority": "il-evanston-development-cooperative",
     "payment_methods": [
       "assistance_program"
     ],
@@ -986,8 +908,6 @@
   },
   {
     "id": "IL-41",
-    "authority_type": "city",
-    "authority": "il-evanston-development-cooperative",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1010,8 +930,6 @@
   },
   {
     "id": "IL-42",
-    "authority_type": "city",
-    "authority": "il-evanston-development-cooperative",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1034,8 +952,6 @@
   },
   {
     "id": "IL-43",
-    "authority_type": "city",
-    "authority": "il-evanston-development-cooperative",
     "payment_methods": [
       "assistance_program"
     ],

--- a/data/IL/programs.json
+++ b/data/IL/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.amerenillinoissavings.com/residential/energy-efficient-product-incentives/"
-    }
+    },
+    "authority": "il-ameren-illinois",
+    "authority_type": "utility"
   },
   "il_amerenIllinois_amerenInstantIncentives": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.amerenillinoissavings.com/res-incentives/"
-    }
+    },
+    "authority": "il-ameren-illinois",
+    "authority_type": "utility"
   },
   "il_commonwealthEdison_comEdApplianceRebates": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.comed.com/WaysToSave/ForYourHome/Pages/ApplianceRebates.aspx"
-    }
+    },
+    "authority": "il-commonwealth-edison",
+    "authority_type": "utility"
   },
   "il_commonwealthEdison_comEdElectricVehicleChargerAndInstallationRebate": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://www.comed.com/about-us/clean-energy/electric-vehicle-charger-and-installation-rebate"
-    }
+    },
+    "authority": "il-commonwealth-edison",
+    "authority_type": "utility"
   },
   "il_commonwealthEdison_comEdSingleFamilyHomeEnergySavings": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://www.comed.com/ways-to-save/for-your-home/home-energy-savings/single-family"
-    }
+    },
+    "authority": "il-commonwealth-edison",
+    "authority_type": "utility"
   },
   "il_cornBeltEnergy_cornBeltEnergyRebateProgram": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.cornbeltenergy.com/programs-services/rebate-program"
-    }
+    },
+    "authority": "il-corn-belt-energy",
+    "authority_type": "utility"
   },
   "il_evanstonDevelopmentCooperative_evanstonGreenHomesPilotProgram": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://greenhomes.cnt.org/"
-    }
+    },
+    "authority": "il-evanston-development-cooperative",
+    "authority_type": "city"
   },
   "il_illinoisSolarForAll_iLSFAResidentialSolarProgram": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.illinoissfa.com/programs/for-homeowners-and-building-owners/"
-    }
+    },
+    "authority": "il-illinois-solar-for-all",
+    "authority_type": "state"
   },
   "il_jo-CarrollEnergyCooperative_jCECo-OpEnergyEfficiencyIncentives": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://jcecoop.com/incentives"
-    }
+    },
+    "authority": "il-jo-carroll-energy-cooperative",
+    "authority_type": "utility"
   },
   "il_midAmericanEnergy_midAmericanEnergyResidentialInstantRebates": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://www.midamericanenergy.com/il-residential-rebates"
-    }
+    },
+    "authority": "il-mid-american-energy",
+    "authority_type": "utility"
   },
   "il_stateOfIllinois_illinoisElectricVehicleRebateProgram": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://epa.illinois.gov/topics/ceja/electric-vehicle-rebates.html"
-    }
+    },
+    "authority": "il-state-of-illinois",
+    "authority_type": "state"
   },
   "il_stateOfIllinois_illinoisHomeWeatherization": {
     "name": {
@@ -93,6 +115,8 @@
     },
     "url": {
       "en": "https://dceo.illinois.gov/communityservices/homeweatherization/howtoapply.html"
-    }
+    },
+    "authority": "il-state-of-illinois",
+    "authority_type": "state"
   }
 }

--- a/data/MI/incentives.json
+++ b/data/MI/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "MI-19",
-    "authority_type": "utility",
-    "authority": "mi-consumers-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -26,8 +24,6 @@
   },
   {
     "id": "MI-20",
-    "authority_type": "utility",
-    "authority": "mi-consumers-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -50,8 +46,6 @@
   },
   {
     "id": "MI-21",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -76,8 +70,6 @@
   },
   {
     "id": "MI-25",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -99,8 +91,6 @@
   },
   {
     "id": "MI-26",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -122,8 +112,6 @@
   },
   {
     "id": "MI-27",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -146,8 +134,6 @@
   },
   {
     "id": "MI-28",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -171,8 +157,6 @@
   },
   {
     "id": "MI-29",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -196,8 +180,6 @@
   },
   {
     "id": "MI-30",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -219,8 +201,6 @@
   },
   {
     "id": "MI-31",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -242,8 +222,6 @@
   },
   {
     "id": "MI-32",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -265,8 +243,6 @@
   },
   {
     "id": "MI-33",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -288,8 +264,6 @@
   },
   {
     "id": "MI-34",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -311,8 +285,6 @@
   },
   {
     "id": "MI-37",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -337,8 +309,6 @@
   },
   {
     "id": "MI-38",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -361,8 +331,6 @@
   },
   {
     "id": "MI-39",
-    "authority_type": "utility",
-    "authority": "mi-dte",
     "payment_methods": [
       "rebate"
     ],
@@ -388,8 +356,6 @@
   },
   {
     "id": "MI-41",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -413,8 +379,6 @@
   },
   {
     "id": "MI-42",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -438,8 +402,6 @@
   },
   {
     "id": "MI-43",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -463,8 +425,6 @@
   },
   {
     "id": "MI-44",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -489,8 +449,6 @@
   },
   {
     "id": "MI-45",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -515,8 +473,6 @@
   },
   {
     "id": "MI-46",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -541,8 +497,6 @@
   },
   {
     "id": "MI-47",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -567,8 +521,6 @@
   },
   {
     "id": "MI-48",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -593,8 +545,6 @@
   },
   {
     "id": "MI-49",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -618,8 +568,6 @@
   },
   {
     "id": "MI-51",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -645,8 +593,6 @@
   },
   {
     "id": "MI-53",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -670,8 +616,6 @@
   },
   {
     "id": "MI-54",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -695,8 +639,6 @@
   },
   {
     "id": "MI-55",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -720,8 +662,6 @@
   },
   {
     "id": "MI-56",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -745,8 +685,6 @@
   },
   {
     "id": "MI-57",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -770,8 +708,6 @@
   },
   {
     "id": "MI-58",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -795,8 +731,6 @@
   },
   {
     "id": "MI-59",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -821,8 +755,6 @@
   },
   {
     "id": "MI-60",
-    "authority_type": "utility",
-    "authority": "mi-indiana-michigan-power",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -847,8 +779,6 @@
   },
   {
     "id": "MI-65",
-    "authority_type": "utility",
-    "authority": "mi-consumers-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -872,8 +802,6 @@
   },
   {
     "id": "MI-66",
-    "authority_type": "utility",
-    "authority": "mi-great-lakes-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -897,8 +825,6 @@
   },
   {
     "id": "MI-67",
-    "authority_type": "utility",
-    "authority": "mi-indiana-michigan-power",
     "payment_methods": [
       "rebate"
     ],
@@ -922,8 +848,6 @@
   },
   {
     "id": "MI-68",
-    "authority_type": "utility",
-    "authority": "mi-upper-peninsula-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -949,8 +873,6 @@
   },
   {
     "id": "MI-69",
-    "authority_type": "utility",
-    "authority": "mi-upper-peninsula-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -972,8 +894,6 @@
   },
   {
     "id": "MI-70",
-    "authority_type": "utility",
-    "authority": "mi-upper-peninsula-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -995,8 +915,6 @@
   },
   {
     "id": "MI-71",
-    "authority_type": "utility",
-    "authority": "mi-upper-peninsula-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -1020,8 +938,6 @@
   },
   {
     "id": "MI-72",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1046,8 +962,6 @@
   },
   {
     "id": "MI-73",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1073,8 +987,6 @@
   },
   {
     "id": "MI-74",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1097,8 +1009,6 @@
   },
   {
     "id": "MI-75",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1123,8 +1033,6 @@
   },
   {
     "id": "MI-77",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1147,8 +1055,6 @@
   },
   {
     "id": "MI-78",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1172,8 +1078,6 @@
   },
   {
     "id": "MI-79",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1197,8 +1101,6 @@
   },
   {
     "id": "MI-80",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],
@@ -1220,8 +1122,6 @@
   },
   {
     "id": "MI-81",
-    "authority_type": "utility",
-    "authority": "mi-lansing-board-of-water-and-light",
     "payment_methods": [
       "rebate"
     ],

--- a/data/MI/programs.json
+++ b/data/MI/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.consumersenergy.com/residential/save-money-and-energy/rebates/heating-and-cooling"
-    }
+    },
+    "authority": "mi-consumers-energy",
+    "authority_type": "utility"
   },
   "mi_consumersEnergy_powerMIDrive™HomeChargerInstallationRebates": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.consumersenergy.com/residential/programs-and-services/electric-vehicles#savings"
-    }
+    },
+    "authority": "mi-consumers-energy",
+    "authority_type": "utility"
   },
   "mi_consumersEnergy_residentialApplianceRebateProgram": {
     "name": {
@@ -21,31 +25,9 @@
     },
     "url": {
       "en": "https://www.consumersenergy.com/-/media/CE/Documents/save%20money%20and%20energy/2020-appliance-application.pdf"
-    }
-  },
-  "mi_consumersEnergy_residentialHeating,CoolingAndWaterHeatingProgram": {
-    "name": {
-      "en": "Residential Heating, Cooling and Water Heating Program"
     },
-    "url": {
-      "en": "https://www.consumersenergy.com/-/media/CE/Documents/residential/save-money-and-energy/rebates/hvac/res-programs.pdf"
-    }
-  },
-  "mi_consumersEnergy_windowAndDoorRebates": {
-    "name": {
-      "en": "Window and Door Rebates"
-    },
-    "url": {
-      "en": "https://www.consumersenergy.com/residential/save-money-and-energy/rebates/windows-and-insulation#inwin-windows-door"
-    }
-  },
-  "mi_consumersEnergy_windowsAndInsulationRebates": {
-    "name": {
-      "en": "Windows and Insulation Rebates"
-    },
-    "url": {
-      "en": "https://www.consumersenergy.com/residential/save-money-and-energy/rebates/windows-and-insulation#insulation-rebates"
-    }
+    "authority": "mi-consumers-energy",
+    "authority_type": "utility"
   },
   "mi_dTE_airConditioners": {
     "name": {
@@ -53,7 +35,9 @@
     },
     "url": {
       "en": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/air-conditioners.html"
-    }
+    },
+    "authority": "mi-dte",
+    "authority_type": "utility"
   },
   "mi_dTE_electricVehicleRebate": {
     "name": {
@@ -61,7 +45,9 @@
     },
     "url": {
       "en": "https://www.dteenergy.com/us/en/residential/service-request/pev/electric-vehicle-rebate.html"
-    }
+    },
+    "authority": "mi-dte",
+    "authority_type": "utility"
   },
   "mi_dTE_homeEVChargerRebate": {
     "name": {
@@ -69,7 +55,9 @@
     },
     "url": {
       "en": "https://www.dteenergy.com/us/en/residential/service-request/pev/home-ev-charger-rebate.html"
-    }
+    },
+    "authority": "mi-dte",
+    "authority_type": "utility"
   },
   "mi_dTE_insulation&Windows": {
     "name": {
@@ -77,7 +65,9 @@
     },
     "url": {
       "en": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html"
-    }
+    },
+    "authority": "mi-dte",
+    "authority_type": "utility"
   },
   "mi_dTE_washers&Dryers": {
     "name": {
@@ -85,15 +75,9 @@
     },
     "url": {
       "en": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/washers-dryers.html#tabs-f1a15f985f-item-83a9b1fa23"
-    }
-  },
-  "mi_dTE_waterHeaters": {
-    "name": {
-      "en": "Water Heaters"
     },
-    "url": {
-      "en": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/water-heaters.html"
-    }
+    "authority": "mi-dte",
+    "authority_type": "utility"
   },
   "mi_dTE_wi-FiEnabledThermostats": {
     "name": {
@@ -101,7 +85,9 @@
     },
     "url": {
       "en": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/wi-fi-enabled-thermostats.html"
-    }
+    },
+    "authority": "mi-dte",
+    "authority_type": "utility"
   },
   "mi_greatLakesEnergyCooperative_energyWise": {
     "name": {
@@ -109,7 +95,9 @@
     },
     "url": {
       "en": "https://www.gtlakes.com/energy-wise/"
-    }
+    },
+    "authority": "mi-great-lakes-energy-cooperative",
+    "authority_type": "utility"
   },
   "mi_indianaMichiganPower_i&MMarketplace": {
     "name": {
@@ -117,7 +105,9 @@
     },
     "url": {
       "en": "https://electricideas.com/at-home/rebates-products/marketplace/"
-    }
+    },
+    "authority": "mi-indiana-michigan-power",
+    "authority_type": "utility"
   },
   "mi_lansingBoardOfWaterAndLight_lansingBWLElectrificationPrograms": {
     "name": {
@@ -125,7 +115,9 @@
     },
     "url": {
       "en": "https://www.lbwl.com/customers/save-money-energy/electrification-programs"
-    }
+    },
+    "authority": "mi-lansing-board-of-water-and-light",
+    "authority_type": "utility"
   },
   "mi_lansingBoardOfWaterAndLight_lansingBWLENERGYSTARApplianceRebates": {
     "name": {
@@ -133,7 +125,9 @@
     },
     "url": {
       "en": "https://www.lbwl.com/appliances"
-    }
+    },
+    "authority": "mi-lansing-board-of-water-and-light",
+    "authority_type": "utility"
   },
   "mi_lansingBoardOfWaterAndLight_lansingBWLHeatingAndCoolingRebates": {
     "name": {
@@ -141,7 +135,9 @@
     },
     "url": {
       "en": "https://www.lbwl.com/hvac"
-    }
+    },
+    "authority": "mi-lansing-board-of-water-and-light",
+    "authority_type": "utility"
   },
   "mi_lansingBoardOfWaterAndLight_lansingBWLPlug-InElectricVehicleRebates": {
     "name": {
@@ -149,7 +145,9 @@
     },
     "url": {
       "en": "https://www.lbwl.com/customers/save-money-energy/plug-electric-vehicles-pev"
-    }
+    },
+    "authority": "mi-lansing-board-of-water-and-light",
+    "authority_type": "utility"
   },
   "mi_upperPeninsulaPowerCompany_uPPCOENERGYSTAR®Program": {
     "name": {
@@ -157,7 +155,9 @@
     },
     "url": {
       "en": "https://ee.uppco.com/uppco-energy-star/"
-    }
+    },
+    "authority": "mi-upper-peninsula-power-company",
+    "authority_type": "utility"
   },
   "mi_upperPeninsulaPowerCompany_uPPCOHeatPumpRebates": {
     "name": {
@@ -165,6 +165,8 @@
     },
     "url": {
       "en": "https://ee.uppco.com/uppco-heat-pump/"
-    }
+    },
+    "authority": "mi-upper-peninsula-power-company",
+    "authority_type": "utility"
   }
 }

--- a/data/NV/incentives.json
+++ b/data/NV/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "NV-1",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -25,8 +23,6 @@
   },
   {
     "id": "NV-2",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -49,8 +45,6 @@
   },
   {
     "id": "NV-3",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -72,8 +66,6 @@
   },
   {
     "id": "NV-4",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -96,8 +88,6 @@
   },
   {
     "id": "NV-5",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -122,8 +112,6 @@
   },
   {
     "id": "NV-6",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -146,8 +134,6 @@
   },
   {
     "id": "NV-7",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -172,8 +158,6 @@
   },
   {
     "id": "NV-9",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -198,8 +182,6 @@
   },
   {
     "id": "NV-11",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -221,8 +203,6 @@
   },
   {
     "id": "NV-12",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -246,8 +226,6 @@
   },
   {
     "id": "NV-13",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -271,8 +249,6 @@
   },
   {
     "id": "NV-14",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -296,8 +272,6 @@
   },
   {
     "id": "NV-15",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -321,8 +295,6 @@
   },
   {
     "id": "NV-16",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -346,8 +318,6 @@
   },
   {
     "id": "NV-17",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "assistance_program"
     ],
@@ -371,8 +341,6 @@
   },
   {
     "id": "NV-18",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -394,8 +362,6 @@
   },
   {
     "id": "NV-19",
-    "authority_type": "utility",
-    "authority": "nv-wells-rural-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -420,8 +386,6 @@
   },
   {
     "id": "NV-20",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -445,8 +409,6 @@
   },
   {
     "id": "NV-21",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -471,8 +433,6 @@
   },
   {
     "id": "NV-22",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -494,8 +454,6 @@
   },
   {
     "id": "NV-23",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -520,8 +478,6 @@
   },
   {
     "id": "NV-24",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -547,8 +503,6 @@
   },
   {
     "id": "NV-25",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -571,8 +525,6 @@
   },
   {
     "id": "NV-26",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "assistance_program"
     ],
@@ -595,8 +547,6 @@
   },
   {
     "id": "NV-27",
-    "authority_type": "utility",
-    "authority": "nv-lincoln-county-power-district-no-1",
     "payment_methods": [
       "rebate"
     ],
@@ -619,8 +569,6 @@
   },
   {
     "id": "NV-28",
-    "authority_type": "utility",
-    "authority": "nv-lincoln-county-power-district-no-1",
     "payment_methods": [
       "rebate"
     ],
@@ -643,8 +591,6 @@
   },
   {
     "id": "NV-29",
-    "authority_type": "utility",
-    "authority": "nv-lincoln-county-power-district-no-1",
     "payment_methods": [
       "rebate"
     ],
@@ -666,8 +612,6 @@
   },
   {
     "id": "NV-30",
-    "authority_type": "utility",
-    "authority": "nv-lincoln-county-power-district-no-1",
     "payment_methods": [
       "rebate"
     ],
@@ -689,8 +633,6 @@
   },
   {
     "id": "NV-31",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -717,8 +659,6 @@
   },
   {
     "id": "NV-32",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -745,8 +685,6 @@
   },
   {
     "id": "NV-33",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -770,8 +708,6 @@
   },
   {
     "id": "NV-34",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -795,8 +731,6 @@
   },
   {
     "id": "NV-35",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -820,8 +754,6 @@
   },
   {
     "id": "NV-36",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -845,8 +777,6 @@
   },
   {
     "id": "NV-37",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -870,8 +800,6 @@
   },
   {
     "id": "NV-38",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -897,8 +825,6 @@
   },
   {
     "id": "NV-39",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -925,8 +851,6 @@
   },
   {
     "id": "NV-40",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -953,8 +877,6 @@
   },
   {
     "id": "NV-41",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -981,8 +903,6 @@
   },
   {
     "id": "NV-42",
-    "authority_type": "utility",
-    "authority": "nv-mt-wheeler-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1006,8 +926,6 @@
   },
   {
     "id": "NV-43",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1032,8 +950,6 @@
   },
   {
     "id": "NV-44",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1058,8 +974,6 @@
   },
   {
     "id": "NV-45",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1083,8 +997,6 @@
   },
   {
     "id": "NV-46",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1108,8 +1020,6 @@
   },
   {
     "id": "NV-47",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1134,8 +1044,6 @@
   },
   {
     "id": "NV-48",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1159,8 +1067,6 @@
   },
   {
     "id": "NV-49",
-    "authority_type": "utility",
-    "authority": "nv-city-of-boulder-city",
     "payment_methods": [
       "rebate"
     ],
@@ -1184,8 +1090,6 @@
   },
   {
     "id": "NV-50",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1208,8 +1112,6 @@
   },
   {
     "id": "NV-51",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1232,8 +1134,6 @@
   },
   {
     "id": "NV-52",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1256,8 +1156,6 @@
   },
   {
     "id": "NV-53",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1280,8 +1178,6 @@
   },
   {
     "id": "NV-54",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1304,8 +1200,6 @@
   },
   {
     "id": "NV-55",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1328,8 +1222,6 @@
   },
   {
     "id": "NV-56",
-    "authority_type": "utility",
-    "authority": "nv-raft-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1353,8 +1245,6 @@
   },
   {
     "id": "NV-59",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1379,8 +1269,6 @@
   },
   {
     "id": "NV-60",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1405,8 +1293,6 @@
   },
   {
     "id": "NV-61",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1431,8 +1317,6 @@
   },
   {
     "id": "NV-62",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1457,8 +1341,6 @@
   },
   {
     "id": "NV-63",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1483,8 +1365,6 @@
   },
   {
     "id": "NV-64",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1509,8 +1389,6 @@
   },
   {
     "id": "NV-65",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1535,8 +1413,6 @@
   },
   {
     "id": "NV-66",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1561,8 +1437,6 @@
   },
   {
     "id": "NV-67",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1587,8 +1461,6 @@
   },
   {
     "id": "NV-68",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1612,8 +1484,6 @@
   },
   {
     "id": "NV-69",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1638,8 +1508,6 @@
   },
   {
     "id": "NV-70",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1664,8 +1532,6 @@
   },
   {
     "id": "NV-71",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1691,8 +1557,6 @@
   },
   {
     "id": "NV-72",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1717,8 +1581,6 @@
   },
   {
     "id": "NV-73",
-    "authority_type": "utility",
-    "authority": "nv-plumas-sierra-rural-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1743,8 +1605,6 @@
   },
   {
     "id": "NV-74",
-    "authority_type": "other",
-    "authority": "nv-csa-reno",
     "eligible_geo_group": "nv-group-csa-reno",
     "payment_methods": [
       "assistance_program"
@@ -1769,8 +1629,6 @@
   },
   {
     "id": "NV-75",
-    "authority_type": "other",
-    "authority": "nv-rural-nevada-development-corporation",
     "eligible_geo_group": "nv-group-rural-nevada-development-corporation",
     "payment_methods": [
       "assistance_program"
@@ -1795,8 +1653,6 @@
   },
   {
     "id": "NV-76",
-    "authority_type": "other",
-    "authority": "nv-nevada-rural-housing",
     "eligible_geo_group": "nv-group-nevada-rural-housing",
     "payment_methods": [
       "assistance_program"
@@ -1821,8 +1677,6 @@
   },
   {
     "id": "NV-77",
-    "authority_type": "other",
-    "authority": "nv-help-of-southern-nevada",
     "eligible_geo_group": "nv-group-help-of-southern-nevada",
     "payment_methods": [
       "assistance_program"
@@ -1847,8 +1701,6 @@
   },
   {
     "id": "NV-78",
-    "authority_type": "utility",
-    "authority": "nv-nv-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1874,8 +1726,6 @@
   },
   {
     "id": "NV-79",
-    "authority_type": "other",
-    "authority": "nv-nevada-rural-housing",
     "eligible_geo_group": "nv-group-nevada-rural-housing-north-lv",
     "payment_methods": [
       "assistance_program"

--- a/data/NV/programs.json
+++ b/data/NV/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://bcnv.org/284/Utility-Rebate-Program"
-    }
+    },
+    "authority": "nv-city-of-boulder-city",
+    "authority_type": "utility"
   },
   "nv_cSAReno_weatherizationAssistanceProgram": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.csareno.org/Energy-Efficiency-Weatherization"
-    }
+    },
+    "authority": "nv-csa-reno",
+    "authority_type": "other"
   },
   "nv_hELPOfSouthernNevada_weatherizationAssistanceProgram": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.helpsonv.org/weatherization"
-    }
+    },
+    "authority": "nv-help-of-southern-nevada",
+    "authority_type": "other"
   },
   "nv_lincolnCountyPowerDistrictNo1_residentialAndCommercialHighEfficiencyAirConditioningAndHeatPumpRebate": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://lcpd1.com/form/hvac-rebate-application"
-    }
+    },
+    "authority": "nv-lincoln-county-power-district-no-1",
+    "authority_type": "utility"
   },
   "nv_mtWheelerPower_airAndHeatRebates": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://www.mwpower.net/sites/default/files/Air%20%26%20Heat%20Rebate%20Application%20revised%201-2024_0.pdf"
-    }
+    },
+    "authority": "nv-mt-wheeler-power",
+    "authority_type": "utility"
   },
   "nv_mtWheelerPower_appliancesRebates": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.mwpower.net/sites/default/files/Appliances%20Rebate%20Application%20-%20updated%209-2022.pdf"
-    }
+    },
+    "authority": "nv-mt-wheeler-power",
+    "authority_type": "utility"
   },
   "nv_mtWheelerPower_hybridWaterHeaterRebate": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.mwpower.net/sites/default/files/Hybrid%20Water%20Heater%20Rebate%20Application%20updated%20%2011-2022.pdf"
-    }
+    },
+    "authority": "nv-mt-wheeler-power",
+    "authority_type": "utility"
   },
   "nv_mtWheelerPower_renewableEnergyGenerationRebates": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.mwpower.net/sites/default/files/Renewable%20Energy%20Generation%20Rebate%20Application%20-revised%209-2022.pdf"
-    }
+    },
+    "authority": "nv-mt-wheeler-power",
+    "authority_type": "utility"
   },
   "nv_mtWheelerPower_windowsAndInsulationRebates": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://www.mwpower.net/sites/default/files/WINDOW%20%26%20INSULATION%20REBATE%20Application%20revised%209-2022.pdf"
-    }
+    },
+    "authority": "nv-mt-wheeler-power",
+    "authority_type": "utility"
   },
   "nv_nevadaRuralHousing_weatherizationAssistanceProgram": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://nvrural.org/programs/weatherization/"
-    }
+    },
+    "authority": "nv-nevada-rural-housing",
+    "authority_type": "other"
   },
   "nv_nVEnergy_nVEnergyHeatPumpWaterHeating": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/water-heating"
-    }
+    },
+    "authority": "nv-nv-energy",
+    "authority_type": "utility"
   },
   "nv_nVEnergy_nVEnergyHomeImprovements": {
     "name": {
@@ -93,7 +115,9 @@
     },
     "url": {
       "en": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/home-improvements"
-    }
+    },
+    "authority": "nv-nv-energy",
+    "authority_type": "utility"
   },
   "nv_nVEnergy_nVEnergyQualifiedApplianceReplacementProgram": {
     "name": {
@@ -101,7 +125,9 @@
     },
     "url": {
       "en": "https://www.nvenergy.com/save-with-powershift/qualified-appliance-replacement"
-    }
+    },
+    "authority": "nv-nv-energy",
+    "authority_type": "utility"
   },
   "nv_nVEnergy_nVEnergyResidentialAirConditioning": {
     "name": {
@@ -109,7 +135,9 @@
     },
     "url": {
       "en": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/residential-ac-and-mid-stream/residential-air-conditioning"
-    }
+    },
+    "authority": "nv-nv-energy",
+    "authority_type": "utility"
   },
   "nv_nVEnergy_nVEnergyResidentialAppliancesAndProducts": {
     "name": {
@@ -117,7 +145,9 @@
     },
     "url": {
       "en": "https://www.nvenergy.com/save-with-powershift/home-energy-saver/retail-appliances-and-products"
-    }
+    },
+    "authority": "nv-nv-energy",
+    "authority_type": "utility"
   },
   "nv_nVEnergy_nVEnergyResidentialSmartThermostatProgram": {
     "name": {
@@ -125,7 +155,9 @@
     },
     "url": {
       "en": "https://www.nvenergy.com/save-with-powershift/smart-thermostat"
-    }
+    },
+    "authority": "nv-nv-energy",
+    "authority_type": "utility"
   },
   "nv_plumas-SierraRuralElectricCooperative_rebates": {
     "name": {
@@ -133,7 +165,9 @@
     },
     "url": {
       "en": "https://www.psrec.coop/energy/rebates/"
-    }
+    },
+    "authority": "nv-plumas-sierra-rural-electric-cooperative",
+    "authority_type": "utility"
   },
   "nv_raftRuralElectricCooperative_energyEfficiencyRebate": {
     "name": {
@@ -141,7 +175,9 @@
     },
     "url": {
       "en": "https://www.rrelectric.com/member-services/energy-efficiency/energy-efficiency-rebates/"
-    }
+    },
+    "authority": "nv-raft-rural-electric-cooperative",
+    "authority_type": "utility"
   },
   "nv_ruralNevadaDevelopmentCorporation_weatherizationAssistanceProgram": {
     "name": {
@@ -149,7 +185,9 @@
     },
     "url": {
       "en": "https://rndcnv.org/weatherization-services-rural-nevada-development-corporation/"
-    }
+    },
+    "authority": "nv-rural-nevada-development-corporation",
+    "authority_type": "other"
   },
   "nv_wellsRuralElectric_saveEnergy,SaveMoney": {
     "name": {
@@ -157,6 +195,8 @@
     },
     "url": {
       "en": "https://www.wrec.coop/save-energy-save-money/rebates/"
-    }
+    },
+    "authority": "nv-wells-rural-electric",
+    "authority_type": "utility"
   }
 }

--- a/data/NY/incentives.json
+++ b/data/NY/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "NY-27",
-    "authority_type": "state",
-    "authority": "ny-nyserda",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -26,8 +24,6 @@
   },
   {
     "id": "NY-28",
-    "authority_type": "state",
-    "authority": "ny-nyserda",
     "payment_methods": [
       "pos_rebate"
     ],

--- a/data/NY/programs.json
+++ b/data/NY/programs.json
@@ -1,58 +1,12 @@
 {
-  "ny_allElectricHomesProgram": {
-    "name": {
-      "en": "All Electric Homes Program"
-    },
-    "url": {
-      "en": "https://homeenergy.pseg.com"
-    }
-  },
-  "ny_cleanHeatIncentives": {
-    "name": {
-      "en": "New York State Clean Heat Program"
-    },
-    "url": {
-      "en": "https://cleanheat.ny.gov"
-    }
-  },
-  "ny_comfortHomeProgram": {
-    "name": {
-      "en": "New York State Comfort Home Program"
-    },
-    "url": {
-      "en": "https://www.nyserda.ny.gov/All-Programs/Comfort-Home-Program"
-    }
-  },
-  "ny_consolidatedEdisonRebates": {
-    "name": {
-      "en": "Consolidated Edison Rebates"
-    },
-    "url": {
-      "en": "https://www.coned.com/en/save-money/rebates-incentives-tax-credits/rebates-incentives-tax-credits-for-residential-customers"
-    }
-  },
   "ny_empower+": {
     "name": {
       "en": "EmPower+"
     },
     "url": {
       "en": "https://www.nyserda.ny.gov/All-Programs/EmPower-New-York-Program"
-    }
-  },
-  "ny_nyStateDriveCleanProgram": {
-    "name": {
-      "en": "NY State Drive Clean Program"
     },
-    "url": {
-      "en": "https://www.nyserda.ny.gov/All-Programs/Drive-Clean-Rebate-For-Electric-Cars-Program/How-it-Works"
-    }
-  },
-  "ny_nyStateResidentialTaxCredit": {
-    "name": {
-      "en": "NY State Residential Tax Credit"
-    },
-    "url": {
-      "en": "https://www.tax.ny.gov/pit/credits/geothermal-energy-system-credit.htm"
-    }
+    "authority": "ny-nyserda",
+    "authority_type": "state"
   }
 }

--- a/data/OR/incentives.json
+++ b/data/OR/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "OR-1",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -24,8 +22,6 @@
   },
   {
     "id": "OR-2",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -48,8 +44,6 @@
   },
   {
     "id": "OR-3",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -71,8 +65,6 @@
   },
   {
     "id": "OR-4",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -94,8 +86,6 @@
   },
   {
     "id": "OR-5",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -119,8 +109,6 @@
   },
   {
     "id": "OR-6",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -143,8 +131,6 @@
   },
   {
     "id": "OR-7",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -167,8 +153,6 @@
   },
   {
     "id": "OR-8",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -190,8 +174,6 @@
   },
   {
     "id": "OR-9",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -212,8 +194,6 @@
   },
   {
     "id": "OR-10",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -234,8 +214,6 @@
   },
   {
     "id": "OR-11",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -258,8 +236,6 @@
   },
   {
     "id": "OR-12",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -282,8 +258,6 @@
   },
   {
     "id": "OR-13",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -307,8 +281,6 @@
   },
   {
     "id": "OR-14",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -332,8 +304,6 @@
   },
   {
     "id": "OR-15",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -357,8 +327,6 @@
   },
   {
     "id": "OR-16",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -382,8 +350,6 @@
   },
   {
     "id": "OR-17",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -405,8 +371,6 @@
   },
   {
     "id": "OR-18",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -428,8 +392,6 @@
   },
   {
     "id": "OR-19",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -451,8 +413,6 @@
   },
   {
     "id": "OR-20",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -475,8 +435,6 @@
   },
   {
     "id": "OR-21",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -498,8 +456,6 @@
   },
   {
     "id": "OR-22",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -521,8 +477,6 @@
   },
   {
     "id": "OR-23",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -545,8 +499,6 @@
   },
   {
     "id": "OR-24",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -568,8 +520,6 @@
   },
   {
     "id": "OR-25",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -592,8 +542,6 @@
   },
   {
     "id": "OR-26",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -616,8 +564,6 @@
   },
   {
     "id": "OR-27",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -639,8 +585,6 @@
   },
   {
     "id": "OR-28",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -663,8 +607,6 @@
   },
   {
     "id": "OR-29",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "rebate"
     ],
@@ -686,8 +628,6 @@
   },
   {
     "id": "OR-32",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -709,8 +649,6 @@
   },
   {
     "id": "OR-33",
-    "authority_type": "state",
-    "authority": "or-energy-trust-of-oregon",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -731,8 +669,6 @@
   },
   {
     "id": "OR-34",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -754,8 +690,6 @@
   },
   {
     "id": "OR-35",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -777,8 +711,6 @@
   },
   {
     "id": "OR-36",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -801,8 +733,6 @@
   },
   {
     "id": "OR-37",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -825,8 +755,6 @@
   },
   {
     "id": "OR-38",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -847,8 +775,6 @@
   },
   {
     "id": "OR-39",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -870,8 +796,6 @@
   },
   {
     "id": "OR-40",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -893,8 +817,6 @@
   },
   {
     "id": "OR-41",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -917,8 +839,6 @@
   },
   {
     "id": "OR-42",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -939,8 +859,6 @@
   },
   {
     "id": "OR-43",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -961,8 +879,6 @@
   },
   {
     "id": "OR-44",
-    "authority_type": "utility",
-    "authority": "or-portland-general-electric",
     "payment_methods": [
       "rebate"
     ],
@@ -983,8 +899,6 @@
   },
   {
     "id": "OR-45",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1005,8 +919,6 @@
   },
   {
     "id": "OR-46",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1027,8 +939,6 @@
   },
   {
     "id": "OR-47",
-    "authority_type": "utility",
-    "authority": "or-pacific-power",
     "payment_methods": [
       "rebate"
     ],

--- a/data/OR/programs.json
+++ b/data/OR/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/residential/incentives"
-    }
+    },
+    "authority": "or-energy-trust-of-oregon",
+    "authority_type": "state"
   },
   "or_energyTrustOfOregon_extendedCapacityHeatPump": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/residential/incentives"
-    }
+    },
+    "authority": "or-energy-trust-of-oregon",
+    "authority_type": "state"
   },
   "or_energyTrustOfOregon_savingsWithinReach": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/residential/incentives"
-    }
+    },
+    "authority": "or-energy-trust-of-oregon",
+    "authority_type": "state"
   },
   "or_pacificPower_extendedCapacityHeatPumpRegionalPromotion": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/residential/incentives/furnace-and-heat-pump/all"
-    }
+    },
+    "authority": "or-pacific-power",
+    "authority_type": "utility"
   },
   "or_pacificPower_heatPumpRegionalPromotion": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/residential/incentives/furnace-and-heat-pump/all"
-    }
+    },
+    "authority": "or-pacific-power",
+    "authority_type": "utility"
   },
   "or_pacificPower_pacificPowerRebates": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.pacificpower.net/savings-energy-choices/electric-vehicles/home-charger-rebates.html"
-    }
+    },
+    "authority": "or-pacific-power",
+    "authority_type": "utility"
   },
   "or_pacificPower_solarForYourHome": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/incentives/solar-for-your-home"
-    }
+    },
+    "authority": "or-pacific-power",
+    "authority_type": "utility"
   },
   "or_pacificPower_solarWithinReach": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/incentives/solar-within-reach"
-    }
+    },
+    "authority": "or-pacific-power",
+    "authority_type": "utility"
   },
   "or_portlandGeneralElectric_pGESmartChargingProgram": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://portlandgeneral.com/energy-choices/electric-vehicles-charging/charging-your-ev/charging-your-ev-at-home"
-    }
+    },
+    "authority": "or-portland-general-electric",
+    "authority_type": "utility"
   },
   "or_portlandGeneralElectric_pGESmartThermostatProgram": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://portlandgeneral.com/save-money/save-money-home/smart-thermostat-program"
-    }
+    },
+    "authority": "or-portland-general-electric",
+    "authority_type": "utility"
   },
   "or_portlandGeneralElectric_solarForYourHome": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://www.energytrust.org/incentives/solar-for-your-home"
-    }
+    },
+    "authority": "or-portland-general-electric",
+    "authority_type": "utility"
   },
   "or_portlandGeneralElectric_solarWithinReach": {
     "name": {
@@ -93,6 +115,8 @@
     },
     "url": {
       "en": "https://www.energytrust.org/incentives/solar-within-reach"
-    }
+    },
+    "authority": "or-portland-general-electric",
+    "authority_type": "utility"
   }
 }

--- a/data/PA/incentives.json
+++ b/data/PA/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "PA-1",
-    "authority_type": "state",
-    "authority": "pa-pennsylvania-department-of-community-and-economic-development",
     "payment_methods": [
       "assistance_program"
     ],
@@ -26,8 +24,6 @@
   },
   {
     "id": "PA-2",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "assistance_program"
     ],
@@ -51,8 +47,6 @@
   },
   {
     "id": "PA-3",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -79,8 +73,6 @@
   },
   {
     "id": "PA-4",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -105,8 +97,6 @@
   },
   {
     "id": "PA-5",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -131,8 +121,6 @@
   },
   {
     "id": "PA-6",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -156,8 +144,6 @@
   },
   {
     "id": "PA-7",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -181,8 +167,6 @@
   },
   {
     "id": "PA-8",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -206,8 +190,6 @@
   },
   {
     "id": "PA-9",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -233,8 +215,6 @@
   },
   {
     "id": "PA-10",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -263,8 +243,6 @@
   },
   {
     "id": "PA-15",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -289,8 +267,6 @@
   },
   {
     "id": "PA-16",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -315,8 +291,6 @@
   },
   {
     "id": "PA-17",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -341,8 +315,6 @@
   },
   {
     "id": "PA-18",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -367,8 +339,6 @@
   },
   {
     "id": "PA-19",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -395,8 +365,6 @@
   },
   {
     "id": "PA-20",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "pos_rebate"
@@ -421,8 +389,6 @@
   },
   {
     "id": "PA-21",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "pos_rebate"
@@ -449,8 +415,6 @@
   },
   {
     "id": "PA-23",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "pos_rebate"
@@ -475,8 +439,6 @@
   },
   {
     "id": "PA-24",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -502,8 +464,6 @@
   },
   {
     "id": "PA-25",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "rebate"
@@ -530,8 +490,6 @@
   },
   {
     "id": "PA-26",
-    "authority_type": "other",
-    "authority": "pa-first-energy",
     "eligible_geo_group": "pa-group-first-energy",
     "payment_methods": [
       "assistance_program"
@@ -556,8 +514,6 @@
   },
   {
     "id": "PA-27",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -579,8 +535,6 @@
   },
   {
     "id": "PA-29",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -603,8 +557,6 @@
   },
   {
     "id": "PA-30",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -629,8 +581,6 @@
   },
   {
     "id": "PA-31",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -655,8 +605,6 @@
   },
   {
     "id": "PA-34",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -680,8 +628,6 @@
   },
   {
     "id": "PA-35",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -703,8 +649,6 @@
   },
   {
     "id": "PA-36",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -727,8 +671,6 @@
   },
   {
     "id": "PA-37",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -753,8 +695,6 @@
   },
   {
     "id": "PA-38",
-    "authority_type": "utility",
-    "authority": "pa-ppl-electric-utilities-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -777,8 +717,6 @@
   },
   {
     "id": "PA-39",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "rebate"
     ],
@@ -802,8 +740,6 @@
   },
   {
     "id": "PA-40",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "rebate"
     ],
@@ -827,8 +763,6 @@
   },
   {
     "id": "PA-41",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "rebate"
     ],
@@ -852,8 +786,6 @@
   },
   {
     "id": "PA-42",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -877,8 +809,6 @@
   },
   {
     "id": "PA-43",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "rebate"
     ],
@@ -904,8 +834,6 @@
   },
   {
     "id": "PA-44",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "rebate"
     ],
@@ -930,8 +858,6 @@
   },
   {
     "id": "PA-45",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -957,8 +883,6 @@
   },
   {
     "id": "PA-46",
-    "authority_type": "utility",
-    "authority": "pa-duquesne-light-company",
     "payment_methods": [
       "rebate"
     ],
@@ -984,8 +908,6 @@
   },
   {
     "id": "PA-47",
-    "authority_type": "state",
-    "authority": "pa-pennsylvania-department-of-environmental-protection",
     "payment_methods": [
       "rebate"
     ],
@@ -1015,8 +937,6 @@
   },
   {
     "id": "PA-48",
-    "authority_type": "state",
-    "authority": "pa-pennsylvania-department-of-environmental-protection",
     "payment_methods": [
       "rebate"
     ],
@@ -1046,8 +966,6 @@
   },
   {
     "id": "PA-49",
-    "authority_type": "state",
-    "authority": "pa-pennsylvania-department-of-environmental-protection",
     "payment_methods": [
       "rebate"
     ],
@@ -1076,8 +994,6 @@
   },
   {
     "id": "PA-50",
-    "authority_type": "state",
-    "authority": "pa-pennsylvania-department-of-environmental-protection",
     "payment_methods": [
       "rebate"
     ],
@@ -1106,8 +1022,6 @@
   },
   {
     "id": "PA-51",
-    "authority_type": "utility",
-    "authority": "pa-ugi-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -1131,8 +1045,6 @@
   },
   {
     "id": "PA-52",
-    "authority_type": "utility",
-    "authority": "pa-ugi-utilities",
     "payment_methods": [
       "rebate"
     ],
@@ -1154,8 +1066,6 @@
   },
   {
     "id": "PA-53",
-    "authority_type": "utility",
-    "authority": "pa-peco",
     "payment_methods": [
       "rebate"
     ],

--- a/data/PA/programs.json
+++ b/data/PA/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://frontdoor.portal.poweredbyefi.org/initiative/duqpev"
-    }
+    },
+    "authority": "pa-duquesne-light-company",
+    "authority_type": "utility"
   },
   "pa_duquesneLightCompany_duquesneEnergyEfficiencyRebateProgram": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://duquesne.clearesult.com/"
-    }
+    },
+    "authority": "pa-duquesne-light-company",
+    "authority_type": "utility"
   },
   "pa_duquesneLightCompany_duquesneHomeWeatherization": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://duquesnelight.com/account-billing/payment-assistance/income-eligible-energy-assessment"
-    }
+    },
+    "authority": "pa-duquesne-light-company",
+    "authority_type": "utility"
   },
   "pa_firstEnergy_firstEnergyWARMProgram": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://www.firstenergycorp.com/save_energy/save_energy_pennsylvania/met_ed/for_your_home/warm-info.html"
-    }
+    },
+    "authority": "pa-first-energy",
+    "authority_type": "other"
   },
   "pa_firstEnergy_residentialProductsRebateProgram": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://rebates.energysavepa.com/"
-    }
+    },
+    "authority": "pa-first-energy",
+    "authority_type": "other"
   },
   "pa_pECO_applianceRebates": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.peco.com/ways-to-save/for-your-home/rebates-discounts/appliance-rebates"
-    }
+    },
+    "authority": "pa-peco",
+    "authority_type": "utility"
   },
   "pa_pECO_heating&CoolingRebates": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.peco.com/ways-to-save/for-your-home/rebates-discounts/heating-cooling-rebates"
-    }
+    },
+    "authority": "pa-peco",
+    "authority_type": "utility"
   },
   "pa_pECO_pECODriverRebates": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.peco.com/smart-energy/innovation-technology/electric-vehicles-l3"
-    }
+    },
+    "authority": "pa-peco",
+    "authority_type": "utility"
   },
   "pa_pECO_waterHeatingRebates": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://www.peco.com/ways-to-save/for-your-home/rebates-discounts/water-heater-rebates"
-    }
+    },
+    "authority": "pa-peco",
+    "authority_type": "utility"
   },
   "pa_pennsylvaniaDepartmentOfCommunityAndEconomicDevelopment_pennsylvaniaWeatherizationAssistanceProgram": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://dced.pa.gov/programs/weatherization-assistance-program-wap/"
-    }
+    },
+    "authority": "pa-pennsylvania-department-of-community-and-economic-development",
+    "authority_type": "state"
   },
   "pa_pennsylvaniaDepartmentOfEnvironmentalProtection_alternativeFuelVehicleRebates": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx"
-    }
+    },
+    "authority": "pa-pennsylvania-department-of-environmental-protection",
+    "authority_type": "state"
   },
   "pa_pPLElectricUtilitiesCorp_products&Rebates": {
     "name": {
@@ -93,7 +115,9 @@
     },
     "url": {
       "en": "https://www.pplelectricsavings.com/ppl/homeequipment/products"
-    }
+    },
+    "authority": "pa-ppl-electric-utilities-corp",
+    "authority_type": "utility"
   },
   "pa_uGIUtilities_applianceRebateProgram": {
     "name": {
@@ -101,7 +125,9 @@
     },
     "url": {
       "en": "https://www.ugi.com/rebates-for-home/electric/appliance-rebate-program"
-    }
+    },
+    "authority": "pa-ugi-utilities",
+    "authority_type": "utility"
   },
   "pa_uGIUtilities_equipmentRebateProgram": {
     "name": {
@@ -109,6 +135,8 @@
     },
     "url": {
       "en": "https://www.ugi.com/rebates-for-home/electric/equipment-rebate-program"
-    }
+    },
+    "authority": "pa-ugi-utilities",
+    "authority_type": "utility"
   }
 }

--- a/data/RI/incentives.json
+++ b/data/RI/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "RI-1",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -29,8 +27,6 @@
   },
   {
     "id": "RI-2",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -54,8 +50,6 @@
   },
   {
     "id": "RI-3",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -77,8 +71,6 @@
   },
   {
     "id": "RI-4",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "rebate"
     ],
@@ -103,8 +95,6 @@
   },
   {
     "id": "RI-5",
-    "authority_type": "utility",
-    "authority": "ri-block-island-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -129,8 +119,6 @@
   },
   {
     "id": "RI-6",
-    "authority_type": "utility",
-    "authority": "ri-block-island-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -154,8 +142,6 @@
   },
   {
     "id": "RI-7",
-    "authority_type": "utility",
-    "authority": "ri-block-island-power-company",
     "payment_methods": [
       "rebate"
     ],
@@ -181,8 +167,6 @@
   },
   {
     "id": "RI-9",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -207,8 +191,6 @@
   },
   {
     "id": "RI-10",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -233,8 +215,6 @@
   },
   {
     "id": "RI-11",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -260,8 +240,6 @@
   },
   {
     "id": "RI-12",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -287,8 +265,6 @@
   },
   {
     "id": "RI-13",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -314,8 +290,6 @@
   },
   {
     "id": "RI-14",
-    "authority_type": "state",
-    "authority": "ri-dhs",
     "payment_methods": [
       "assistance_program"
     ],
@@ -339,8 +313,6 @@
   },
   {
     "id": "RI-19",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -362,8 +334,6 @@
   },
   {
     "id": "RI-20",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -389,8 +359,6 @@
   },
   {
     "id": "RI-21",
-    "authority_type": "state",
-    "authority": "ri-commerce-corp",
     "payment_methods": [
       "rebate"
     ],
@@ -415,8 +383,6 @@
   },
   {
     "id": "RI-27",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "assistance_program"
     ],
@@ -439,8 +405,6 @@
   },
   {
     "id": "RI-30",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -465,8 +429,6 @@
   },
   {
     "id": "RI-31",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -490,8 +452,6 @@
   },
   {
     "id": "RI-32",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -513,8 +473,6 @@
   },
   {
     "id": "RI-33",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -538,8 +496,6 @@
   },
   {
     "id": "RI-34",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -564,8 +520,6 @@
   },
   {
     "id": "RI-35",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],
@@ -589,8 +543,6 @@
   },
   {
     "id": "RI-37",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -616,8 +568,6 @@
   },
   {
     "id": "RI-39",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -643,8 +593,6 @@
   },
   {
     "id": "RI-40",
-    "authority_type": "utility",
-    "authority": "ri-rhode-island-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -669,8 +617,6 @@
   },
   {
     "id": "RI-41",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "rebate"
     ],
@@ -693,8 +639,6 @@
   },
   {
     "id": "RI-42",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "rebate"
     ],
@@ -717,8 +661,6 @@
   },
   {
     "id": "RI-43",
-    "authority_type": "state",
-    "authority": "ri-oer",
     "payment_methods": [
       "rebate"
     ],

--- a/data/RI/programs.json
+++ b/data/RI/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://blockislandpowercompany.com/efficiency-program/"
-    }
+    },
+    "authority": "ri-block-island-power-company",
+    "authority_type": "utility"
   },
   "ri_commerceCorp_smallScaleSolarProgram": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://energy.ri.gov/sites/g/files/xkgbur741/files/2023-03/REF-Small-Scale-Flyer-1.18.22.pdf"
-    }
+    },
+    "authority": "ri-commerce-corp",
+    "authority_type": "state"
   },
   "ri_dHS_weatherizationAssistanceProgram": {
     "name": {
@@ -21,15 +25,9 @@
     },
     "url": {
       "en": "https://dhs.ri.gov/programs-and-services/energy-assistance-programs/weatherization-assistance-program-wap"
-    }
-  },
-  "ri_erikaNiedowskiMemorialEBikeRebateProgram": {
-    "name": {
-      "en": "Erika Niedowski Memorial Electric Bicycle Rebate Program"
     },
-    "url": {
-      "en": "https://drive.ri.gov/erika-niedowski-memorial-electric-bicycle-rebate-program"
-    }
+    "authority": "ri-dhs",
+    "authority_type": "state"
   },
   "ri_oER_cleanHeatRhodeIslandResidentialIncentive": {
     "name": {
@@ -37,7 +35,9 @@
     },
     "url": {
       "en": "https://cleanheatri.com/"
-    }
+    },
+    "authority": "ri-oer",
+    "authority_type": "state"
   },
   "ri_oER_cleanHeatRhodeIslandResidentialIncome-EligibleIncentive": {
     "name": {
@@ -45,7 +45,9 @@
     },
     "url": {
       "en": "https://cleanheatri.com/"
-    }
+    },
+    "authority": "ri-oer",
+    "authority_type": "state"
   },
   "ri_oER_dRIVE": {
     "name": {
@@ -53,7 +55,9 @@
     },
     "url": {
       "en": "https://drive.ri.gov/ev-programs/drive-ev"
-    }
+    },
+    "authority": "ri-oer",
+    "authority_type": "state"
   },
   "ri_oER_dRIVE+": {
     "name": {
@@ -61,7 +65,9 @@
     },
     "url": {
       "en": "https://drive.ri.gov/ev-programs/drive-plus"
-    }
+    },
+    "authority": "ri-oer",
+    "authority_type": "state"
   },
   "ri_oER_erikaNiedowskiMemorialElectricBicycleRebateProgram": {
     "name": {
@@ -69,7 +75,9 @@
     },
     "url": {
       "en": "https://drive.ri.gov/erika-niedowski-memorial-electric-bicycle-rebate-program"
-    }
+    },
+    "authority": "ri-oer",
+    "authority_type": "state"
   },
   "ri_pascoagUtilityDistrict_hVAC&WaterHeaterIncentives": {
     "name": {
@@ -77,7 +85,9 @@
     },
     "url": {
       "en": "https://pud-ri.org/conservation/download-rebate-forms"
-    }
+    },
+    "authority": "ri-pascoag-utility-district",
+    "authority_type": "utility"
   },
   "ri_pascoagUtilityDistrict_residentialEnergyAudit-WeatherizationIncentives": {
     "name": {
@@ -85,7 +95,9 @@
     },
     "url": {
       "en": "https://pud-ri.org/conservation/download-rebate-forms"
-    }
+    },
+    "authority": "ri-pascoag-utility-district",
+    "authority_type": "utility"
   },
   "ri_pascoagUtilityDistrict_residentialEnergyStarOfferings": {
     "name": {
@@ -93,7 +105,9 @@
     },
     "url": {
       "en": "https://pud-ri.org/conservation/download-rebate-forms"
-    }
+    },
+    "authority": "ri-pascoag-utility-district",
+    "authority_type": "utility"
   },
   "ri_rhodeIslandEnergy_electricHeatingAndCoolingRebates": {
     "name": {
@@ -101,7 +115,9 @@
     },
     "url": {
       "en": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Heat-Pump-Incentives"
-    }
+    },
+    "authority": "ri-rhode-island-energy",
+    "authority_type": "utility"
   },
   "ri_rhodeIslandEnergy_incomeEligibleEnergySavingsProgram": {
     "name": {
@@ -109,7 +125,9 @@
     },
     "url": {
       "en": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/Income-Eligible-Services"
-    }
+    },
+    "authority": "ri-rhode-island-energy",
+    "authority_type": "utility"
   },
   "ri_rhodeIslandEnergy_residentialHeatPumpWaterHeaterRebate": {
     "name": {
@@ -117,7 +135,9 @@
     },
     "url": {
       "en": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs"
-    }
+    },
+    "authority": "ri-rhode-island-energy",
+    "authority_type": "utility"
   },
   "ri_rhodeIslandEnergy_rhodeIslandENERGYSTAR®CertifiedElectricClothesDryerRebate": {
     "name": {
@@ -125,6 +145,8 @@
     },
     "url": {
       "en": "https://www.rienergy.com/RI-Home/Energy-Saving-Programs/rebate-programs"
-    }
+    },
+    "authority": "ri-rhode-island-energy",
+    "authority_type": "utility"
   }
 }

--- a/data/VA/incentives.json
+++ b/data/VA/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "VA-1",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -26,8 +24,6 @@
   },
   {
     "id": "VA-2",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -51,8 +47,6 @@
   },
   {
     "id": "VA-3",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -76,8 +70,6 @@
   },
   {
     "id": "VA-4",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -101,8 +93,6 @@
   },
   {
     "id": "VA-5",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -124,8 +114,6 @@
   },
   {
     "id": "VA-6",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -149,8 +137,6 @@
   },
   {
     "id": "VA-7",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -172,8 +158,6 @@
   },
   {
     "id": "VA-8",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -197,8 +181,6 @@
   },
   {
     "id": "VA-10",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "rebate"
     ],
@@ -222,8 +204,6 @@
   },
   {
     "id": "VA-13",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "assistance_program"
     ],
@@ -246,8 +226,6 @@
   },
   {
     "id": "VA-14",
-    "authority_type": "utility",
-    "authority": "va-appalachian-power",
     "payment_methods": [
       "assistance_program"
     ],
@@ -270,8 +248,6 @@
   },
   {
     "id": "VA-15",
-    "authority_type": "utility",
-    "authority": "va-dominion-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -294,8 +270,6 @@
   },
   {
     "id": "VA-16",
-    "authority_type": "utility",
-    "authority": "va-dominion-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -319,8 +293,6 @@
   },
   {
     "id": "VA-17",
-    "authority_type": "utility",
-    "authority": "va-dominion-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -342,8 +314,6 @@
   },
   {
     "id": "VA-18",
-    "authority_type": "utility",
-    "authority": "va-dominion-energy",
     "payment_methods": [
       "assistance_program"
     ],

--- a/data/VA/programs.json
+++ b/data/VA/programs.json
@@ -1,19 +1,13 @@
 {
-  "va_controlYourHeatingAndCoolingProgram": {
-    "name": {
-      "en": "Control Your Heating and Cooling Program"
-    },
-    "url": {
-      "en": "https://www.dominionenergy.com/virginia/save-energy/control-your-heating-and-cooling"
-    }
-  },
   "va_energyStarRebates": {
     "name": {
       "en": "Energy Star Rebates"
     },
     "url": {
       "en": "https://www.dominionenergy.com/virginia/save-energy/energy-star-products"
-    }
+    },
+    "authority": "va-dominion-energy",
+    "authority_type": "utility"
   },
   "va_evChargerRewards": {
     "name": {
@@ -21,7 +15,9 @@
     },
     "url": {
       "en": "https://www.dominionenergy.com/virginia/save-energy/ev-charger-rewards"
-    }
+    },
+    "authority": "va-dominion-energy",
+    "authority_type": "utility"
   },
   "va_incomeAndAgeQualifyingEnergyEfficiencyProgram": {
     "name": {
@@ -29,7 +25,9 @@
     },
     "url": {
       "en": "https://www.dominionenergy.com/virginia/save-energy/income-and-age-qualifying-home-improvements"
-    }
+    },
+    "authority": "va-dominion-energy",
+    "authority_type": "utility"
   },
   "va_takeChargeVirginiaEfficientProductsProgram": {
     "name": {
@@ -37,7 +35,9 @@
     },
     "url": {
       "en": "https://takechargeva.com/programs/for-your-home/efficient-products-program-appliances"
-    }
+    },
+    "authority": "va-appalachian-power",
+    "authority_type": "utility"
   },
   "va_takeChargeVirginiaHomePerformanceProgram": {
     "name": {
@@ -45,7 +45,9 @@
     },
     "url": {
       "en": "https://takechargeva.com/resources/docs/hp-2023.pdf"
-    }
+    },
+    "authority": "va-appalachian-power",
+    "authority_type": "utility"
   },
   "va_waterEnergySavingsProgram": {
     "name": {
@@ -53,6 +55,8 @@
     },
     "url": {
       "en": "https://cdn-dominionenergy-prd-001.azureedge.net/-/media/pdfs/virginia/save-energy/residential-water-energy--savings-program-measures.pdf"
-    }
+    },
+    "authority": "va-dominion-energy",
+    "authority_type": "utility"
   }
 }

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "VT-1",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -28,8 +26,6 @@
   },
   {
     "id": "VT-2",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -53,8 +49,6 @@
   },
   {
     "id": "VT-3",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -82,8 +76,6 @@
   },
   {
     "id": "VT-4",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -110,8 +102,6 @@
   },
   {
     "id": "VT-5",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -136,8 +126,6 @@
   },
   {
     "id": "VT-6",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -162,8 +150,6 @@
   },
   {
     "id": "VT-7",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -188,8 +174,6 @@
   },
   {
     "id": "VT-8",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -212,8 +196,6 @@
   },
   {
     "id": "VT-10",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -237,8 +219,6 @@
   },
   {
     "id": "VT-11",
-    "authority_type": "other",
-    "authority": "vt-vppsa",
     "eligible_geo_group": "vt-group-vppsa",
     "payment_methods": [
       "rebate"
@@ -263,8 +243,6 @@
   },
   {
     "id": "VT-12",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -291,8 +269,6 @@
   },
   {
     "id": "VT-13",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -318,8 +294,6 @@
   },
   {
     "id": "VT-16",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -343,8 +317,6 @@
   },
   {
     "id": "VT-17",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -366,8 +338,6 @@
   },
   {
     "id": "VT-18",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -392,8 +362,6 @@
   },
   {
     "id": "VT-21",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -418,8 +386,6 @@
   },
   {
     "id": "VT-22",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -441,8 +407,6 @@
   },
   {
     "id": "VT-23",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -468,8 +432,6 @@
   },
   {
     "id": "VT-25",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -495,8 +457,6 @@
   },
   {
     "id": "VT-26",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -519,8 +479,6 @@
   },
   {
     "id": "VT-28",
-    "authority_type": "state",
-    "authority": "vt-state-of-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -546,8 +504,6 @@
   },
   {
     "id": "VT-31",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -573,8 +529,6 @@
   },
   {
     "id": "VT-32",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "assistance_program"
     ],
@@ -597,8 +551,6 @@
   },
   {
     "id": "VT-33",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -622,8 +574,6 @@
   },
   {
     "id": "VT-34",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "assistance_program"
     ],
@@ -648,8 +598,6 @@
   },
   {
     "id": "VT-35",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "assistance_program"
     ],
@@ -674,8 +622,6 @@
   },
   {
     "id": "VT-36",
-    "authority_type": "other",
-    "authority": "vt-vppsa",
     "eligible_geo_group": "vt-group-vppsa",
     "payment_methods": [
       "assistance_program"
@@ -701,8 +647,6 @@
   },
   {
     "id": "VT-37",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -726,8 +670,6 @@
   },
   {
     "id": "VT-38",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -752,8 +694,6 @@
   },
   {
     "id": "VT-39",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -779,8 +719,6 @@
   },
   {
     "id": "VT-40",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -804,8 +742,6 @@
   },
   {
     "id": "VT-41",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -828,8 +764,6 @@
   },
   {
     "id": "VT-42",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -854,8 +788,6 @@
   },
   {
     "id": "VT-43",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -881,8 +813,6 @@
   },
   {
     "id": "VT-44",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -908,8 +838,6 @@
   },
   {
     "id": "VT-45",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -934,8 +862,6 @@
   },
   {
     "id": "VT-46",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -960,8 +886,6 @@
   },
   {
     "id": "VT-47",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -986,8 +910,6 @@
   },
   {
     "id": "VT-48",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1011,8 +933,6 @@
   },
   {
     "id": "VT-49",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1037,8 +957,6 @@
   },
   {
     "id": "VT-50",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1063,8 +981,6 @@
   },
   {
     "id": "VT-51",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1090,8 +1006,6 @@
   },
   {
     "id": "VT-52",
-    "authority_type": "state",
-    "authority": "vt-state-of-vermont",
     "payment_methods": [
       "assistance_program"
     ],
@@ -1116,8 +1030,6 @@
   },
   {
     "id": "VT-53",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1140,8 +1052,6 @@
   },
   {
     "id": "VT-54",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1165,8 +1075,6 @@
   },
   {
     "id": "VT-55",
-    "authority_type": "utility",
-    "authority": "vt-vgs",
     "payment_methods": [
       "rebate"
     ],
@@ -1190,8 +1098,6 @@
   },
   {
     "id": "VT-56",
-    "authority_type": "utility",
-    "authority": "vt-vgs",
     "payment_methods": [
       "rebate"
     ],
@@ -1215,8 +1121,6 @@
   },
   {
     "id": "VT-57",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1243,8 +1147,6 @@
   },
   {
     "id": "VT-58",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1268,8 +1170,6 @@
   },
   {
     "id": "VT-59",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1295,8 +1195,6 @@
   },
   {
     "id": "VT-60",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1320,8 +1218,6 @@
   },
   {
     "id": "VT-61",
-    "authority_type": "utility",
-    "authority": "vt-stowe-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1347,8 +1243,6 @@
   },
   {
     "id": "VT-62",
-    "authority_type": "utility",
-    "authority": "vt-stowe-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1373,8 +1267,6 @@
   },
   {
     "id": "VT-63",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1397,8 +1289,6 @@
   },
   {
     "id": "VT-64",
-    "authority_type": "other",
-    "authority": "vt-vppsa",
     "eligible_geo_group": "vt-group-vppsa",
     "payment_methods": [
       "rebate"
@@ -1424,8 +1314,6 @@
   },
   {
     "id": "VT-65",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1449,8 +1337,6 @@
   },
   {
     "id": "VT-66",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1475,8 +1361,6 @@
   },
   {
     "id": "VT-67",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1501,8 +1385,6 @@
   },
   {
     "id": "VT-68",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1527,8 +1409,6 @@
   },
   {
     "id": "VT-69",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1552,8 +1432,6 @@
   },
   {
     "id": "VT-70",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1577,8 +1455,6 @@
   },
   {
     "id": "VT-72",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1602,8 +1478,6 @@
   },
   {
     "id": "VT-73",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],
@@ -1627,8 +1501,6 @@
   },
   {
     "id": "VT-74",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1652,8 +1524,6 @@
   },
   {
     "id": "VT-75",
-    "authority_type": "state",
-    "authority": "vt-state-of-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1680,8 +1550,6 @@
   },
   {
     "id": "VT-76",
-    "authority_type": "state",
-    "authority": "vt-state-of-vermont",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -1708,8 +1576,6 @@
   },
   {
     "id": "VT-83",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1735,8 +1601,6 @@
   },
   {
     "id": "VT-84",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1762,8 +1626,6 @@
   },
   {
     "id": "VT-85",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1787,8 +1649,6 @@
   },
   {
     "id": "VT-86",
-    "authority_type": "utility",
-    "authority": "vt-green-mountain-power",
     "payment_methods": [
       "rebate"
     ],
@@ -1812,8 +1672,6 @@
   },
   {
     "id": "VT-87",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1839,8 +1697,6 @@
   },
   {
     "id": "VT-88",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1864,8 +1720,6 @@
   },
   {
     "id": "VT-89",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1892,8 +1746,6 @@
   },
   {
     "id": "VT-90",
-    "authority_type": "utility",
-    "authority": "vt-burlington-electric-department",
     "payment_methods": [
       "rebate"
     ],
@@ -1918,8 +1770,6 @@
   },
   {
     "id": "VT-91",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1944,8 +1794,6 @@
   },
   {
     "id": "VT-92",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1970,8 +1818,6 @@
   },
   {
     "id": "VT-93",
-    "authority_type": "utility",
-    "authority": "vt-washington-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1996,8 +1842,6 @@
   },
   {
     "id": "VT-94",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2024,8 +1868,6 @@
   },
   {
     "id": "VT-95",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2051,8 +1893,6 @@
   },
   {
     "id": "VT-96",
-    "authority_type": "utility",
-    "authority": "vt-vermont-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2078,8 +1918,6 @@
   },
   {
     "id": "VT-97",
-    "authority_type": "utility",
-    "authority": "vt-vgs",
     "payment_methods": [
       "rebate"
     ],
@@ -2104,8 +1942,6 @@
   },
   {
     "id": "VT-98",
-    "authority_type": "state",
-    "authority": "vt-efficiency-vermont",
     "payment_methods": [
       "rebate"
     ],

--- a/data/VT/programs.json
+++ b/data/VT/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/evrebates/"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartmentElectricVehicleRebates": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/evrebates/"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-HeatPumpRebates-IncomeBonus": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/waterheaters"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-LawnCare-ResidentialRebate": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/lawnmowers"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForAir-To-WaterHeatPump": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/rebate-form"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctedHeatPump": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/heatpumps"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctlessHeatPump": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Mini-Split%20Heat%20Pump"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForGroundSourceHeatPump": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/gshp"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForHeatPumpWaterHeater": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/waterheaters"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForInductionCooktop": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Induction%20Cooktop"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-ResidentialEVChargerRebate": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://www.burlingtonelectric.com/evchargers#"
-    }
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility"
   },
   "vt_efficiencyVermont_efficiencyVermontAirToWaterHeatPumpRebate": {
     "name": {
@@ -93,7 +115,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontAirToWaterHeatPumpRebateIncomeBonus": {
     "name": {
@@ -101,7 +125,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/air-to-water-heat-pumps"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-CentralWoodPelletBoilerRebate": {
     "name": {
@@ -109,7 +135,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/central-wood-pellet-furnaces-boilers-business"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontClothesDryerRebate": {
     "name": {
@@ -117,7 +145,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/clothes-dryers"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-DehumidifierRebate": {
     "name": {
@@ -125,7 +155,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/dehumidifiers"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontDuctedHeatPumpRebate": {
     "name": {
@@ -133,7 +165,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontDuctedHeatPumpRebateIncomeBonus": {
     "name": {
@@ -141,7 +175,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontDuctlessHeatPumpRebate": {
     "name": {
@@ -149,7 +185,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontDuctlessHeatPumpRebateIncomeBonus": {
     "name": {
@@ -157,15 +195,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system"
-    }
-  },
-  "vt_efficiencyVermont_efficiencyVermont-FreeProductForLow-IncomeVermonters": {
-    "name": {
-      "en": "Efficiency Vermont - Free Product for Low-Income Vermonters"
     },
-    "url": {
-      "en": "https://www.efficiencyvermont.com/free-products"
-    }
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontGroundSourceHeatPumpRebate": {
     "name": {
@@ -173,7 +205,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-ground-source-heat-pump-rebate-form.pdf"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontGroundSourceHeatPumpRebateIncomeBonus": {
     "name": {
@@ -181,7 +215,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/ground-source-heat-pumps"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermontHeatPumpWaterHeaterRebateProgram": {
     "name": {
@@ -189,7 +225,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/heat-pump-water-heaters"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-High-PerformanceCirculatorPumpRebate": {
     "name": {
@@ -197,7 +235,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/high-performance-circulator-pumps"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-LEDsForIndoorGrowing": {
     "name": {
@@ -205,7 +245,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/led-indoor-growing"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-ResidentialEnergyEfficiencyRebateProgram": {
     "name": {
@@ -213,7 +255,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/integrated-controls"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-ResidentialEnergyEfficiencyRebateProgram(DIYWeatherization)": {
     "name": {
@@ -221,7 +265,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-residential-diy-weatherization-rebate-form.pdf"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-SmartThermostats": {
     "name": {
@@ -229,7 +275,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-smart-therm-rebate-form.pdf, https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/efficiency-vermont-smart-therm-rebate-form.pdf"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-Washer&DryerRebate": {
     "name": {
@@ -237,7 +285,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/washer-dryer"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-WindowAirConditionerRebate": {
     "name": {
@@ -245,7 +295,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/window-air-conditioners"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_efficiencyVermont-Wood&PelletStoveRebate": {
     "name": {
@@ -253,7 +305,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/wood-stoves"
-    }
+    },
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_efficiencyVermont_homePerformanceWithENERGYSTAR": {
     "name": {
@@ -261,15 +315,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/rebates/list/home-performance-with-energy-star"
-    }
-  },
-  "vt_greenMountainPower_greenMountainPowerDuctlessHeatPumpRebate": {
-    "name": {
-      "en": "Green Mountain Power Ductless Heat Pump Rebate"
     },
-    "url": {
-      "en": "https://greenmountainpower.com/rebates-programs/home-and-yard/heat-pump/"
-    }
+    "authority": "vt-efficiency-vermont",
+    "authority_type": "state"
   },
   "vt_greenMountainPower_greenMountainPowerElectricVehicleRebate": {
     "name": {
@@ -277,7 +325,9 @@
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/electric-vehicles/ev-rebate/"
-    }
+    },
+    "authority": "vt-green-mountain-power",
+    "authority_type": "utility"
   },
   "vt_greenMountainPower_greenMountainPowerElectricVehicleRebateIncomeBonus": {
     "name": {
@@ -285,7 +335,9 @@
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/electric-vehicles/ev-rebate/"
-    }
+    },
+    "authority": "vt-green-mountain-power",
+    "authority_type": "utility"
   },
   "vt_greenMountainPower_greenMountainPower-FreeLevel2EVCharger": {
     "name": {
@@ -293,7 +345,9 @@
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/electric-vehicles/in-home-ev-charger/"
-    }
+    },
+    "authority": "vt-green-mountain-power",
+    "authority_type": "utility"
   },
   "vt_greenMountainPower_greenMountainPowerHeatPumpRebate": {
     "name": {
@@ -301,15 +355,9 @@
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/home-and-yard/heat-pump/"
-    }
-  },
-  "vt_greenMountainPower_greenMountainPowerHeatPumpRebateIncomeBonus": {
-    "name": {
-      "en": "Green Mountain Power Heat Pump Rebate Income Bonus"
     },
-    "url": {
-      "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/green-mountain-power-income-bonus-form.pdf"
-    }
+    "authority": "vt-green-mountain-power",
+    "authority_type": "utility"
   },
   "vt_greenMountainPower_greenMountainPower-RebateForInductionCooktop": {
     "name": {
@@ -317,7 +365,9 @@
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/home-and-yard/induction-cooktop-rebate/"
-    }
+    },
+    "authority": "vt-green-mountain-power",
+    "authority_type": "utility"
   },
   "vt_greenMountainPower_greenMountainPower-YardCareRebates": {
     "name": {
@@ -325,7 +375,9 @@
     },
     "url": {
       "en": "https://greenmountainpower.com/rebates-programs/home-and-yard/electric-mower-rebate/"
-    }
+    },
+    "authority": "vt-green-mountain-power",
+    "authority_type": "utility"
   },
   "vt_stateOfVermont_incomeBasedWeatherizationAssistanceProgram": {
     "name": {
@@ -333,7 +385,9 @@
     },
     "url": {
       "en": "https://dcf.vermont.gov/benefits/weatherization"
-    }
+    },
+    "authority": "vt-state-of-vermont",
+    "authority_type": "state"
   },
   "vt_stateOfVermont_mileageSmartUsedHighEfficiencyVehicleIncentiveProgram": {
     "name": {
@@ -341,15 +395,9 @@
     },
     "url": {
       "en": "https://www.driveelectricvt.com/incentives/vermont-state-incentives#mileagesmart"
-    }
-  },
-  "vt_stateOfVermont_replaceYourRide": {
-    "name": {
-      "en": "Replace your ride"
     },
-    "url": {
-      "en": "https://www.driveelectricvt.com/Media/Default/docs/ryr/vermont-replace-your-ride-program-guidelines.pdf?refresh"
-    }
+    "authority": "vt-state-of-vermont",
+    "authority_type": "state"
   },
   "vt_stateOfVermont_stateOfVermontIncentivesForNewElectricVehicles": {
     "name": {
@@ -357,7 +405,9 @@
     },
     "url": {
       "en": "https://www.driveelectricvt.com/Media/Default/docs/purchase-incentives/vermont-new-pev-incentive-form.pdf?refresh"
-    }
+    },
+    "authority": "vt-state-of-vermont",
+    "authority_type": "state"
   },
   "vt_stoweElectricDepartment_stoweElectricRebates&Incentives": {
     "name": {
@@ -365,7 +415,9 @@
     },
     "url": {
       "en": "https://www.stoweelectric.com/rebates/electric-yard-equipment"
-    }
+    },
+    "authority": "vt-stowe-electric-department",
+    "authority_type": "utility"
   },
   "vt_vermontElectricCooperative_energyTransformationIncentives": {
     "name": {
@@ -373,7 +425,9 @@
     },
     "url": {
       "en": "https://vermontelectric.coop/energy-transformation-programs"
-    }
+    },
+    "authority": "vt-vermont-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_vermontElectricCooperative_thermalEfficiencyBillCreditBonus": {
     "name": {
@@ -381,7 +435,9 @@
     },
     "url": {
       "en": "https://eternityweb.formstack.com/forms/vermont_electric_coop_thermal_efficiency_bonus"
-    }
+    },
+    "authority": "vt-vermont-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_vermontElectricCooperative_vermontElectric-BillCreditForInductionCooktop": {
     "name": {
@@ -389,7 +445,9 @@
     },
     "url": {
       "en": "https://vermontelectric.coop/client_media/files/Induction_cooktop_incentive_form_9_1_22_Fillable.pdf"
-    }
+    },
+    "authority": "vt-vermont-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_vermontElectricCooperative_vermontElectricCoop-BillCreditForLevel2HomeEVChargingEquipment": {
     "name": {
@@ -397,7 +455,9 @@
     },
     "url": {
       "en": "https://vermontelectric.coop/energy-transformation-programs"
-    }
+    },
+    "authority": "vt-vermont-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_vermontElectricCooperative_vermontElectricCo-OpEnergyTransformationIncentives": {
     "name": {
@@ -405,7 +465,9 @@
     },
     "url": {
       "en": "https://vermontelectric.coop/energy-transformation-programs"
-    }
+    },
+    "authority": "vt-vermont-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_vermontElectricCooperative_vermontElectricCoop-FreeLevel2EVCharger": {
     "name": {
@@ -413,7 +475,9 @@
     },
     "url": {
       "en": "https://vermontelectric.coop/energy-transformation-programs"
-    }
+    },
+    "authority": "vt-vermont-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_vGS_vGSWeatherizationProgram": {
     "name": {
@@ -421,7 +485,9 @@
     },
     "url": {
       "en": "https://vgsvt.com/savings/residentialrebate/energy-audits-weatherization/"
-    }
+    },
+    "authority": "vt-vgs",
+    "authority_type": "utility"
   },
   "vt_vGS_vGSWeatherizationRebatesForIncome-QualifiedHomeowners": {
     "name": {
@@ -429,23 +495,9 @@
     },
     "url": {
       "en": "https://vgsvt.com/savings/residentialrebate/weatherization-rebates/"
-    }
-  },
-  "vt_vPPSA_2021ColdClimateHeatPumpInstantDiscount": {
-    "name": {
-      "en": "2021 Cold Climate Heat Pump Instant Discount"
     },
-    "url": {
-      "en": "http://vppsa.com/wp-content/uploads/2021/01/2021-Weatherized-Heat-Pump-REBATE.pdf"
-    }
-  },
-  "vt_vPPSA_2022ColdClimateHeatPumpInstantDiscount": {
-    "name": {
-      "en": "2022 Cold Climate Heat Pump Instant Discount"
-    },
-    "url": {
-      "en": "http://vppsa.com/wp-content/uploads/2021/01/2021-Weatherized-Heat-Pump-REBATE.pdf"
-    }
+    "authority": "vt-vgs",
+    "authority_type": "utility"
   },
   "vt_vPPSA_electricLawnMowerRebate": {
     "name": {
@@ -453,7 +505,9 @@
     },
     "url": {
       "en": "https://vppsa.com/2023-electric-lawn-mower-rebate/"
-    }
+    },
+    "authority": "vt-vppsa",
+    "authority_type": "other"
   },
   "vt_vPPSA_vPPSAHeatPumpRebateIncomeBonus": {
     "name": {
@@ -461,7 +515,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/Media/Default/docs/rebates/forms/vppsa-tc-income-bonus-form.pdf"
-    }
+    },
+    "authority": "vt-vppsa",
+    "authority_type": "other"
   },
   "vt_vPPSA_vPPSA-PowerShift": {
     "name": {
@@ -469,7 +525,9 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/powershift"
-    }
+    },
+    "authority": "vt-vppsa",
+    "authority_type": "other"
   },
   "vt_washingtonElectricCooperative_buttonUpWEC-AirToWaterHeatPumpRebate": {
     "name": {
@@ -477,7 +535,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2024/01/1-2024-WEC-Button-Up-Thermal-incentives.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_buttonUpWEC-DuctedHeatPumpRebate": {
     "name": {
@@ -485,7 +545,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_buttonUpWEC-DuctlessHeatPumpRebate": {
     "name": {
@@ -493,7 +555,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_buttonUpWEC-GroundSourceHeatPumpRebate": {
     "name": {
@@ -501,7 +565,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2024/01/1-2024-WEC-Button-Up-Thermal-incentives.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_buttonUpWEC-HeatPumpWaterHeaterRebate": {
     "name": {
@@ -509,7 +575,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2024/01/1-2024-WEC-Button-Up-Thermal-incentives.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_buttonUpWECTransportationIncentives": {
     "name": {
@@ -517,7 +585,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2024/02/2-2024-WEC-Button-Up-Transportation-sheet.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_buttonUpWEC-WeatherizationProgram": {
     "name": {
@@ -525,7 +595,9 @@
     },
     "url": {
       "en": "https://www.washingtonelectric.coop/wp-content/uploads/2023/06/5-2023-WEC-Button-Up-Thermal-incentives.pdf"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   },
   "vt_washingtonElectricCooperative_washingtonElectricCo-Op-PowerShift": {
     "name": {
@@ -533,6 +605,8 @@
     },
     "url": {
       "en": "https://www.efficiencyvermont.com/powershift"
-    }
+    },
+    "authority": "vt-washington-electric-cooperative",
+    "authority_type": "utility"
   }
 }

--- a/data/WI/incentives.json
+++ b/data/WI/incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "WI-18",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -29,8 +27,6 @@
   },
   {
     "id": "WI-19",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "pos_rebate"
@@ -54,8 +50,6 @@
   },
   {
     "id": "WI-20",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "pos_rebate"
@@ -84,8 +78,6 @@
   },
   {
     "id": "WI-21",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -111,8 +103,6 @@
   },
   {
     "id": "WI-22",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -139,8 +129,6 @@
   },
   {
     "id": "WI-23",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -167,8 +155,6 @@
   },
   {
     "id": "WI-24",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -196,8 +182,6 @@
   },
   {
     "id": "WI-25",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -223,8 +207,6 @@
   },
   {
     "id": "WI-26",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "pos_rebate"
@@ -251,8 +233,6 @@
   },
   {
     "id": "WI-27",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -279,8 +259,6 @@
   },
   {
     "id": "WI-28",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "pos_rebate"
@@ -308,8 +286,6 @@
   },
   {
     "id": "WI-29",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -336,8 +312,6 @@
   },
   {
     "id": "WI-30",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "pos_rebate"
@@ -365,8 +339,6 @@
   },
   {
     "id": "WI-31",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -393,8 +365,6 @@
   },
   {
     "id": "WI-32",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -421,8 +391,6 @@
   },
   {
     "id": "WI-34",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "pos_rebate"
     ],
@@ -445,8 +413,6 @@
   },
   {
     "id": "WI-35",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -469,8 +435,6 @@
   },
   {
     "id": "WI-36",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -494,8 +458,6 @@
   },
   {
     "id": "WI-37",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -521,8 +483,6 @@
   },
   {
     "id": "WI-38",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -548,8 +508,6 @@
   },
   {
     "id": "WI-39",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -575,8 +533,6 @@
   },
   {
     "id": "WI-40",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -600,8 +556,6 @@
   },
   {
     "id": "WI-41",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -625,8 +579,6 @@
   },
   {
     "id": "WI-42",
-    "authority_type": "utility",
-    "authority": "wi-barron-electric-cooperative",
     "payment_methods": [
       "account_credit",
       "rebate"
@@ -651,8 +603,6 @@
   },
   {
     "id": "WI-43",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -675,8 +625,6 @@
   },
   {
     "id": "WI-44",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -699,8 +647,6 @@
   },
   {
     "id": "WI-45",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -724,8 +670,6 @@
   },
   {
     "id": "WI-46",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -748,8 +692,6 @@
   },
   {
     "id": "WI-47",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -774,8 +716,6 @@
   },
   {
     "id": "WI-48",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -798,8 +738,6 @@
   },
   {
     "id": "WI-49",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -824,8 +762,6 @@
   },
   {
     "id": "WI-50",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -848,8 +784,6 @@
   },
   {
     "id": "WI-51",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -872,8 +806,6 @@
   },
   {
     "id": "WI-52",
-    "authority_type": "utility",
-    "authority": "wi-bayfield-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -896,8 +828,6 @@
   },
   {
     "id": "WI-53",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -920,8 +850,6 @@
   },
   {
     "id": "WI-54",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -945,8 +873,6 @@
   },
   {
     "id": "WI-55",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -969,8 +895,6 @@
   },
   {
     "id": "WI-56",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -996,8 +920,6 @@
   },
   {
     "id": "WI-57",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1021,8 +943,6 @@
   },
   {
     "id": "WI-58",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1047,8 +967,6 @@
   },
   {
     "id": "WI-59",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1071,8 +989,6 @@
   },
   {
     "id": "WI-60",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1095,8 +1011,6 @@
   },
   {
     "id": "WI-61",
-    "authority_type": "utility",
-    "authority": "wi-chippewa-valley-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1119,8 +1033,6 @@
   },
   {
     "id": "WI-62",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1143,8 +1055,6 @@
   },
   {
     "id": "WI-63",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1169,8 +1079,6 @@
   },
   {
     "id": "WI-64",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1193,8 +1101,6 @@
   },
   {
     "id": "WI-65",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1217,8 +1123,6 @@
   },
   {
     "id": "WI-66",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1243,8 +1147,6 @@
   },
   {
     "id": "WI-67",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1268,8 +1170,6 @@
   },
   {
     "id": "WI-68",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1292,8 +1192,6 @@
   },
   {
     "id": "WI-69",
-    "authority_type": "utility",
-    "authority": "wi-clark-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1316,8 +1214,6 @@
   },
   {
     "id": "WI-70",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1341,8 +1237,6 @@
   },
   {
     "id": "WI-71",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1366,8 +1260,6 @@
   },
   {
     "id": "WI-72",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1390,8 +1282,6 @@
   },
   {
     "id": "WI-73",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1414,8 +1304,6 @@
   },
   {
     "id": "WI-74",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1440,8 +1328,6 @@
   },
   {
     "id": "WI-75",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1465,8 +1351,6 @@
   },
   {
     "id": "WI-76",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1492,8 +1376,6 @@
   },
   {
     "id": "WI-77",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1517,8 +1399,6 @@
   },
   {
     "id": "WI-78",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1544,8 +1424,6 @@
   },
   {
     "id": "WI-79",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1570,8 +1448,6 @@
   },
   {
     "id": "WI-80",
-    "authority_type": "utility",
-    "authority": "wi-dunn-energy-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1595,8 +1471,6 @@
   },
   {
     "id": "WI-81",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1618,8 +1492,6 @@
   },
   {
     "id": "WI-82",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1642,8 +1514,6 @@
   },
   {
     "id": "WI-83",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1665,8 +1535,6 @@
   },
   {
     "id": "WI-84",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1689,8 +1557,6 @@
   },
   {
     "id": "WI-85",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1712,8 +1578,6 @@
   },
   {
     "id": "WI-86",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1735,8 +1599,6 @@
   },
   {
     "id": "WI-87",
-    "authority_type": "utility",
-    "authority": "wi-east-central-energy",
     "payment_methods": [
       "rebate"
     ],
@@ -1758,8 +1620,6 @@
   },
   {
     "id": "WI-88",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1783,8 +1643,6 @@
   },
   {
     "id": "WI-89",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1808,8 +1666,6 @@
   },
   {
     "id": "WI-90",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -1833,8 +1689,6 @@
   },
   {
     "id": "WI-91",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1860,8 +1714,6 @@
   },
   {
     "id": "WI-92",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1886,8 +1738,6 @@
   },
   {
     "id": "WI-93",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1911,8 +1761,6 @@
   },
   {
     "id": "WI-94",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1938,8 +1786,6 @@
   },
   {
     "id": "WI-95",
-    "authority_type": "utility",
-    "authority": "wi-jackson-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -1963,8 +1809,6 @@
   },
   {
     "id": "WI-97",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -1987,8 +1831,6 @@
   },
   {
     "id": "WI-98",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2011,8 +1853,6 @@
   },
   {
     "id": "WI-99",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2036,8 +1876,6 @@
   },
   {
     "id": "WI-100",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2060,8 +1898,6 @@
   },
   {
     "id": "WI-101",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2086,8 +1922,6 @@
   },
   {
     "id": "WI-102",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2110,8 +1944,6 @@
   },
   {
     "id": "WI-103",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2135,8 +1967,6 @@
   },
   {
     "id": "WI-104",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2160,8 +1990,6 @@
   },
   {
     "id": "WI-105",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2184,8 +2012,6 @@
   },
   {
     "id": "WI-106",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2208,8 +2034,6 @@
   },
   {
     "id": "WI-107",
-    "authority_type": "utility",
-    "authority": "wi-pierce-pepin-cooperative-services",
     "payment_methods": [
       "rebate"
     ],
@@ -2232,8 +2056,6 @@
   },
   {
     "id": "WI-108",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2257,8 +2079,6 @@
   },
   {
     "id": "WI-109",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2283,8 +2103,6 @@
   },
   {
     "id": "WI-110",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -2308,8 +2126,6 @@
   },
   {
     "id": "WI-111",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2333,8 +2149,6 @@
   },
   {
     "id": "WI-112",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2360,8 +2174,6 @@
   },
   {
     "id": "WI-113",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "account_credit"
     ],
@@ -2385,8 +2197,6 @@
   },
   {
     "id": "WI-114",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2412,8 +2222,6 @@
   },
   {
     "id": "WI-115",
-    "authority_type": "utility",
-    "authority": "wi-polk-burnett-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2437,8 +2245,6 @@
   },
   {
     "id": "WI-116",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2462,8 +2268,6 @@
   },
   {
     "id": "WI-117",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2486,8 +2290,6 @@
   },
   {
     "id": "WI-118",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2512,8 +2314,6 @@
   },
   {
     "id": "WI-119",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2536,8 +2336,6 @@
   },
   {
     "id": "WI-120",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2562,8 +2360,6 @@
   },
   {
     "id": "WI-121",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2586,8 +2382,6 @@
   },
   {
     "id": "WI-122",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2611,8 +2405,6 @@
   },
   {
     "id": "WI-123",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2635,8 +2427,6 @@
   },
   {
     "id": "WI-124",
-    "authority_type": "utility",
-    "authority": "wi-price-electric-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2659,8 +2449,6 @@
   },
   {
     "id": "WI-125",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2683,8 +2471,6 @@
   },
   {
     "id": "WI-126",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2707,8 +2493,6 @@
   },
   {
     "id": "WI-127",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2732,8 +2516,6 @@
   },
   {
     "id": "WI-128",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2756,8 +2538,6 @@
   },
   {
     "id": "WI-129",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2782,8 +2562,6 @@
   },
   {
     "id": "WI-130",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2806,8 +2584,6 @@
   },
   {
     "id": "WI-131",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2832,8 +2608,6 @@
   },
   {
     "id": "WI-132",
-    "authority_type": "utility",
-    "authority": "wi-riverland-energy-cooperative",
     "payment_methods": [
       "rebate"
     ],
@@ -2856,8 +2630,6 @@
   },
   {
     "id": "WI-135",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -2884,8 +2656,6 @@
   },
   {
     "id": "WI-136",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"
@@ -2912,8 +2682,6 @@
   },
   {
     "id": "WI-137",
-    "authority_type": "other",
-    "authority": "wi-focus-on-energy",
     "eligible_geo_group": "wi-group-focus-on-energy",
     "payment_methods": [
       "rebate"

--- a/data/WI/programs.json
+++ b/data/WI/programs.json
@@ -5,7 +5,9 @@
     },
     "url": {
       "en": "https://www.barronelectric.com/2024-energy-rebates"
-    }
+    },
+    "authority": "wi-barron-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_barronElectricCooperative_energySavingsRebates:EnergyStarAppliances": {
     "name": {
@@ -13,7 +15,9 @@
     },
     "url": {
       "en": "https://www.barronelectric.com/2024-energy-rebates"
-    }
+    },
+    "authority": "wi-barron-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_barronElectricCooperative_energySavingsRebates:EVChargers": {
     "name": {
@@ -21,7 +25,9 @@
     },
     "url": {
       "en": "https://www.barronelectric.com/2024-energy-rebates"
-    }
+    },
+    "authority": "wi-barron-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_barronElectricCooperative_energySavingsRebates:HVAC": {
     "name": {
@@ -29,7 +35,9 @@
     },
     "url": {
       "en": "https://www.barronelectric.com/2024-energy-rebates"
-    }
+    },
+    "authority": "wi-barron-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_barronElectricCooperative_energySavingsRebates:WaterHeaters": {
     "name": {
@@ -37,7 +45,9 @@
     },
     "url": {
       "en": "https://www.barronelectric.com/2024-energy-rebates"
-    }
+    },
+    "authority": "wi-barron-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_bayfieldElectricCooperative_applianceRebates": {
     "name": {
@@ -45,7 +55,9 @@
     },
     "url": {
       "en": "https://www.bayfieldelectric.com/rebates"
-    }
+    },
+    "authority": "wi-bayfield-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_bayfieldElectricCooperative_auditRecommendedImprovementRebates": {
     "name": {
@@ -53,7 +65,9 @@
     },
     "url": {
       "en": "https://www.bayfieldelectric.com/rebates"
-    }
+    },
+    "authority": "wi-bayfield-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_bayfieldElectricCooperative_eVChargerRebates": {
     "name": {
@@ -61,7 +75,9 @@
     },
     "url": {
       "en": "https://www.bayfieldelectric.com/rebates"
-    }
+    },
+    "authority": "wi-bayfield-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_bayfieldElectricCooperative_hVACRebates": {
     "name": {
@@ -69,7 +85,9 @@
     },
     "url": {
       "en": "https://www.bayfieldelectric.com/rebates"
-    }
+    },
+    "authority": "wi-bayfield-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_bayfieldElectricCooperative_waterHeaterRebates": {
     "name": {
@@ -77,7 +95,9 @@
     },
     "url": {
       "en": "https://www.bayfieldelectric.com/rebates"
-    }
+    },
+    "authority": "wi-bayfield-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_chippewaValleyElectricCooperative_applianceIncentives": {
     "name": {
@@ -85,7 +105,9 @@
     },
     "url": {
       "en": "https://www.cvecoop.com/rebates.php"
-    }
+    },
+    "authority": "wi-chippewa-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_chippewaValleyElectricCooperative_auditRecommendedImprovementsIncentives": {
     "name": {
@@ -93,7 +115,9 @@
     },
     "url": {
       "en": "https://www.cvecoop.com/rebates.php"
-    }
+    },
+    "authority": "wi-chippewa-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_chippewaValleyElectricCooperative_electricVehicleChargingStationIncentives": {
     "name": {
@@ -101,7 +125,9 @@
     },
     "url": {
       "en": "https://www.cvecoop.com/rebates.php"
-    }
+    },
+    "authority": "wi-chippewa-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_chippewaValleyElectricCooperative_hVACIncentives": {
     "name": {
@@ -109,7 +135,9 @@
     },
     "url": {
       "en": "https://www.cvecoop.com/rebates.php"
-    }
+    },
+    "authority": "wi-chippewa-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_chippewaValleyElectricCooperative_waterHeaterIncentives": {
     "name": {
@@ -117,7 +145,9 @@
     },
     "url": {
       "en": "https://www.cvecoop.com/rebates.php"
-    }
+    },
+    "authority": "wi-chippewa-valley-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_clarkElectricCooperative_auditRecommendedImprovementsIncentives": {
     "name": {
@@ -125,7 +155,9 @@
     },
     "url": {
       "en": "https://www.cecoop.com/rebatesincentives"
-    }
+    },
+    "authority": "wi-clark-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_clarkElectricCooperative_eNERGYSTARApplianceIncentives": {
     "name": {
@@ -133,7 +165,9 @@
     },
     "url": {
       "en": "https://www.cecoop.com/rebatesincentives"
-    }
+    },
+    "authority": "wi-clark-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_clarkElectricCooperative_hVACIncentives": {
     "name": {
@@ -141,7 +175,9 @@
     },
     "url": {
       "en": "https://www.cecoop.com/rebatesincentives"
-    }
+    },
+    "authority": "wi-clark-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_clarkElectricCooperative_waterHeaterIncentives": {
     "name": {
@@ -149,7 +185,9 @@
     },
     "url": {
       "en": "https://www.cecoop.com/rebatesincentives"
-    }
+    },
+    "authority": "wi-clark-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_dunnEnergyCooperative_electricVehicleIncentives": {
     "name": {
@@ -157,7 +195,9 @@
     },
     "url": {
       "en": "https://www.dunnenergy.com/electric-vehicles"
-    }
+    },
+    "authority": "wi-dunn-energy-cooperative",
+    "authority_type": "utility"
   },
   "wi_dunnEnergyCooperative_homeRebates": {
     "name": {
@@ -165,7 +205,9 @@
     },
     "url": {
       "en": "https://www.dunnenergy.com/home-rebates"
-    }
+    },
+    "authority": "wi-dunn-energy-cooperative",
+    "authority_type": "utility"
   },
   "wi_eastCentralEnergy_residentialRebates": {
     "name": {
@@ -173,7 +215,9 @@
     },
     "url": {
       "en": "https://eastcentralenergy.com/2024-residential-rebates"
-    }
+    },
+    "authority": "wi-east-central-energy",
+    "authority_type": "utility"
   },
   "wi_focusOnEnergy_dIYInsulation&AirSealingRebates": {
     "name": {
@@ -181,7 +225,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/residential/diy"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_focusOnEnergy_heating&CoolingRebates": {
     "name": {
@@ -189,7 +235,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/residential/heating-and-cooling"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_focusOnEnergy_homeEfficiencyRebates": {
     "name": {
@@ -197,7 +245,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/ira-homes"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_focusOnEnergy_insulation&AirSealingRebates": {
     "name": {
@@ -205,7 +255,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/residential/insulation-and-air-sealing"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_focusOnEnergy_smartThermostatsRebates": {
     "name": {
@@ -213,7 +265,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/residential/smart-thermostats"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_focusOnEnergy_solarForHomes": {
     "name": {
@@ -221,7 +275,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/residential/solar-for-homes"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_focusOnEnergy_waterHeatingRebates": {
     "name": {
@@ -229,7 +285,9 @@
     },
     "url": {
       "en": "https://focusonenergy.com/residential/water-heating"
-    }
+    },
+    "authority": "wi-focus-on-energy",
+    "authority_type": "other"
   },
   "wi_jacksonElectricCooperative_rebatesAndIncentives": {
     "name": {
@@ -237,15 +295,9 @@
     },
     "url": {
       "en": "https://www.jackelec.com/rebates-and-incentives"
-    }
-  },
-  "wi_madisonGasAndElectric_charge@Home": {
-    "name": {
-      "en": "Charge@Home"
     },
-    "url": {
-      "en": "https://www.mge.com/our-environment/electric-vehicles/charging/charge-at-home-program"
-    }
+    "authority": "wi-jackson-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_piercePepinCooperativeServices_applianceRebates": {
     "name": {
@@ -253,7 +305,9 @@
     },
     "url": {
       "en": "https://www.piercepepin.coop/programs-rebates"
-    }
+    },
+    "authority": "wi-pierce-pepin-cooperative-services",
+    "authority_type": "utility"
   },
   "wi_piercePepinCooperativeServices_electricWaterHeaterRebates": {
     "name": {
@@ -261,7 +315,9 @@
     },
     "url": {
       "en": "https://www.piercepepin.coop/programs-rebates"
-    }
+    },
+    "authority": "wi-pierce-pepin-cooperative-services",
+    "authority_type": "utility"
   },
   "wi_piercePepinCooperativeServices_energyEfficiencyImprovements": {
     "name": {
@@ -269,7 +325,9 @@
     },
     "url": {
       "en": "https://www.piercepepin.coop/programs-rebates"
-    }
+    },
+    "authority": "wi-pierce-pepin-cooperative-services",
+    "authority_type": "utility"
   },
   "wi_piercePepinCooperativeServices_eVChargingStationRebates": {
     "name": {
@@ -277,7 +335,9 @@
     },
     "url": {
       "en": "https://www.piercepepin.coop/programs-rebates"
-    }
+    },
+    "authority": "wi-pierce-pepin-cooperative-services",
+    "authority_type": "utility"
   },
   "wi_piercePepinCooperativeServices_hVAC-HeatPumps": {
     "name": {
@@ -285,7 +345,9 @@
     },
     "url": {
       "en": "https://www.piercepepin.coop/programs-rebates"
-    }
+    },
+    "authority": "wi-pierce-pepin-cooperative-services",
+    "authority_type": "utility"
   },
   "wi_polk-BurnettElectricCooperative_applianceRebates": {
     "name": {
@@ -293,7 +355,9 @@
     },
     "url": {
       "en": "https://www.polkburnett.com/rebates"
-    }
+    },
+    "authority": "wi-polk-burnett-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_polk-BurnettElectricCooperative_eVChargerRebates": {
     "name": {
@@ -301,7 +365,9 @@
     },
     "url": {
       "en": "https://www.polkburnett.com/rebates"
-    }
+    },
+    "authority": "wi-polk-burnett-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_polk-BurnettElectricCooperative_homeImprovementMeasureRebates": {
     "name": {
@@ -309,7 +375,9 @@
     },
     "url": {
       "en": "https://www.polkburnett.com/rebates"
-    }
+    },
+    "authority": "wi-polk-burnett-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_polk-BurnettElectricCooperative_hVACRebates": {
     "name": {
@@ -317,7 +385,9 @@
     },
     "url": {
       "en": "https://www.polkburnett.com/rebates"
-    }
+    },
+    "authority": "wi-polk-burnett-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_polk-BurnettElectricCooperative_renewableSolarRebates": {
     "name": {
@@ -325,7 +395,9 @@
     },
     "url": {
       "en": "https://www.polkburnett.com/rebates"
-    }
+    },
+    "authority": "wi-polk-burnett-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_polk-BurnettElectricCooperative_waterHeaterRebates": {
     "name": {
@@ -333,7 +405,9 @@
     },
     "url": {
       "en": "https://www.polkburnett.com/rebates"
-    }
+    },
+    "authority": "wi-polk-burnett-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_priceElectricCooperative_pECSmartSenseRebates:Appliances": {
     "name": {
@@ -341,7 +415,9 @@
     },
     "url": {
       "en": "https://priceelectric.coop/smart-sense-rebates"
-    }
+    },
+    "authority": "wi-price-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_priceElectricCooperative_pECSmartSenseRebates:EnergyAudit-RecommendedImprovements": {
     "name": {
@@ -349,7 +425,9 @@
     },
     "url": {
       "en": "https://priceelectric.coop/smart-sense-rebates"
-    }
+    },
+    "authority": "wi-price-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_priceElectricCooperative_pECSmartSenseRebates:HVAC": {
     "name": {
@@ -357,7 +435,9 @@
     },
     "url": {
       "en": "https://priceelectric.coop/smart-sense-rebates"
-    }
+    },
+    "authority": "wi-price-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_priceElectricCooperative_pECSmartSenseRebates:Solar": {
     "name": {
@@ -365,7 +445,9 @@
     },
     "url": {
       "en": "https://priceelectric.coop/smart-sense-rebates"
-    }
+    },
+    "authority": "wi-price-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_priceElectricCooperative_pECSmartSenseRebates:WaterHeaters": {
     "name": {
@@ -373,7 +455,9 @@
     },
     "url": {
       "en": "https://priceelectric.coop/smart-sense-rebates"
-    }
+    },
+    "authority": "wi-price-electric-cooperative",
+    "authority_type": "utility"
   },
   "wi_riverlandEnergyCooperative_applianceRebates": {
     "name": {
@@ -381,7 +465,9 @@
     },
     "url": {
       "en": "https://www.riverlandenergy.com/rebates"
-    }
+    },
+    "authority": "wi-riverland-energy-cooperative",
+    "authority_type": "utility"
   },
   "wi_riverlandEnergyCooperative_eVChargingRebates": {
     "name": {
@@ -389,7 +475,9 @@
     },
     "url": {
       "en": "https://www.riverlandenergy.com/rebates"
-    }
+    },
+    "authority": "wi-riverland-energy-cooperative",
+    "authority_type": "utility"
   },
   "wi_riverlandEnergyCooperative_hVACRebates": {
     "name": {
@@ -397,7 +485,9 @@
     },
     "url": {
       "en": "https://www.riverlandenergy.com/rebates"
-    }
+    },
+    "authority": "wi-riverland-energy-cooperative",
+    "authority_type": "utility"
   },
   "wi_riverlandEnergyCooperative_waterHeaterRebates": {
     "name": {
@@ -405,22 +495,8 @@
     },
     "url": {
       "en": "https://www.riverlandenergy.com/rebates"
-    }
-  },
-  "wi_weEnergies_residentialEVChargerPilotProgram": {
-    "name": {
-      "en": "Residential EV charger pilot program"
     },
-    "url": {
-      "en": "https://www.we-energies.com/services/electric-vehicles/ev-charger-pilot"
-    }
-  },
-  "wi_xcelEnergy_eVChargingIncentives": {
-    "name": {
-      "en": "EV Charging Incentives"
-    },
-    "url": {
-      "en": "https://ev.xcelenergy.com/ev-accelerate-at-home-wi"
-    }
+    "authority": "wi-riverland-energy-cooperative",
+    "authority_type": "utility"
   }
 }

--- a/scripts/lib/authority-and-program-updater.ts
+++ b/scripts/lib/authority-and-program-updater.ts
@@ -164,7 +164,12 @@ export function updateGeoGroups(
   return sortMapByKey(json);
 }
 
-type Program = { name: { en: string }; url: { en: string } };
+type Program = {
+  name: { en: string };
+  url: { en: string };
+  authority: string;
+  authority_type: string;
+};
 
 export async function createProgramsContent(
   state: string,
@@ -173,7 +178,7 @@ export async function createProgramsContent(
 ) {
   const programs: Record<string, Program> = {};
 
-  for (const authority of Object.values(authorityMap)) {
+  for (const [authorityId, authority] of Object.entries(authorityMap)) {
     for (const [programShort, program] of Object.entries(authority.programs)) {
       programs[programShort] = {
         name: {
@@ -182,6 +187,8 @@ export async function createProgramsContent(
         url: {
           en: program.url,
         },
+        authority: authorityId,
+        authority_type: authority.authority_type,
       };
     }
   }

--- a/scripts/lib/data-refiner.ts
+++ b/scripts/lib/data-refiner.ts
@@ -8,10 +8,7 @@ import {
   PASS_THROUGH_FIELDS,
   StateIncentive,
 } from '../../src/data/state_incentives';
-import {
-  createAuthorityName,
-  createProgramName,
-} from './authority-and-program-updater';
+import { createProgramName } from './authority-and-program-updater';
 
 type IncentiveToIdentifierMap = {
   [index: string]: string;
@@ -43,11 +40,9 @@ export class DataRefiner {
     state: string,
     record: CollectedIncentive,
   ): Partial<StateIncentive> {
-    const authorityName = createAuthorityName(state, record.authority_name);
     // Pass-through fields are those in CollectedIncentive that appear in the
     // refined StateIncentive verbatim. Everything else needs some processing.
     const output: Partial<StateIncentive> = _.pick(record, PASS_THROUGH_FIELDS);
-    output.authority = authorityName;
     output.program = createProgramName(
       state,
       record.authority_name,

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -1,15 +1,11 @@
 import fs from 'fs';
-import { LocalizableString } from './types/localizable-string';
+import { AuthorityType } from './authorities';
+import { Program } from './types/program';
 import { STATES_AND_TERRITORIES } from './types/states';
 
 const PROGRAMS_DIR = 'data';
 
-interface Program {
-  name: LocalizableString;
-  url: LocalizableString;
-}
-
-interface Programs {
+export interface Programs {
   [key: string]: Program;
 }
 
@@ -23,6 +19,8 @@ export const ira_programs = {
       en: 'https://www.irs.gov/credits-deductions/alternative-fuel-vehicle-refueling-property-credit',
       es: 'https://www.irs.gov/es/credits-deductions/alternative-fuel-vehicle-refueling-property-credit',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
   cleanVehicleCredit: {
     name: {
@@ -33,6 +31,8 @@ export const ira_programs = {
       en: 'https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after',
       es: 'https://www.irs.gov/es/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
   creditForPreviouslyOwnedCleanVehicles: {
     name: {
@@ -43,6 +43,8 @@ export const ira_programs = {
       en: 'https://www.irs.gov/credits-deductions/used-clean-vehicle-credit',
       es: 'https://www.irs.gov/es/credits-deductions/used-clean-vehicle-credit',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
   energyEfficientHomeImprovementCredit: {
     name: {
@@ -53,6 +55,8 @@ export const ira_programs = {
       en: 'https://www.irs.gov/credits-deductions/energy-efficient-home-improvement-credit',
       es: 'https://www.irs.gov/es/credits-deductions/energy-efficient-home-improvement-credit',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
   homeElectrificationAndApplianceRebates: {
     name: {
@@ -65,6 +69,8 @@ export const ira_programs = {
       en: 'https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates',
       es: 'https://www.rewiringamerica.org/app/ira-calculator/information/cuadro-electrico',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
   homeEfficiencyRebates: {
     name: {
@@ -77,6 +83,8 @@ export const ira_programs = {
       en: 'https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates',
       es: 'https://www.rewiringamerica.org/app/ira-calculator/information/climatizacion',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
   residentialCleanEnergyCredit: {
     name: {
@@ -87,20 +95,23 @@ export const ira_programs = {
       en: 'https://www.irs.gov/credits-deductions/residential-clean-energy-credit',
       es: 'https://www.irs.gov/es/credits-deductions/residential-clean-energy-credit',
     },
+    authority_type: AuthorityType.Federal,
+    authority: null,
   },
 } as const;
 
-const all_programs = STATES_AND_TERRITORIES.reduce((acc, state) => {
-  try {
-    const statePrograms = parseProgramJSON(state);
-    return { ...acc, ...statePrograms };
-  } catch (error) {
-    console.error(`Error parsing programs for state ${state}:`, error);
-    return acc;
-  }
-}, ira_programs);
-
-export const PROGRAMS: Programs = all_programs;
+export const PROGRAMS: Programs = STATES_AND_TERRITORIES.reduce(
+  (acc, state) => {
+    try {
+      const statePrograms = parseProgramJSON(state);
+      return { ...acc, ...statePrograms };
+    } catch (error) {
+      console.error(`Error parsing programs for state ${state}:`, error);
+      return acc;
+    }
+  },
+  ira_programs,
+);
 
 function parseProgramJSON(state: string) {
   let result: Programs = {};

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -138,7 +138,6 @@ const requiredCollectedFields = [
 // fitting to an enum or converting from string to number with minor cleanup,
 // it should have a separate collected and derived version.
 export type DerivedFields = {
-  authority: string;
   eligible_geo_group?: string;
   program: string;
   bonus_available?: boolean;
@@ -147,7 +146,6 @@ export type DerivedFields = {
 };
 
 const derivedIncentivePropertySchema = {
-  authority: { type: 'string' },
   eligible_geo_group: { type: 'string', nullable: true },
   program: { type: 'string', enum: Object.keys(PROGRAMS) },
   bonus_available: { type: 'boolean', nullable: true },
@@ -161,7 +159,6 @@ const derivedIncentivePropertySchema = {
 // without any modification or processing.
 export const PASS_THROUGH_FIELDS = [
   'id',
-  'authority_type',
   'payment_methods',
   'items',
   'start_date',
@@ -195,8 +192,6 @@ const fieldOrder: {
   [Key in keyof typeof incentivePropertySchema]: undefined;
 } = {
   id: undefined,
-  authority_type: undefined,
-  authority: undefined,
   eligible_geo_group: undefined,
   payment_methods: undefined,
   items: undefined,
@@ -214,8 +209,6 @@ export const FIELD_ORDER = Object.keys(fieldOrder);
 
 const requiredProperties = [
   'id',
-  'authority',
-  'authority_type',
   'payment_methods',
   'items',
   'program',

--- a/src/data/types/program.ts
+++ b/src/data/types/program.ts
@@ -1,3 +1,7 @@
+import { FromSchema } from 'json-schema-to-ts';
+import { AuthorityType } from '../authorities';
+import { LOCALIZABLE_STRING_SCHEMA } from './localizable-string';
+
 export const PROGRAM_SCHEMA = {
   $id: 'Program.schema.json',
   type: 'object',
@@ -8,9 +12,12 @@ export const PROGRAM_SCHEMA = {
     url: {
       $ref: 'LocalizableString',
     },
+    authority_type: { type: 'string', enum: Object.values(AuthorityType) },
+    authority: { type: 'string', nullable: true },
     description: { type: 'string' },
   },
-  required: ['name', 'url'],
+  required: ['name', 'url', 'authority_type', 'authority'],
+  additionalProperties: false,
 } as const;
 
 export const PROGRAMS_SCHEMA = {
@@ -22,3 +29,10 @@ export const PROGRAMS_SCHEMA = {
   },
   additionalProperties: false,
 } as const;
+
+export type Program = FromSchema<
+  typeof PROGRAM_SCHEMA,
+  {
+    references: [typeof LOCALIZABLE_STRING_SCHEMA];
+  }
+>;

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -6,6 +6,7 @@ import {
 } from '../data/authorities';
 import { DataPartnersType } from '../data/data_partners';
 import { IRAIncentive, IRA_INCENTIVES } from '../data/ira_incentives';
+import { PROGRAMS } from '../data/programs';
 import { SOLAR_PRICES } from '../data/solar_prices';
 import { StateIncentive } from '../data/state_incentives';
 import { FilingStatus } from '../data/tax_brackets';
@@ -320,6 +321,7 @@ export default function calculateIncentives(
       allStateIncentives,
       stateIncentiveRelationships,
       stateAuthorities,
+      PROGRAMS,
       amiAndEvCreditEligibility,
     );
     incentives.push(...state.stateIncentives);
@@ -357,9 +359,13 @@ export default function calculateIncentives(
   const authorities: AuthoritiesById = {};
   if (stateAuthorities) {
     incentives.forEach(i => {
-      if ('authority' in i && i.authority && i.authority_type !== 'federal') {
-        authorities[i.authority] =
-          stateAuthorities[i.authority_type]![i.authority];
+      const program = PROGRAMS[i.program];
+      if (
+        program.authority !== null &&
+        program.authority_type !== AuthorityType.Federal
+      ) {
+        authorities[program.authority] =
+          stateAuthorities[program.authority_type]![program.authority];
       }
     });
   }

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -28,6 +28,10 @@ function transformIncentives(
   return incentives.map(incentive => ({
     ...incentive,
 
+    // Transfer authority fields from program
+    authority: PROGRAMS[incentive.program].authority ?? undefined,
+    authority_type: PROGRAMS[incentive.program].authority_type,
+
     // Localize localizable fields
     program: tr(PROGRAMS[incentive.program].name, language),
     program_url: tr(PROGRAMS[incentive.program].url, language),

--- a/test/data/geo_groups.test.ts
+++ b/test/data/geo_groups.test.ts
@@ -4,6 +4,7 @@ import {
   AuthorityType,
 } from '../../src/data/authorities';
 import { GEO_GROUPS_BY_STATE } from '../../src/data/geo_groups';
+import { PROGRAMS } from '../../src/data/programs';
 import {
   STATE_INCENTIVES_BY_STATE,
   StateIncentive,
@@ -75,7 +76,8 @@ test('geo groups are equivalent in JSON config and incentives', async t => {
 test('Only AuthorityType.Other incentives have eligible_geo_group and vice versa', async t => {
   for (const [, stateIncentives] of Object.entries(STATE_INCENTIVES_BY_STATE)) {
     for (const incentive of stateIncentives) {
-      if (incentive.authority_type === AuthorityType.Other) {
+      const program = PROGRAMS[incentive.program];
+      if (program.authority_type === AuthorityType.Other) {
         t.hasProp(
           incentive,
           'eligible_geo_group',

--- a/test/fixtures/test-incentives.json
+++ b/test/fixtures/test-incentives.json
@@ -1,8 +1,6 @@
 [
   {
     "id": "A",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -22,8 +20,6 @@
   },
   {
     "id": "B",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -44,8 +40,6 @@
   },
   {
     "id": "C",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -65,8 +59,6 @@
   },
   {
     "id": "D",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -85,8 +77,6 @@
   },
   {
     "id": "E",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],
@@ -106,8 +96,6 @@
   },
   {
     "id": "F",
-    "authority_type": "utility",
-    "authority": "ri-pascoag-utility-district",
     "payment_methods": [
       "account_credit"
     ],

--- a/test/fixtures/test-programs.json
+++ b/test/fixtures/test-programs.json
@@ -1,0 +1,12 @@
+{
+  "ri_hvacAndWaterHeaterIncentives": {
+    "name": {
+      "en": "HVAC and water heater incentives"
+    },
+    "url": {
+      "en": "http://example.com"
+    },
+    "authority_type": "utility",
+    "authority": "ri-pascoag-utility-district"
+  }
+}

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -13,7 +13,7 @@ import {
   TEST_INVALID_INCENTIVE_RELATIONSHIPS,
   TEST_NESTED_INCENTIVE_RELATIONSHIPS,
 } from '../mocks/state-incentive-relationships';
-import { TEST_INCENTIVES } from '../mocks/state-incentives';
+import { TEST_INCENTIVES, TEST_PROGRAMS } from '../mocks/state-incentives';
 
 const LOCATION: ResolvedLocation = {
   state: 'RI',
@@ -45,6 +45,7 @@ test('basic test for supplying test incentive data to calculation logic', async 
     TEST_INCENTIVES,
     {},
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);
@@ -71,6 +72,7 @@ test('test calculation with no incentives', async t => {
     [],
     TEST_INCENTIVE_RELATIONSHIPS,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);
@@ -101,6 +103,7 @@ test('test incentive relationship logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);
@@ -139,6 +142,7 @@ test('test more complex incentive relationship logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_2,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);
@@ -180,6 +184,7 @@ test('test incentive relationship and combined max value logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);
@@ -223,6 +228,7 @@ test('test incentive relationship and permanent ineligibility criteria', async t
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
 
@@ -264,6 +270,7 @@ test('test nested incentive relationship logic', async t => {
     TEST_INCENTIVES,
     TEST_NESTED_INCENTIVE_RELATIONSHIPS,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);
@@ -295,6 +302,7 @@ test('test combined maximum savings logic', async t => {
     TEST_INCENTIVES,
     TEST_INCENTIVE_RELATIONSHIPS_3,
     {},
+    TEST_PROGRAMS,
     AMIS,
   );
   t.ok(data);

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -3,6 +3,7 @@ import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import { afterEach, beforeEach, test } from 'tap';
 import { AuthoritiesByType, AuthorityType } from '../../src/data/authorities';
+import { Programs } from '../../src/data/programs';
 import { StateIncentive } from '../../src/data/state_incentives';
 import { FilingStatus } from '../../src/data/tax_brackets';
 import { AmountType } from '../../src/data/types/amount';
@@ -510,8 +511,6 @@ test('correctly sorts incentives', async t => {
 test('correct filtering of county incentives', async t => {
   const incentive: StateIncentive = {
     id: 'CO',
-    authority_type: AuthorityType.County,
-    authority: 'mock-county-authority',
     start_date: '2023',
     end_date: '2024',
     payment_methods: [PaymentMethod.AccountCredit],
@@ -526,6 +525,15 @@ test('correct filtering of county incentives', async t => {
     ],
     short_description: {
       en: 'This is a model incentive only to be used for testing.',
+    },
+  };
+
+  const programs: Programs = {
+    ri_hvacAndWaterHeaterIncentives: {
+      name: { en: '' },
+      url: { en: '' },
+      authority: 'mock-county-authority',
+      authority_type: AuthorityType.County,
     },
   };
 
@@ -554,6 +562,7 @@ test('correct filtering of county incentives', async t => {
     [incentive],
     {},
     authorities,
+    programs,
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldFind);
@@ -565,6 +574,7 @@ test('correct filtering of county incentives', async t => {
     [incentive],
     {},
     authorities,
+    programs,
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldNotFind);
@@ -574,8 +584,6 @@ test('correct filtering of county incentives', async t => {
 test('correct filtering of city incentives', async t => {
   const incentive: StateIncentive = {
     id: 'CO',
-    authority_type: AuthorityType.City,
-    authority: 'mock-city-authority',
     start_date: '2023',
     end_date: '2024',
     payment_methods: [PaymentMethod.AccountCredit],
@@ -590,6 +598,15 @@ test('correct filtering of city incentives', async t => {
     ],
     short_description: {
       en: 'This is a model incentive only to be used for testing.',
+    },
+  };
+
+  const programs: Programs = {
+    ri_hvacAndWaterHeaterIncentives: {
+      name: { en: '' },
+      url: { en: '' },
+      authority: 'mock-city-authority',
+      authority_type: AuthorityType.City,
     },
   };
 
@@ -619,6 +636,7 @@ test('correct filtering of city incentives', async t => {
     [incentive],
     {},
     authorities,
+    programs,
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldFind);
@@ -630,6 +648,7 @@ test('correct filtering of city incentives', async t => {
     [incentive],
     {},
     authorities,
+    programs,
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldNotFindWithPartialMatch);
@@ -639,8 +658,6 @@ test('correct filtering of city incentives', async t => {
 test('correctly evaluates savings when state tax liability is lower than max savings', async t => {
   const incentive: StateIncentive = {
     id: 'CO',
-    authority_type: AuthorityType.State,
-    authority: 'mock-state-authority',
     start_date: '2023',
     end_date: '2024',
     payment_methods: [PaymentMethod.TaxCredit],
@@ -655,6 +672,15 @@ test('correctly evaluates savings when state tax liability is lower than max sav
     ],
     short_description: {
       en: 'This is a model incentive only to be used for testing.',
+    },
+  };
+
+  const programs: Programs = {
+    co_hvacAndWaterHeaterIncentives: {
+      name: { en: '' },
+      url: { en: '' },
+      authority: 'mock-state-authority',
+      authority_type: AuthorityType.State,
     },
   };
 
@@ -690,6 +716,7 @@ test('correctly evaluates savings when state tax liability is lower than max sav
     [incentive],
     {},
     authorities,
+    programs,
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
 

--- a/test/mocks/state-incentives.ts
+++ b/test/mocks/state-incentives.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { Programs } from '../../src/data/programs';
 import { StateIncentive } from '../../src/data/state_incentives';
 
 // These are model incentives created for the purpose of testing specific
@@ -6,4 +7,8 @@ import { StateIncentive } from '../../src/data/state_incentives';
 // launched data.
 export const TEST_INCENTIVES: StateIncentive[] = JSON.parse(
   fs.readFileSync('./test/fixtures/test-incentives.json', 'utf-8'),
+);
+
+export const TEST_PROGRAMS: Programs = JSON.parse(
+  fs.readFileSync('./test/fixtures/test-programs.json', 'utf-8'),
 );

--- a/test/scripts/authority-and-program-updater.test.ts
+++ b/test/scripts/authority-and-program-updater.test.ts
@@ -240,6 +240,8 @@ test('generate state program content', async tap => {
       url: {
         en: 'foo.com',
       },
+      authority: 'de-state',
+      authority_type: 'state',
     },
     de_delawareStateEnergy_bar: {
       name: {
@@ -248,6 +250,8 @@ test('generate state program content', async tap => {
       url: {
         en: 'bar.com',
       },
+      authority: 'de-state',
+      authority_type: 'state',
     },
     de_delawareUtility_baz: {
       name: {
@@ -256,6 +260,8 @@ test('generate state program content', async tap => {
       url: {
         en: 'baz.com',
       },
+      authority: 'de-utility',
+      authority_type: 'utility',
     },
     de_delawareUtility_qux: {
       name: {
@@ -264,6 +270,8 @@ test('generate state program content', async tap => {
       url: {
         en: 'qux.com',
       },
+      authority: 'de-utility',
+      authority_type: 'utility',
     },
   };
 

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -62,8 +62,6 @@ test('correct row to record transformation', tap => {
       },
       want: {
         id: 'VA-1',
-        authority_type: 'utility',
-        authority: 'va-appalachian-power',
         items: ['heat_pump_clothes_dryer'],
         payment_methods: ['rebate'],
         program:


### PR DESCRIPTION
## Description

Since incentive-admin stores these things as "incentive has a program,
program has an authority", which reflects the underlying reality. It
causes some difficulty that this codebase stores them as "incentive
has a program, incentive has an authority".

This makes it so that programs refer to authorities, and incentives
don't.

- Application-code changes are actually pretty minimal.

- This uncovered a bunch of programs that aren't used anymore; I
  removed those by hand.

- The CT data (very old; predates spreadsheet-JSON scripts) had some
  programs that overlapped multiple utilities, so I split them up by hand.

## Test Plan

`yarn test` with a bunch of updated tests.

With a corresponding admin change, successfully imported and exported.

The spreadsheet-to-JSON scripts are updated enough to pass unit tests,
but I admit I did not test them with real spreadsheets. I'm hopeful
that we won't need to use them much longer.
