### PR TITLE
Export additive changes from HERO

### DIFF
--- a/data/MI/authorities.json
+++ b/data/MI/authorities.json
@@ -1,4 +1,11 @@
 {
+  "city": {
+    "mi-ann-arbor-city-of": {
+      "name": "City of Ann Arbor",
+      "city": "Ann Arbor",
+      "county_fips": "26161"
+    }
+  },
   "utility": {
     "mi-alger-delta-cooperative-electric-association": {
       "name": "Alger-Delta Cooperative Electric Association"

--- a/data/MI/incentives.json
+++ b/data/MI/incentives.json
@@ -1142,5 +1142,301 @@
       "en": "Up to $1,000 rebate for installation of a home EV charger.",
       "es": "Un reembolso de hasta $1,000 por la instalación de un cargador de VE doméstico."
     }
+  },
+  {
+    "id": "MI-82",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "battery_storage_installation"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2000,
+      "maximum": 2000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$2000 Rebate for battery storage"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-83",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "weatherization"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2500,
+      "maximum": 2500
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$2500 Rebate for weatherization"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-84",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "ducted_heat_pump"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2500,
+      "maximum": 2500
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$2500 Rebate for air source heat pump"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-85",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1000,
+      "maximum": 1000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$1000 Rebate for heat pump water heater"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-86",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2000,
+      "maximum": 2000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$2000 Rebate for heat pump water heater"
+    },
+    "start_date": "2024-07-01",
+    "low_income": "mi-a2zero"
+  },
+  {
+    "id": "MI-87",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "battery_storage_installation"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 3500,
+      "maximum": 3500
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$3500 Rebate for battery storage"
+    },
+    "start_date": "2024-07-01",
+    "low_income": "mi-a2zero"
+  },
+  {
+    "id": "MI-88",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "weatherization"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 4000,
+      "maximum": 4000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$4000 Rebate for weatherization"
+    },
+    "start_date": "2024-07-01",
+    "low_income": "mi-a2zero"
+  },
+  {
+    "id": "MI-89",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "ducted_heat_pump"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 3500,
+      "maximum": 3500
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$2500 Rebate for air source heat pump"
+    },
+    "start_date": "2024-07-01",
+    "low_income": "mi-a2zero"
+  },
+  {
+    "id": "MI-90",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "heat_pump_water_heater"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1000,
+      "maximum": 1000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$1000 Rebate for heat pump water heater"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-91",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "ebike"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 500,
+      "minimum": 250,
+      "maximum": 500
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$500 Rebate for cargo e-bikes and $250 for standard e-bikes"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-92",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "ebike"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1200,
+      "minimum": 1000,
+      "maximum": 1200
+    },
+    "owner_status": [
+      "homeowner",
+      "renter"
+    ],
+    "short_description": {
+      "en": "$1200 Rebate for cargo e-bikes and $1000 for standard e-bikes"
+    },
+    "start_date": "2024-07-01",
+    "low_income": "mi-a2zero"
+  },
+  {
+    "id": "MI-93",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "electric_panel"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1000,
+      "maximum": 1000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$1000 Rebate for Electric panel upgrades"
+    },
+    "start_date": "2024-07-01"
+  },
+  {
+    "id": "MI-94",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "electric_panel"
+    ],
+    "program": "mi_a2zero_home_energy_rebates",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 1000,
+      "maximum": 1000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "$2000 Rebate for electric panel upgrades"
+    },
+    "start_date": "2024-07-01",
+    "low_income": "mi-a2zero"
   }
 ]

--- a/data/MI/programs.json
+++ b/data/MI/programs.json
@@ -1,4 +1,15 @@
 {
+  "mi_a2zero_home_energy_rebates": {
+    "name": {
+      "en": "Ann Arbor A2 ZERO Home Energy Rebates"
+    },
+    "url": {
+      "en": "https://www.a2gov.org/departments/sustainability/Sustainability-Me/Families-Individuals/Pages/Home-Energy-Rebates.aspx"
+    },
+    "authority": "mi-ann-arbor-city-of",
+    "authority_type": "city",
+    "description": "Ann Arbor A2 ZERO Home Energy Rebates"
+  },
   "mi_consumersEnergy_heatingAndCoolingRebates": {
     "name": {
       "en": "Heating and Cooling Rebates"

--- a/data/VT/incentive_relationships.json
+++ b/data/VT/incentive_relationships.json
@@ -11,6 +11,13 @@
         "VT-21"
       ]
     },
+    "VT-23": {
+      "ids": [
+        "VT-8",
+        "VT-21"
+      ],
+      "description": ""
+    },
     "VT-40": {
       "ids": [
         "VT-37"
@@ -42,6 +49,18 @@
         "VT-41",
         "VT-42"
       ]
+    },
+    "VT-100": {
+      "ids": [
+        "VT-7"
+      ],
+      "description": ""
+    },
+    "VT-101": {
+      "ids": [
+        "VT-18"
+      ],
+      "description": ""
     }
   },
   "prerequisites": {

--- a/data/VT/incentives.json
+++ b/data/VT/incentives.json
@@ -424,8 +424,8 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Customers may receive a rebate up to $2,500 on qualifying ductless heat pumps, or $500 for a second heat pump.",
-      "es": "Los clientes de BED pueden recibir un reembolso de hasta $2,500 en las bombas de calor que cumplan los requisitos, o $500 por una segunda bomba de calor."
+      "en": "Customers may receive a rebate up to $2,500 on qualifying ductless heat pumps, or $500 for a second heat pump. Total rebate capped at 75% of the cost. Available through your contractor.",
+      "es": "Los clientes de BED pueden recibir un reembolso de hasta $2,500 en las bombas de calor que cumplan los requisitos, o $500 por una segunda bomba de calor. El reembolso total está limitado al 75% del costo. Disponible a través de su contratista."
     },
     "start_date": "2022-01-01",
     "end_date": "2024-12-31"
@@ -797,7 +797,7 @@
     "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForHeatPumpWaterHeater",
     "amount": {
       "type": "dollar_amount",
-      "number": 800,
+      "number": 600,
       "minimum": 500,
       "maximum": 800
     },
@@ -805,8 +805,8 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Customers may receive upto $800 rebate for a heat pump water heater.",
-      "es": "Los clientes de BED pueden recibir un reembolso de hasta $800 por un calentador de agua con bomba de calor."
+      "en": "$600 available from BED through Efficiency VT, available through your contractor.",
+      "es": "Los clientes de BED pueden recibir un reembolso de hasta $600 por un calentador de agua con bomba de calor, disponible a través de su contratista."
     },
     "start_date": "2022-01-01",
     "end_date": "2024-12-31"
@@ -950,7 +950,7 @@
       "homeowner"
     ],
     "short_description": {
-      "en": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing.",
+      "en": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing. If you are a VGS customer, visit www.vermontgas.com to determine eligibility for further weatherization projects",
       "es": "Reciba dinero en efectivo en materiales para tres proyectos de auto-instalación elegibiles, incluyendo la colocación de sellos, aislamiento y sellado para juntas herméticas."
     },
     "start_date": "2019-09-23"
@@ -1131,15 +1131,15 @@
     "amount": {
       "type": "percent",
       "number": 0.5,
-      "minimum": 100,
+      "minimum": 40,
       "maximum": 300
     },
     "owner_status": [
       "homeowner"
     ],
     "short_description": {
-      "en": "Up to $100 back for residential push mower or up to $300 back for a ride-on mower and $50 on electric chainsaws and trimmers.",
-      "es": "Hasta $100 de devolución por una podadora manual residencial o hasta $300 de reembolso por una podadora de operador a bordo y $50 en motosierras y desbrozadoras eléctricas."
+      "en": "Up to $100 back for residential push mower or up to $300 back for a ride-on mower, $50 on electric chainsaws and trimmers, $40 on electric leaf blowers.",
+      "es": "Hasta $100 de devolución por una podadora manual residencial o hasta $300 de reembolso por una podadora de operador a bordo, $50 en motosierras y desbrozadoras eléctricas, $40 en sopladores de hojas eléctricos."
     },
     "start_date": "2022-01-01",
     "end_date": "2024-12-31",
@@ -1459,7 +1459,7 @@
       "rebate"
     ],
     "items": [
-      "other"
+      "heat_pump_clothes_dryer"
     ],
     "program": "vt_efficiencyVermont_efficiencyVermont-Washer&DryerRebate",
     "amount": {
@@ -1505,7 +1505,7 @@
       "pos_rebate"
     ],
     "items": [
-      "other"
+      "electric_stove"
     ],
     "program": "vt_efficiencyVermont_efficiencyVermont-Wood&PelletStoveRebate",
     "amount": {
@@ -1962,5 +1962,78 @@
       "es": "Un 100% de descuento en un calentador de agua con bomba de calor, hasta $5,000, para clientes con bajos ingresos."
     },
     "low_income": "vt-default"
+  },
+  {
+    "id": "VT-99",
+    "payment_methods": [
+      "rebate"
+    ],
+    "items": [
+      "heat_pump_clothes_dryer"
+    ],
+    "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForClothesDryer",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 400,
+      "maximum": 400
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "BED rebate offered through Efficiency Vermont. Apply for a rebate and get up to $400 cash back on qualifying ENERGY STAR® heat pump models.",
+      "es": "BED reembolso ofrecido por Efficiency Vermont. Solicite un reembolso y reciba hasta $400 de devolución en los modelos de bomba de calor ENERGY STAR® que cumplan los requisitos."
+    },
+    "start_date": "2023-10-01"
+  },
+  {
+    "id": "VT-100",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "items": [
+      "ducted_heat_pump"
+    ],
+    "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctedHeatPump",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 2000,
+      "minimum": 1000,
+      "maximum": 2000
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "Work with a contractor to install your ducted heat pump and get a $1,000-$2,000 instant discount.",
+      "es": "Trabaje con un contratista para instalar su bomba de calor con ductos y obtenga un descuento instantáneo de entre $1,000 y $2,000."
+    },
+    "start_date": "2021-11-01",
+    "end_date": "2024-12-31"
+  },
+  {
+    "id": "VT-101",
+    "payment_methods": [
+      "pos_rebate"
+    ],
+    "items": [
+      "ductless_heat_pump"
+    ],
+    "program": "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctlessHeatPump",
+    "amount": {
+      "type": "dollar_amount",
+      "number": 450,
+      "minimum": 350,
+      "maximum": 450
+    },
+    "owner_status": [
+      "homeowner"
+    ],
+    "short_description": {
+      "en": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor.",
+      "es": "Contrate a un técnico y obtenga un descuento instantáneo de entre $350 y $450 en modelos aprobados de bombas de calor sin ductos de un distribuidor participante."
+    },
+    "start_date": "2021-11-01",
+    "end_date": "2024-12-31"
   }
 ]

--- a/data/VT/programs.json
+++ b/data/VT/programs.json
@@ -29,6 +29,17 @@
     "authority": "vt-burlington-electric-department",
     "authority_type": "utility"
   },
+  "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForClothesDryer": {
+    "name": {
+      "en": "Burlington Electric Department - Rebate for Heat Pump Clothes Dryers"
+    },
+    "url": {
+      "en": "https://www.burlingtonelectric.com/laundry"
+    },
+    "authority": "vt-burlington-electric-department",
+    "authority_type": "utility",
+    "description": ""
+  },
   "vt_burlingtonElectricDepartment_burlingtonElectricDepartment-RebateForDuctedHeatPump": {
     "name": {
       "en": "Burlington Electric Department - Rebate for Ducted Heat Pump"

--- a/data/low_income_thresholds.json
+++ b/data/low_income_thresholds.json
@@ -1097,6 +1097,45 @@
     }
   },
   "MI": {
+    "mi-a2li": {
+      "type": "hhsize",
+      "incentives": [],
+      "source_url": "https://www.a2gov.org/departments/sustainability/Sustainability-Me/Families-Individuals/Pages/Home-Energy-Rebates.aspx",
+      "description": "Ann Arbor 120% AMI",
+      "thresholds": {
+        "1": 104200,
+        "2": 119200,
+        "3": 134000,
+        "4": 148800,
+        "5": 160800,
+        "6": 172800,
+        "7": 184600,
+        "8": 196600
+      }
+    },
+    "mi-a2zero": {
+      "type": "hhsize",
+      "incentives": [
+        "MI-86",
+        "MI-87",
+        "MI-88",
+        "MI-89",
+        "MI-92",
+        "MI-94"
+      ],
+      "source_url": "https://www.a2gov.org/departments/sustainability/Sustainability-Me/Families-Individuals/Pages/Home-Energy-Rebates.aspx",
+      "description": "Ann Arbor LMI Thresholds",
+      "thresholds": {
+        "1": 104200,
+        "2": 119200,
+        "3": 134000,
+        "4": 148800,
+        "5": 160800,
+        "6": 172800,
+        "7": 184600,
+        "8": 196600
+      }
+    },
     "mi-dte": {
       "type": "hhsize",
       "incentives": [

--- a/src/data/low_income_thresholds.ts
+++ b/src/data/low_income_thresholds.ts
@@ -59,7 +59,6 @@ export const AUTHORITY_INFO_SCHEMA = {
     incentives: {
       type: 'array',
       items: { type: 'string' },
-      minItems: 1,
       uniqueItems: true,
     },
   },

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -76,6 +76,9 @@ import {
 } from '../../src/lib/incentive-relationship-calculation';
 import { incentiveRelationshipsContainCycle } from './cycles';
 
+const ENGLISH_DESC_CHAR_LIMIT = 250;
+const SPANISH_DESC_CHAR_LIMIT = 400;
+
 const TESTS = [
   [I_SCHEMA, IRA_INCENTIVES, 'ira_incentives'],
   [ISS_SCHEMA, IRA_STATE_SAVINGS, 'ira_state_savings'],
@@ -165,7 +168,7 @@ test('state incentives JSON files match schemas', async tap => {
     // Check some constraints that aren't expressed in JSON schema
     data.forEach((incentive, index) => {
       tap.ok(
-        incentive.short_description.en.length <= 150,
+        incentive.short_description.en.length <= ENGLISH_DESC_CHAR_LIMIT,
         `${stateId} English description too long ` +
           `(${incentive.short_description.en.length}), id ${incentive.id}, index ${index}`,
       );
@@ -173,7 +176,7 @@ test('state incentives JSON files match schemas', async tap => {
       // We let Spanish descriptions be longer
       if (incentive.short_description.es) {
         tap.ok(
-          incentive.short_description.es.length <= 400,
+          incentive.short_description.es.length <= SPANISH_DESC_CHAR_LIMIT,
           `${stateId} Spanish description too long ` +
             `(${incentive.short_description.en.length}), id ${incentive.id}, index ${index}`,
         );

--- a/test/snapshots/v1-80517-xcel.json
+++ b/test/snapshots/v1-80517-xcel.json
@@ -3,11 +3,11 @@
   "is_under_150_ami": true,
   "is_over_150_ami": false,
   "authorities": {
-    "co-colorado-energy-office": {
-      "name": "Colorado Energy Office"
-    },
     "co-xcel-energy": {
       "name": "Xcel Energy"
+    },
+    "co-colorado-energy-office": {
+      "name": "Colorado Energy Office"
     },
     "co-state-of-colorado": {
       "name": "State of Colorado"

--- a/test/snapshots/v1-vt-05401-state-utility-lowincome.json
+++ b/test/snapshots/v1-vt-05401-state-utility-lowincome.json
@@ -103,10 +103,10 @@
       "payment_methods": [
         "pos_rebate"
       ],
-      "authority_type": "state",
-      "authority": "vt-efficiency-vermont",
-      "program": "Efficiency Vermont Ducted Heat Pump Rebate",
-      "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
+      "authority_type": "utility",
+      "authority": "vt-burlington-electric-department",
+      "program": "Burlington Electric Department - Rebate for Ducted Heat Pump",
+      "program_url": "https://www.burlingtonelectric.com/heatpumps",
       "items": [
         "ducted_heat_pump"
       ],
@@ -119,16 +119,17 @@
         "homeowner"
       ],
       "start_date": "2021-11-01",
+      "end_date": "2024-12-31",
       "short_description": "Work with a contractor to install your ducted heat pump and get a $1,000-$2,000 instant discount."
     },
     {
       "payment_methods": [
         "pos_rebate"
       ],
-      "authority_type": "state",
-      "authority": "vt-efficiency-vermont",
-      "program": "Efficiency Vermont Ductless Heat Pump Rebate",
-      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
+      "authority_type": "utility",
+      "authority": "vt-burlington-electric-department",
+      "program": "Burlington Electric Department - Rebate for Ductless Heat Pump",
+      "program_url": "https://www.burlingtonelectric.com/rebate-form?item_purchased=Mini-Split%20Heat%20Pump",
       "items": [
         "ductless_heat_pump"
       ],
@@ -141,6 +142,7 @@
         "homeowner"
       ],
       "start_date": "2021-11-01",
+      "end_date": "2024-12-31",
       "short_description": "Hire a contractor and get a $350-$450 instant discount on qualifying models of ductless heat pumps at a participating distributor."
     },
     {
@@ -152,7 +154,7 @@
       "program": "Efficiency Vermont - Wood & Pellet Stove Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/wood-stoves",
       "items": [
-        "other"
+        "electric_stove"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -251,7 +253,7 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "short_description": "Customers may receive a rebate up to $2,500 on qualifying ductless heat pumps, or $500 for a second heat pump."
+      "short_description": "Customers may receive a rebate up to $2,500 on qualifying ductless heat pumps, or $500 for a second heat pump. Total rebate capped at 75% of the cost. Available through your contractor."
     },
     {
       "payment_methods": [
@@ -340,7 +342,7 @@
       ],
       "start_date": "2022-01-01",
       "end_date": "2024-12-31",
-      "short_description": "Up to $100 back for residential push mower or up to $300 back for a ride-on mower and $50 on electric chainsaws and trimmers."
+      "short_description": "Up to $100 back for residential push mower or up to $300 back for a ride-on mower, $50 on electric chainsaws and trimmers, $40 on electric leaf blowers."
     },
     {
       "payment_methods": [
@@ -482,50 +484,6 @@
       "payment_methods": [
         "rebate"
       ],
-      "authority_type": "state",
-      "authority": "vt-efficiency-vermont",
-      "program": "Efficiency Vermont Ductless Heat Pump Rebate Income Bonus",
-      "program_url": "https://www.efficiencyvermont.com/rebates/list/heat-pump-heating-cooling-system",
-      "items": [
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1000,
-        "maximum": 1000
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "short_description": "Income-eligible Vermonters qualify for a $200-$1,000 bonus rebate on a ductless heat pump, depending on their utility."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "vt-burlington-electric-department",
-      "program": "Burlington Electric Department - Rebate for Heat Pump Water Heater",
-      "program_url": "https://www.burlingtonelectric.com/waterheaters",
-      "items": [
-        "heat_pump_water_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 800,
-        "maximum": 800
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2022-01-01",
-      "end_date": "2024-12-31",
-      "short_description": "Customers may receive upto $800 rebate for a heat pump water heater."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
       "authority_type": "utility",
       "authority": "vt-burlington-electric-department",
       "program": "Burlington Electric Department Electric Vehicle Rebate Income Bonus",
@@ -544,6 +502,29 @@
         "renter"
       ],
       "short_description": "An extra $700 for a new all-electric vehicle, or $300 for a plug-in hybrid, for income-qualified customers."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "utility",
+      "authority": "vt-burlington-electric-department",
+      "program": "Burlington Electric Department - Rebate for Heat Pump Water Heater",
+      "program_url": "https://www.burlingtonelectric.com/waterheaters",
+      "items": [
+        "heat_pump_water_heater"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 600,
+        "maximum": 800
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2022-01-01",
+      "end_date": "2024-12-31",
+      "short_description": "$600 available from BED through Efficiency VT, available through your contractor."
     },
     {
       "payment_methods": [
@@ -667,7 +648,7 @@
       "program": "Efficiency Vermont - Washer & Dryer Rebate",
       "program_url": "https://www.efficiencyvermont.com/rebates/list/washer-dryer",
       "items": [
-        "other"
+        "heat_pump_clothes_dryer"
       ],
       "amount": {
         "type": "dollar_amount",
@@ -684,21 +665,23 @@
       "payment_methods": [
         "rebate"
       ],
-      "authority_type": "state",
-      "authority": "vt-efficiency-vermont",
-      "program": "Efficiency Vermont Ducted Heat Pump Rebate Income Bonus",
-      "program_url": "https://www.efficiencyvermont.com/rebates/list/centrally-ducted-heat-pumps",
+      "authority_type": "utility",
+      "authority": "vt-burlington-electric-department",
+      "program": "Burlington Electric Department - Rebate for Heat Pump Clothes Dryers",
+      "program_url": "https://www.burlingtonelectric.com/laundry",
       "items": [
-        "ducted_heat_pump"
+        "heat_pump_clothes_dryer"
       ],
       "amount": {
         "type": "dollar_amount",
-        "number": 200
+        "number": 400,
+        "maximum": 400
       },
       "owner_status": [
         "homeowner"
       ],
-      "short_description": "Vermonters with low or moderate household income may qualify for a $200 bonus rebate on a ducted heat pump, depending on their utility."
+      "start_date": "2023-10-01",
+      "short_description": "BED rebate offered through Efficiency Vermont. Apply for a rebate and get up to $400 cash back on qualifying ENERGY STAR® heat pump models."
     },
     {
       "payment_methods": [
@@ -789,7 +772,7 @@
         "homeowner"
       ],
       "start_date": "2019-09-23",
-      "short_description": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing."
+      "short_description": "Get cash back on materials for three elgibile DIY projects including weather-stripping, insulation, and air sealing. If you are a VGS customer, visit www.vermontgas.com to determine eligibility for further weatherization projects"
     },
     {
       "payment_methods": [


### PR DESCRIPTION
## Description

HERO and this codebase are currently out of sync -- both sides have
changes that the other side does not have. This is the first step to
resolving that situation.

I did a full export from HERO, and created this PR from only the parts
that were _added_; these are the updates that were in HERO but not in
JSON/spreadsheets.

With this done, we can once again do non-destructive imports from JSON
to HERO, to bring them fully back in sync and complete the deprecation
of spreadsheets.

There are two minor changes to the validation tests:

- Bumped the English character limit for descriptions up to 250, to
  accommodate a long description for a VT incentive that we were asked
  to put in. We do have a path to reducing this again, though; I've
  made a ticket for it.

- Removed `minItems: 1` from the JSON schema for low-income
  thresholds, because there's now a set of thresholds in MI that has
  no incentives. The check was there in the manually-edited-JSON days
  basically to catch mistakes where you forgot to set the threshold on
  the incentives that used it; that's less of an issue now, so I feel
  OK losing this check.

## Test Plan

`yarn test`.

If I import from prod HERO now, the only changes are removing a bunch
of ME and RI data. That's data that was added via spreadsheets, and
not reflected in HERO.
