### PR TITLE
Change link to dev portal login/signup

### DIFF
--- a/src/plugins/swagger.ts
+++ b/src/plugins/swagger.ts
@@ -12,7 +12,8 @@ The "v0" of this API is still available, but deprecated; we plan to remove it \
 in the near future, and new applications should not use it.
 
 **To generate an API key, click on the "Sign In" button. You can also use \
-[this link](https://www.rewiringamerica.org/api) to sign up if needed**.
+[this link](https://homes.rewiringamerica.org/api/developer-login) to sign up \
+if needed**.
 
 If you have feedback, or if you've stumbled across this page by accident and \
 you'd like to learn more, reach out to us at \


### PR DESCRIPTION
The previous link now goes to the wrong place with the main site
relaunch (the API marketing page instead of the Auth0 dev portal/login).
