### PR TITLE
update Efficiency Maine mobile home heat pump incentive

### DIFF
--- a/data/ME/incentives.json
+++ b/data/ME/incentives.json
@@ -358,14 +358,15 @@
     ],
     "program": "me_efficiencyMaine_efficiencyMaineResidentialHeatPumpIncentives",
     "amount": {
-      "type": "dollar_amount",
-      "number": 2000
+      "type": "percent",
+      "number": 0.85,
+      "maximum": 12900
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "$2,000 rebate for ducted heat pump, with option to be distributed in monthly payments. Available for low income residents."
+      "en": "Up to 85% of the cost of ducted heat pump systems for manufactured (mobile) homes. Available for low-income households. $2,000 co-pay."
     },
     "low_income": "me-low-income"
   },

--- a/test/snapshots/v1-me-04772-state-lowincome.json
+++ b/test/snapshots/v1-me-04772-state-lowincome.json
@@ -65,6 +65,27 @@
       ],
       "authority_type": "state",
       "authority": "me-efficiency-maine",
+      "program": "Efficiency Maine Residential Heat Pump Incentives",
+      "program_url": "https://www.efficiencymaine.com",
+      "items": [
+        "ducted_heat_pump"
+      ],
+      "amount": {
+        "type": "percent",
+        "number": 0.85,
+        "maximum": 12900
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "short_description": "Up to 85% of the cost of ducted heat pump systems for manufactured (mobile) homes. Available for low-income households. $2,000 co-pay."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "state",
+      "authority": "me-efficiency-maine",
       "program": "Efficiency Maine Insulation Rebates",
       "program_url": "https://www.efficiencymaine.com",
       "items": [
@@ -272,26 +293,6 @@
         "renter"
       ],
       "short_description": "$2,000 rebate for new battery electric vehicles."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "me-efficiency-maine",
-      "program": "Efficiency Maine Residential Heat Pump Incentives",
-      "program_url": "https://www.efficiencymaine.com",
-      "items": [
-        "ducted_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 2000
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "$2,000 rebate for ducted heat pump, with option to be distributed in monthly payments. Available for low income residents."
     },
     {
       "payment_methods": [


### PR DESCRIPTION
From EM: "One other inconsistency is on the heat pump offers. We do not have a rebate for $2,000 for a ducted system. I think what is trying to be expressed there is that we have a Manufactured (Mobile) Home Initiative that pays the complete installation of a heat pump and removal of the fossil system with a customer co-pay of $2,000, where Efficiency Maine pays the remaining cost ($12,900)"