### PR TITLE
[NOT FOR MERGE] Import extra columns from spreadsheet

### DIFF
--- a/data/WI/incentives.json
+++ b/data/WI/incentives.json
@@ -22,8 +22,18 @@
       "en": "$200 rebate for DIY attic insulation and air sealing, must meet R42 insulation level.",
       "es": "Un reembolso de $200 por aislamiento térmico y sellado hermético del ático realizado por usted mismo, debe cumplir el nivel de aislamiento R42."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/diy"
+    ],
+    "equipment_standards_restrictions": "Insulation level of R42 or greater",
+    "equipment_capacity_restrictions": "At least 600 sq ft of attic area must be improved",
+    "contractor_restrictions": "DIY installations, consult with a Trade Ally contractor if needed",
+    "other_restrictions": "Only for living spaces, not for new construction/additions, must be a customer of a participating utility",
+    "stacking_details": "Cannot be claimed on another Focus on Energy application, one rebate per type of improvement",
+    "financing_details": "Rebate may not exceed the total purchase price of the improvement"
   },
   {
     "id": "WI-19",
@@ -46,7 +56,13 @@
     "short_description": {
       "en": "Instant discounts starting at $300 for ENERGY STAR® certified electric heat pump water heaters.",
       "es": "Descuentos instantáneos a partir de $300 para calentadores de agua eléctricos con bomba de calor y certificación ENERGY STAR®."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://focusonenergy.com/residential/water-heating"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® certified electric heat pump water heater",
+    "other_restrictions": "Must be completed along with Trade Ally contractor installed attic insulation improvements."
   },
   {
     "id": "WI-20",
@@ -72,9 +88,18 @@
       "en": "Up to $500 rebate for residential solar PV systems, additional $500 for rural areas.",
       "es": "Un reembolso de hasta $500 para sistemas solares fotovoltaicos residenciales, $500 adicionales para zonas rurales."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-12-31",
-    "bonus_available": true
+    "bonus_available": true,
+    "data_urls": [
+      "https://focusonenergy.com/residential/solar-for-homes"
+    ],
+    "equipment_standards_restrictions": "Must select qualified models from Solar Electric Qualified Equipment List",
+    "equipment_capacity_restrictions": "System capacity must be 0.5 kWDC or greater",
+    "contractor_restrictions": "Must be installed by a professional contractor with a valid Wisconsin State professional contractor's license",
+    "other_restrictions": "System must be grid-tied, installed behind the meter, and purchased new. Rebate cannot exceed cost to customer.",
+    "stacking_details": "Focus on Energy will only pay one rebate per site or meter per calendar year."
   },
   {
     "id": "WI-21",
@@ -98,8 +123,14 @@
       "en": "$50 rebate for qualified smart thermostats. Available as instant discounts in the online marketplace or as rebates.",
       "es": "Un reembolso de $50 para termostatos inteligentes que reúnan los requisitos. Disponibles como descuentos instantáneos en el mercado en línea o como reembolsos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "bonus_available": true
+    "bonus_available": true,
+    "data_urls": [
+      "https://focusonenergy.com/residential/smart-thermostats"
+    ],
+    "equipment_standards_restrictions": "ENERGY STAR certified",
+    "other_restrictions": "Cannot be resale, leased, rebuilt, rented, from insurance claims, warranty, won as prize, or purchased for resale."
   },
   {
     "id": "WI-22",
@@ -124,8 +155,13 @@
       "en": "$1,000 rebate for air source heat pumps replacing natural gas or electric resistance.",
       "es": "Un reembolso de $1,000 para bombas de calor con fuente de aire que sustituyan a las de gas natural o resistencia eléctrica."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-05-31"
+    "end_date": "2024-05-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/heating-and-cooling"
+    ],
+    "equipment_standards_restrictions": "Ducted 15.2 SEER2 | 10.0 EER2 | 8.1 HSPF2 | 1.75 COP at 5°\n\nDuctless 16.0 SEER2 | 9.0 EER2 | 9.5 HSPF2 | 1.75 COP at 5°"
   },
   {
     "id": "WI-23",
@@ -150,8 +186,13 @@
       "en": "$400 rebate for air source heat pumps replacing propane, oil, existing heat pump, etc.",
       "es": "Un reembolso de $400 para bombas de calor de fuente de aire que sustituyan a las de propano, gasóleo, bombas de calor existentes, etc."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-05-31"
+    "end_date": "2024-05-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/heating-and-cooling"
+    ],
+    "equipment_standards_restrictions": "Ducted 15.2 SEER2 | 10.0 EER2 | 8.1 HSPF2 | 1.75 COP at 5°\n\nDuctless 16.0 SEER2 | 9.0 EER2 | 9.5 HSPF2 | 1.75 COP at 5°"
   },
   {
     "id": "WI-24",
@@ -177,8 +218,14 @@
       "en": "$750 rebate for certified geothermal heat pumps without natural gas service or $1000 with natural gas service.",
       "es": "Un reembolso de $750 para bombas de calor geotérmicas certificadas sin servicio de gas natural o de $1,000 con servicio de gas natural."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-05-31"
+    "end_date": "2024-05-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/heating-and-cooling"
+    ],
+    "equipment_standards_restrictions": "Qualifying products list",
+    "other_restrictions": "Must be completed along with Trade Ally contractor installed attic insulation improvements."
   },
   {
     "id": "WI-25",
@@ -202,8 +249,14 @@
       "en": "Up to $675 rebate for ENERGY STAR® Qualified Air Sealing, assessment required.",
       "es": "Un reembolso de hasta $675 para el sellado hermético con certificación ENERGY STAR®, pero se requiere una evaluación."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-05-31"
+    "end_date": "2024-05-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility"
   },
   {
     "id": "WI-26",
@@ -227,9 +280,15 @@
       "en": "Up to $1,125 rebate for ENERGY STAR® Qualified Air Sealing, assessment required. For income-qualified customers.",
       "es": "Un reembolso de hasta $1,125 para el sellado hermético con certificación ENERGY STAR®, pero se requiere una evaluación. Para clientes que cumplen requisitos de nivel de ingresos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
-    "low_income": "wi-focus-on-energy"
+    "low_income": "wi-focus-on-energy",
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility"
   },
   {
     "id": "WI-27",
@@ -253,9 +312,16 @@
       "en": "Up to $525 rebate for attic insulation.",
       "es": "Un reembolso de hasta $525 para aislamiento térmico del ático."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
-    "bonus_available": true
+    "bonus_available": true,
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility",
+    "stacking_details": "Can stack with all federal and state funding"
   },
   {
     "id": "WI-28",
@@ -279,10 +345,17 @@
       "en": "Up to $675 rebate for attic insulation. For income-qualified customers.",
       "es": "Un reembolso de hasta $675 para aislamiento térmico del ático. Para clientes que cumplan requisitos de nivel de ingresos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
+    "bonus_available": true,
     "low_income": "wi-focus-on-energy",
-    "bonus_available": true
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility",
+    "stacking_details": "Can stack with all federal and state funding"
   },
   {
     "id": "WI-29",
@@ -306,9 +379,16 @@
       "en": "Up to $150 rebate for foundation insulation.",
       "es": "Un reembolso de hasta $150 para aislamiento térmico de cimientos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
-    "bonus_available": true
+    "bonus_available": true,
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility",
+    "stacking_details": "Can stack with all federal and state funding"
   },
   {
     "id": "WI-30",
@@ -332,10 +412,17 @@
       "en": "Up to $225 rebate for foundation insulation. For income-qualified customers.",
       "es": "Un reembolso de hasta $225 para aislamiento térmico de cimientos. Para clientes que cumplan con  requisitos de nivel de ingresos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
+    "bonus_available": true,
     "low_income": "wi-focus-on-energy",
-    "bonus_available": true
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility",
+    "stacking_details": "Can stack with all federal and state funding"
   },
   {
     "id": "WI-31",
@@ -359,9 +446,16 @@
       "en": "Up to $450 rebate for wall insulation.",
       "es": "Un reembolso de hasta $450 para aislamiento térmico de muros."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
-    "bonus_available": true
+    "bonus_available": true,
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility",
+    "stacking_details": "Can stack with all federal and state funding"
   },
   {
     "id": "WI-32",
@@ -385,9 +479,16 @@
       "en": "Up to $75 rebate for duct sealing & insulation.",
       "es": "Un reembolso de hasta $75 para sellado y aislamiento térmico de ductos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
     "end_date": "2024-05-31",
-    "bonus_available": true
+    "bonus_available": true,
+    "data_urls": [
+      "https://focusonenergy.com/residential/insulation-and-air-sealing"
+    ],
+    "contractor_restrictions": "Must be installed by a participating insulation Trade Ally contractor",
+    "other_restrictions": "Must be a customer of a participating utility, 51% of home's heating from participating utility",
+    "stacking_details": "Can stack with all federal and state funding"
   },
   {
     "id": "WI-34",
@@ -409,7 +510,15 @@
       "en": "Free smart EV charger ($1,100 value) for members who purchase an EV and meet requirements.",
       "es": "Cargador de VE inteligente gratuito (con un valor de $1,100) para usuarios que adquieran un VE y cumplan los requisitos."
     },
-    "end_date": "2024-12-13"
+    "program_status": "active",
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20Form%20--%20EV%20Charger.pdf"
+    ],
+    "equipment_standards_restrictions": "Must work with all J1772 complying cars and Tesla with adapter",
+    "contractor_restrictions": "Members are responsible for installation costs",
+    "other_restrictions": "Must participate in load management program; Smart Charger has a 3-year parts warranty",
+    "financing_details": "Funds are limited, submit documentation ASAP"
   },
   {
     "id": "WI-35",
@@ -431,7 +540,14 @@
       "en": "$400 rebate for alternative EV chargers compatible with load management equipment.",
       "es": "Un reembolso de $400 para cargadores alternativos de VE compatibles con equipos de manejo de carga."
     },
-    "end_date": "2024-12-13"
+    "program_status": "active",
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20Form%20--%20EV%20Charger.pdf"
+    ],
+    "contractor_restrictions": "Members are responsible for installation costs",
+    "other_restrictions": "Must participate in load management program; Tesla NEMA plug/adapter does not qualify",
+    "financing_details": "Funds are limited, submit documentation ASAP"
   },
   {
     "id": "WI-36",
@@ -453,8 +569,13 @@
       "en": "20% rebate for geothermal heat pumps, up to $500/ton.",
       "es": "Un reembolso del 20% para bombas de calor geotérmicas, hasta $500/tonelada."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-13"
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20Form%20--%20HVAC.pdf"
+    ],
+    "stacking_details": "Rebate not allowed for a measure and a component of that measure."
   },
   {
     "id": "WI-37",
@@ -478,8 +599,14 @@
       "en": "20% rebate for residential electric water heaters, up to $150 for 75-99 gallons and up to $300 for 100+ gallons. Must be load managed.",
       "es": "Un reembolso del 20% para calentadores de agua eléctricos residenciales, de hasta $150 para 75-99 galones y de hasta $300 para 100+ galones. Hay que administrar la carga."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-13"
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20Form%20--%20Water%20Heating%20Rebates.pdf"
+    ],
+    "other_restrictions": "Must be installed on cooperative's lines and purchased in 2024. Special rates and monthly credit recipients not eligible.",
+    "financing_details": "Incentive not to exceed 20% of the equipment cost."
   },
   {
     "id": "WI-38",
@@ -503,8 +630,15 @@
       "en": "20% rebate for heat pump water heaters with EF 2.00+, up to $300.",
       "es": "Un reembolso del 20% para calentadores de agua eléctricos residenciales, de hasta $150 para 75-99 galones y de hasta $300 para 100+ galones. La carga debe ser administrada."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-13"
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20Form%20--%20Water%20Heating%20Rebates.pdf"
+    ],
+    "equipment_standards_restrictions": "Integrated (all-in-one) units, EF 2.00+",
+    "other_restrictions": "Must be installed on cooperative's lines and purchased in 2024. Special rates and monthly credit recipients not eligible.",
+    "financing_details": "Incentive not to exceed 20% of the equipment cost."
   },
   {
     "id": "WI-39",
@@ -528,8 +662,14 @@
       "en": "20% rebate for air source & mini-split heat pumps, up to $300/ton. SEER2 14.3+, HSPF2 7.5+.",
       "es": "Un reembolso del 20% para bombas de calor de fuente de aire y mini-splits, hasta $300/tonelada. SEER2 14.3+, HSPF2 7.5+."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-13"
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20Form%20--%20HVAC.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+, or SEER 15+, HSPF 8.8+",
+    "stacking_details": "Rebate not allowed for a measure and a component of that measure."
   },
   {
     "id": "WI-40",
@@ -551,8 +691,13 @@
       "en": "$25 rebate for ENERGY STAR® induction ranges.",
       "es": "Un reembolso de $25 para estufas con parrillas de inducción ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-13"
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20form%20-%20Appliances.pdf"
+    ],
+    "equipment_standards_restrictions": "All induction ranges qualify"
   },
   {
     "id": "WI-41",
@@ -574,8 +719,13 @@
       "en": "$25 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-13"
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20form%20-%20Appliances.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-42",
@@ -599,7 +749,14 @@
       "en": "20% of cost for energy efficiency improvements, up to $500.",
       "es": "20% del costo para mejoras de eficiencia energética, hasta $500."
     },
-    "end_date": "2024-12-13"
+    "program_status": "active",
+    "end_date": "2024-12-13",
+    "data_urls": [
+      "https://www.barronelectric.com/sites/default/files/2024%20Incentive%20form-Audit%20Recommended%20Improvements.pdf"
+    ],
+    "other_restrictions": "Improvements must be recommended during an audit or assessment by the cooperative or approved partner.",
+    "stacking_details": "If another incentive is available, only that incentive applies. One Audit Recommended Improvement incentive every 5 years per Member account.",
+    "financing_details": "The incentive will appear as a bill credit unless it's greater than $200, then a check may be issued."
   },
   {
     "id": "WI-43",
@@ -621,7 +778,13 @@
       "en": "Up to $400 incentive for EV chargers.",
       "es": "Incentivo de hasta $400 para cargadores de VEs."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/EV%20Chargers%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Must be installed on cooperative's lines and on load control as defined by cooperative",
+    "financing_details": "Incentive not to exceed the EV charger cost"
   },
   {
     "id": "WI-44",
@@ -643,7 +806,13 @@
       "en": "Up to $800 incentive for smart EV chargers with integrated metering.",
       "es": "Incentivo de hasta $800 para cargadores inteligentes de VEs con medidor integrado."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/EV%20Chargers%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Must be installed on cooperative's lines and on load control as defined by cooperative",
+    "financing_details": "Incentive not to exceed the EV charger cost"
   },
   {
     "id": "WI-45",
@@ -666,7 +835,12 @@
       "en": "$500/ton for geothermal heat pumps.",
       "es": "$500/tonelada para bombas de calor geotérmicas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/HVAC.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost."
   },
   {
     "id": "WI-46",
@@ -688,7 +862,12 @@
       "en": "$50 for ENERGY STAR® clothes dryers.",
       "es": "$50 para secadoras de ropa ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/Appliances.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-47",
@@ -712,7 +891,12 @@
       "en": "$150 rebate for 75-99 gallon residential high efficiency water heaters or $300 for 100+ gallons. UEF must be at least .88.",
       "es": "Un reembolso de $150 para calentadores de agua residenciales de alta eficiencia de 75-99 galones o de $300 para los de 100 galones o más. El UEF debe ser de al menos .88."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/Water%20Heaters%20w-cost_0.pdf"
+    ],
+    "equipment_standards_restrictions": "75-99 gallons: $150\n100+ gallons: $300\nMust be on load control as defined by cooperative\nUEF >= 0.88"
   },
   {
     "id": "WI-48",
@@ -734,7 +918,13 @@
       "en": "$300 rebate for heat pump water heaters, UEF .88, on load control.",
       "es": "Un reembolso de $300 para calentadores de agua con bomba de calor, UEF .88, en control de carga."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/Water%20Heaters%20w-cost_0.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF .88",
+    "other_restrictions": "Must be on load control as defined by cooperative"
   },
   {
     "id": "WI-49",
@@ -758,7 +948,13 @@
       "en": "$300/ton for SEER2 14.3+, HSPF2 7.5+ or SEER 15+, HSPF 8.8+ air source & mini-split heat pumps.",
       "es": "$300/tonelada para SEER2 14.3+, HSPF2 7.5+ o SEER 15+, HSPF 8.8+ bombas de calor de fuente de aire y mini-splits."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/HVAC.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+ OR SEER 15+, HSPF 8.8+",
+    "other_restrictions": "Incentive not to exceed equipment cost. Cannot claim for measure and its component."
   },
   {
     "id": "WI-50",
@@ -780,7 +976,11 @@
       "en": "$50 for induction ranges.",
       "es": "$50 para estufas con parrillas de inducción."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/Appliances.pdf"
+    ]
   },
   {
     "id": "WI-51",
@@ -802,7 +1002,13 @@
       "en": "$25 incentive for Honeywell or Emerson brand smart thermostats enrolled in Load Management Program.",
       "es": "Incentivo de $25 para termostatos inteligentes de  marcas Honeywell o Emerson inscritos en el Load Management Program (o programa de manejo de cargas)."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/HVAC.pdf"
+    ],
+    "equipment_standards_restrictions": "Honeywell or Emerson brand, enrolled in Load Management Program",
+    "other_restrictions": "Incentive not to exceed equipment cost."
   },
   {
     "id": "WI-52",
@@ -824,7 +1030,13 @@
       "en": "Up to $500 for audit-recommended energy efficiency improvements.",
       "es": "Hasta $500 para mejoras de eficiencia energética recomendadas por la auditoría."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.bayfieldelectric.com/sites/default/files/Audit%20Recommended%20Improvements.pdf"
+    ],
+    "other_restrictions": "Improvement must be from audit by cooperative or approved partner. One incentive every 5 years per member.",
+    "stacking_details": "If another incentive is available, only that incentive applies, not both."
   },
   {
     "id": "WI-53",
@@ -846,7 +1058,12 @@
       "en": "$400 incentive towards the purchase of any EV charger.",
       "es": "Incentivo de $400 para la compra de cualquier cargador de VEs."
     },
-    "end_date": "2023-12-31"
+    "program_status": "active",
+    "end_date": "2023-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_EV-Chargers-w-cost-FORM.pdf"
+    ],
+    "other_restrictions": "Must be on load control as defined by cooperative."
   },
   {
     "id": "WI-54",
@@ -869,7 +1086,12 @@
       "en": "Up to $800/ton rebate for geothermal heat pumps.",
       "es": "Un reembolso de hasta $800/tonelada para bombas de calor geotérmicas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_HVAC-w-cost-FORM.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost. No incentives for components of the measure if the measure itself is incentivized."
   },
   {
     "id": "WI-55",
@@ -891,7 +1113,12 @@
       "en": "$25 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_Appliances-FORM.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-56",
@@ -915,8 +1142,14 @@
       "en": "Up to $461/unit rebate for high efficiency water heaters. UEF must be .88 or greater, must be controlled by load control program .",
       "es": "Un reembolso de hasta $461/unidad para calentadores de agua de alta eficiencia. El UEF debe ser de .88 o superior, debe estar administrado por un programa de control de carga."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_Incentive_Forms-WH_Incentive_and_Agreement_Combined.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF .88 or greater for sizes 50-84 gallons, UEF 2.00 for integrated units",
+    "other_restrictions": "Must be controlled by cooperative's load control program, must complete Water Heater-Interruptible Service Agreement"
   },
   {
     "id": "WI-57",
@@ -938,8 +1171,14 @@
       "en": "Up to $300/unit rebate for heat pump water heaters. UEF must be 2.00 or greater.",
       "es": "Un reembolso de hasta $300/unidad para calentadores de agua con bomba de calor. El UEF debe ser de 2.00 o superior."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_Incentive_Forms-WH_Incentive_and_Agreement_Combined.pdf"
+    ],
+    "equipment_standards_restrictions": "Integrated (all-in-one) units\nUEF ≥ 2.00",
+    "other_restrictions": "Must be controlled by cooperative's load control program, must complete Water Heater-Interruptible Service Agreement"
   },
   {
     "id": "WI-58",
@@ -963,7 +1202,13 @@
       "en": "Up to $300/ton rebate for air source & mini-split heat pumps. SEER2 14.3+, HSPF2 7.5+ or SEER 15+, HSPF 8.8+.",
       "es": "Un reembolso de hasta $300/tonelada para bombas de calor de fuente de aire y mini-splits. SEER2 14.3+, HSPF2 7.5+ o SEER 15+, HSPF 8.8+."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_HVAC-w-cost-FORM.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+ OR SEER 15+, HSPF 8.8+",
+    "other_restrictions": "Incentive not to exceed equipment cost. No incentives for components of the measure if the measure itself is incentivized."
   },
   {
     "id": "WI-59",
@@ -985,7 +1230,11 @@
       "en": "$25 incentive for induction ranges.",
       "es": "Incentivo de $25 para estufas con parrillas de inducción."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_Appliances-FORM.pdf"
+    ]
   },
   {
     "id": "WI-60",
@@ -1007,7 +1256,13 @@
       "en": "$25 incentive for Honeywell or Emerson brand smart thermostats enrolled in Load Management Program.",
       "es": "Incentivo de $25 para termostatos inteligentes de  marcas Honeywell o Emerson inscritos en el Programa de Manejo de Cargas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_HVAC-w-cost-FORM.pdf"
+    ],
+    "equipment_standards_restrictions": "Honeywell or Emerson brand, enrolled in Load Management Program",
+    "other_restrictions": "Incentive not to exceed equipment cost. No incentives for components of the measure if the measure itself is incentivized."
   },
   {
     "id": "WI-61",
@@ -1029,7 +1284,13 @@
       "en": "Up to $500 for audit-recommended energy efficiency improvements.",
       "es": "Hasta $500 para mejoras de eficiencia energética recomendadas por la auditoría."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cvecoop.com/PDFs/RebateForms/2024/2024_CVEC_IncentiveForm_Audit_Recommended_Improvements-FORM.pdf"
+    ],
+    "other_restrictions": "Improvements must be from audit recommendations; 1 incentive per member every 5 years.",
+    "stacking_details": "If another incentive is available, only that incentive applies."
   },
   {
     "id": "WI-62",
@@ -1051,7 +1312,12 @@
       "en": "$25 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20Appliances.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-63",
@@ -1075,7 +1341,14 @@
       "en": "Up to $500 rebate for an electric water heaters, depending on efficiency and capacity. Must be on load control.",
       "es": "Un reembolso de hasta $500 para un calentador de agua eléctrico, dependiendo de la eficiencia y la capacidad. Debe estar administrado por un control de carga ."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20Water%20Heaters.pdf"
+    ],
+    "equipment_standards_restrictions": "$50: UEF .88 or less\n$300: UEF ≥ .88\n$500: UEF ≥ .88",
+    "equipment_capacity_restrictions": "$50: UEF .88 or less\n$300: UEF ≥ .88\n$500: UEF ≥ .88",
+    "other_restrictions": "Must be on load control as defined by cooperative"
   },
   {
     "id": "WI-64",
@@ -1097,7 +1370,13 @@
       "en": "$400 rebate for heat pump water heaters, UEF .88, on load control.",
       "es": "Un reembolso de $400 para calentadores de agua con bomba de calor, UEF .88, bajo control de carga."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20Water%20Heaters.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF .88",
+    "other_restrictions": "Must be on load control as defined by cooperative"
   },
   {
     "id": "WI-65",
@@ -1119,7 +1398,11 @@
       "en": "$25 rebate for induction ranges.",
       "es": "Un reembolso de $25 para estufas con parrilla de inducción."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20Appliances.pdf"
+    ]
   },
   {
     "id": "WI-66",
@@ -1143,7 +1426,14 @@
       "en": "Up to $400/ton rebate for air source & mini-split heat pumps. SEER2 14.3+, HSPF2 7.5+ or SEER 15+, HSPF 8.8+.",
       "es": "Un reembolso de hasta $400/tonelada para bombas de calor de fuente de aire y mini-splits. SEER2 14.3+, HSPF2 7.5+ o SEER 15+, HSPF 8.8+."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20HVAC.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+ OR\nSEER 15+, HSPF 8.8+",
+    "other_restrictions": "Incentive not allowed for a measure and a component of that measure. Must be installed on cooperative's lines.",
+    "stacking_details": "Incentive not to exceed the equipment cost. Not allowed for a measure and a component of that measure."
   },
   {
     "id": "WI-67",
@@ -1166,7 +1456,13 @@
       "en": "Up to $850/ton rebate for geothermal heat pumps.",
       "es": "Un reembolso de hasta $850/tonelada para bombas de calor geotérmicas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20HVAC.pdf"
+    ],
+    "other_restrictions": "Incentive not allowed for a measure and a component of that measure. Must be installed on cooperative's lines.",
+    "stacking_details": "Incentive not to exceed the equipment cost. Not allowed for a measure and a component of that measure."
   },
   {
     "id": "WI-68",
@@ -1188,7 +1484,13 @@
       "en": "$25 incentive for Honeywell or Emerson brand smart thermostats enrolled in Load Management Program.",
       "es": "Incentivo de $25 para termostatos inteligentes de  marcas Honeywell o Emerson inscritos en el Programa de Manejo de Cargas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20HVAC.pdf"
+    ],
+    "other_restrictions": "Incentive not allowed for a measure and a component of that measure. Must be installed on cooperative's lines.",
+    "stacking_details": "Incentive not to exceed the equipment cost. Not allowed for a measure and a component of that measure."
   },
   {
     "id": "WI-69",
@@ -1210,7 +1512,13 @@
       "en": "Up to $500 for audit-recommended energy efficiency improvements.",
       "es": "Hasta $500 para mejoras de eficiencia energética recomendadas por la auditoría."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.cecoop.com/sites/default/files/Clark%20Electric/Rebates/2024%20Incentive%20Form%20--%20Audit%20Recommended%20Improvements.pdf"
+    ],
+    "other_restrictions": "Improvement must be from audit arranged by cooperative or approved partner. Cannot exceed cost of improvements.",
+    "stacking_details": "If another incentive is available, only that incentive applies."
   },
   {
     "id": "WI-70",
@@ -1232,8 +1540,13 @@
       "en": "$25 rebate for ENERGY STAR® rated clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa con clasificación ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ],
+    "equipment_standards_restrictions": "Must have ENERGY STAR® rating"
   },
   {
     "id": "WI-71",
@@ -1255,8 +1568,13 @@
       "en": "$25 rebate for ENERGY STAR® rated induction ranges.",
       "es": "Un reembolso de $25 para estufas con parrilla de inducción con clasificación ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ],
+    "equipment_standards_restrictions": "Must have ENERGY STAR® rating"
   },
   {
     "id": "WI-72",
@@ -1278,7 +1596,13 @@
       "en": "$400 incentive for new EV chargers.",
       "es": "Incentivo de $400 para cargadores de VEs nuevos."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/sites/default/files/2024%20Incentive%20Form%20--%20EV%20Chargers%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Must be installed on cooperative's lines and on load control as defined by cooperative",
+    "stacking_details": "Incentive not to exceed the EV charger cost"
   },
   {
     "id": "WI-73",
@@ -1300,7 +1624,13 @@
       "en": "$800 incentive for smart EV chargers with integrated metering.",
       "es": "Incentivo de 800 para cargadores inteligentes de VEs con medidor integrado."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/sites/default/files/2024%20Incentive%20Form%20--%20EV%20Chargers%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Must be installed on cooperative's lines and on load control as defined by cooperative",
+    "stacking_details": "Incentive not to exceed the EV charger cost"
   },
   {
     "id": "WI-74",
@@ -1323,8 +1653,12 @@
       "en": "$500/ton rebate for geothermal heat pumps.",
       "es": "Un reembolso de $500/tonelada para bombas de calor geotérmicas."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ]
   },
   {
     "id": "WI-75",
@@ -1346,8 +1680,12 @@
       "en": "$50 rebate for heat pump clothes dryers.",
       "es": "Un reembolso de $50 para secadoras de ropa con bomba de calor."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ]
   },
   {
     "id": "WI-76",
@@ -1371,8 +1709,13 @@
       "en": "Up to $300 rebate for residential high efficiency water heaters. UEF of at least .88. Must be on load control.",
       "es": "Un reembolso de hasta $300 para calentadores de agua residenciales de alta eficiencia. UEF de al menos 0.88. Debe estar bajo control de carga."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ],
+    "equipment_standards_restrictions": "UEF ≥ .88"
   },
   {
     "id": "WI-77",
@@ -1394,8 +1737,13 @@
       "en": "Up to $300 rebate for heat pump water heaters. Must have UEF of at least 2.20.",
       "es": "Un reembolso de hasta $300 para calentadores de agua con bomba de calor. Deben tener un UEF de al menos 2.20."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ],
+    "equipment_standards_restrictions": "Integrated (all-in-one) units\nUEF ≥ 2.20"
   },
   {
     "id": "WI-78",
@@ -1419,8 +1767,13 @@
       "en": "$300/ton rebate for air source heat pumps/mini-splits. Must be 14.3+ SEER2 , HSPF2 7.5+ or SEER 15+, HSPF 8.8+.",
       "es": "Un reembolso de $300/tonelada para bombas de calor de fuente de aire/mini-splits. Deben ser 14.3+SEER2 , HSPF2 7.5+ o SEER 15+, HSPF 8.8+."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ],
+    "equipment_standards_restrictions": "Must be 14.3+ SEER2, HSPF2 7.5+ or SEER 15+, HSPF 8.8+"
   },
   {
     "id": "WI-79",
@@ -1443,8 +1796,12 @@
       "en": "$500/ton rebate for geothermal heat pumps. AHRI Certificate must be provided.",
       "es": "Un reembolso de $500/tonelada para bombas de calor geotérmicas. Debe proporcionarse el Certificado AHRI."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ]
   },
   {
     "id": "WI-80",
@@ -1466,8 +1823,14 @@
       "en": "$25 rebate for Emerson or Honeywell smart thermostats.",
       "es": "Un reembolso de $25 para termostatos inteligentes Emerson o Honeywell."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.dunnenergy.com/home-rebates"
+    ],
+    "equipment_standards_restrictions": "Must be Emerson or Honeywell unit",
+    "other_restrictions": "Must be enrolled in load management"
   },
   {
     "id": "WI-81",
@@ -1488,7 +1851,11 @@
     "short_description": {
       "en": "$500 rebate for metered level 2 EV chargers.",
       "es": "Un reembolso de $500 para cargadores de VEs de nivel 2 con medidor."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-82",
@@ -1510,7 +1877,11 @@
     "short_description": {
       "en": "$400/ton rebate for ENERGY STAR® rated ground source heat pumps.",
       "es": "Un reembolso de $400/tonelada para bombas de calor geotérmicas con clasificación ENERGY STAR®."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-83",
@@ -1531,7 +1902,11 @@
     "short_description": {
       "en": "$500 rebate for ENERGY STAR® rated heat pump water heaters.",
       "es": "Un reembolso de $500 para calentadores de agua con bomba de calor y clasificación ENERGY STAR®."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-84",
@@ -1553,7 +1928,11 @@
     "short_description": {
       "en": "Up to $1,000 rebate for air source heat pumps, must meet SEER2 and HSPF2.",
       "es": "Un reembolso de hasta $1,000 para bombas de calor con fuente de aire, deben cumplir con SEER2 y HSPF2."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-85",
@@ -1574,7 +1953,11 @@
     "short_description": {
       "en": "$25 rebate for ENERGY STAR® rated electric clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa eléctricas con clasificación ENERGY STAR®."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-86",
@@ -1595,7 +1978,11 @@
     "short_description": {
       "en": "$400 rebate for pool air source heat pumps, must be tested to AHRI 1160.",
       "es": "Un reembolso de $400 para bombas de calor con fuente de aire para piscinas, deben ser probadas según AHRI 1160."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-87",
@@ -1616,7 +2003,11 @@
     "short_description": {
       "en": "$25 rebate for Wi-Fi smart thermostats.",
       "es": "Un reembolso de $25 para termostatos inteligentes Wi-Fi."
-    }
+    },
+    "program_status": "active",
+    "data_urls": [
+      "https://eastcentralenergy.com/2024-residential-rebates"
+    ]
   },
   {
     "id": "WI-88",
@@ -1638,8 +2029,14 @@
       "en": "$150 rebate for ENERGY STAR® rated clothes dryers.",
       "es": "Un reembolso de $150 para secadoras de ropa con clasificación ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-89",
@@ -1661,8 +2058,14 @@
       "en": "$150 rebate for ENERGY STAR® rated induction ranges.",
       "es": "Un reembolso de $150 para estufas con parrilla de inducción con clasificación ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-90",
@@ -1684,8 +2087,14 @@
       "en": "$800 rebate for smart EV chargers with integrated metering.",
       "es": "Un reembolso de $800 para cargadores inteligentes de VEs con medidor integrado."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-91",
@@ -1709,8 +2118,15 @@
       "en": "$500/ton rebate for air source heat pumps SEER 14+, HSPF 8.2+, or EER 11+.",
       "es": "Un reembolso de $500/tonelada para bombas de calor con fuente de aire SEER 14+, HSPF 8.2+ o EER 11+."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "equipment_standards_restrictions": "SEER 14+, HSPF 8.2+, or EER 11+",
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-92",
@@ -1733,8 +2149,14 @@
       "en": "$500/ton rebate for geothermal heat pumps. New units not allowed on load management program .",
       "es": "Un reembolso de $500/tonelada para bombas de calor geotérmicas. No se permiten unidades nuevas en el programa de manejo de cargas."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines. New units not allowed on Jackson Electric's load management program",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-93",
@@ -1756,8 +2178,14 @@
       "en": "Up to $500 rebate for energy efficiency improvements. Must be recommendations from an audit arranged by a cooperative approved partner.",
       "es": "Un reembolso de hasta $500 para mejoras de eficiencia energética. Deben ser recomendaciones de una auditoría ordenada por un socio autorizado de la cooperativa."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines. Each member account qualifies for only one of this incentive every five years.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-94",
@@ -1781,8 +2209,14 @@
       "en": "Up to $300 rebate for water heaters with capacity of at least 75 gallons.",
       "es": "Un reembolso de hasta $300 para calentadores de agua con capacidad de al menos 75 galones."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-95",
@@ -1804,8 +2238,14 @@
       "en": "$300 rebate for integrated heat pump water heaters. UEF 2.00 or greater.",
       "es": "Un reembolso de $300 para calentadores de agua integrados con bomba de calor. UEF 2.00 o superior."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.jackelec.com/rebates-and-incentives"
+    ],
+    "other_restrictions": "Rebates not to exceed equipment cost, must be new equipment, installed on Jackson Electric Cooperative's lines.",
+    "stacking_details": "Rebate may be denied if documentation is incomplete or submitted after 60 days of invoice date."
   },
   {
     "id": "WI-97",
@@ -1827,7 +2267,13 @@
       "en": "Up to $400 incentive for EV chargers.",
       "es": "Incentivo de hasta $400 para cargadores de VEs."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20EV%20Chargers%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Must be connected to the PPCS load management system. Incentive not to exceed the EV charger cost.",
+    "stacking_details": "Funds are limited, submit documentation ASAP."
   },
   {
     "id": "WI-98",
@@ -1849,7 +2295,13 @@
       "en": "Up to $800 incentive for smart EV chargers with integrated metering.",
       "es": "Incentivo de hasta $800 para cargadores inteligentes de VEs con medidor integrado."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20EV%20Chargers%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Must be connected to the PPCS load management system. Incentive not to exceed the EV charger cost.",
+    "stacking_details": "Funds are limited, submit documentation ASAP."
   },
   {
     "id": "WI-99",
@@ -1872,7 +2324,12 @@
       "en": "$500/ton rebate for geothermal heat pumps.",
       "es": "Un reembolso de $500/tonelada para bombas de calor geotérmicas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20HVAC%20w%20cost.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost. Must be connected to PPCS load management system."
   },
   {
     "id": "WI-100",
@@ -1894,7 +2351,12 @@
       "en": "$25 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20Appliances.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-101",
@@ -1918,7 +2380,14 @@
       "en": "Up to $600 incentive for residential high efficiency water heaters, depending on capacity. UEF must be at least .88.",
       "es": "Incentivo de hasta $600 para calentadores de agua residenciales de alta eficiencia, en función de la capacidad. El UEF debe ser de al menos .88."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20Water%20Heaters.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF >= 0.88",
+    "equipment_capacity_restrictions": "$300: 75-99 gallons\n$600: 100+ gallons",
+    "other_restrictions": "Must be installed on cooperative's lines and connected to the PPCS load management system."
   },
   {
     "id": "WI-102",
@@ -1940,7 +2409,13 @@
       "en": "$600 incentive for integrated heat pump water heaters. UEF must be at least 2.20.",
       "es": "Incentivo de $600 para calentadores de agua integrados con bomba de calor. El UEF debe ser de al menos 2.20."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20Water%20Heaters.pdf"
+    ],
+    "equipment_standards_restrictions": "Integrated (all-in-one) units, UEF 2.20",
+    "other_restrictions": "Must be installed on cooperative's lines and connected to the PPCS load management system."
   },
   {
     "id": "WI-103",
@@ -1963,7 +2438,13 @@
       "en": "$300/ton rebate for central ducted air source heat pumps. SEER2 14.3+, HSPF2 7.5+ OR SEER 15+, HSPF 8.8+.",
       "es": "Un reembolso de $300/tonelada para bombas de calor de fuente de aire con ductos centrales. SEER2 14.3+, HSPF2 7.5+ O SEER 15+, HSPF 8.8+."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20HVAC%20w%20cost.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+ OR SEER 15+, HSPF 8.8+",
+    "other_restrictions": "Incentive not to exceed equipment cost. Must be connected to PPCS load management system."
   },
   {
     "id": "WI-104",
@@ -1986,7 +2467,13 @@
       "en": "$300/ton rebate for ductless mini-split heat pumps. SEER2 14.3+, HSPF2 7.5+ OR SEER 15+, HSPF 8.8+.",
       "es": "Un reembolso de $300/tonelada para bombas de calor sin ductos mini-splits. SEER2 14.3+, HSPF2 7.5+ O SEER 15+, HSPF 8.8+."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20HVAC%20w%20cost.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+ OR SEER 15+, HSPF 8.8+",
+    "other_restrictions": "Incentive not to exceed equipment cost. Must be connected to PPCS load management system."
   },
   {
     "id": "WI-105",
@@ -2008,7 +2495,11 @@
       "en": "$25 incentive for induction ranges.",
       "es": "Incentivo de $25 para estufas con parrilla de inducción."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20Appliances.pdf"
+    ]
   },
   {
     "id": "WI-106",
@@ -2030,7 +2521,13 @@
       "en": "$25 for smart thermostats enrolled in Load Management Program.",
       "es": "$25 para termostatos inteligentes inscritos en el Programa de Manejo de Cargas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20HVAC%20w%20cost.pdf"
+    ],
+    "equipment_standards_restrictions": "Honeywell or Emerson brand, enrolled in Load Management Program",
+    "other_restrictions": "Incentive not to exceed equipment cost. Must be connected to PPCS load management system."
   },
   {
     "id": "WI-107",
@@ -2052,7 +2549,14 @@
       "en": "Up to $500 for audit-recommended energy efficiency improvements.",
       "es": "Hasta $500 para mejoras de eficiencia energética recomendadas por la auditoría."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.piercepepin.coop/sites/default/files/documents/Rebates/2024%20Rebates/2024%20Rebate%20Form%20--%20Audit%20Recommended%20Improvements.pdf"
+    ],
+    "other_restrictions": "Improvement must be from audit arranged by cooperative or approved partner. Cannot exceed cost of improvements.",
+    "stacking_details": "If another incentive is available, only that incentive applies. One incentive every 5 years per member.",
+    "financing_details": "Contact cooperative for details. Funds are limited."
   },
   {
     "id": "WI-108",
@@ -2074,8 +2578,13 @@
       "en": "$800 rebate for smart EV chargers with integrated metering.",
       "es": "Un reembolso de $800 para cargadores inteligentes de VEs con medidor integrado."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20ZEFSmartChargerE-Vehicle%20%20-%20Reader.pdf"
+    ],
+    "other_restrictions": "Must be purchased from Polk-Burnett and installed on Polk-Burnett electric lines. Must be connected to load management."
   },
   {
     "id": "WI-109",
@@ -2098,8 +2607,13 @@
       "en": "$500/ton rebate for geothermal heat pumps, may qualify for off-peak rates.",
       "es": "Un reembolso de $500/tonelada para bombas de calor geotérmicas, puede tener derecho a tarifas reducidas."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20HVAC%20-%20Reader.pdf"
+    ],
+    "other_restrictions": "Rebate cannot exceed cost of efficiency equipment. Must be installed on Polk-Burnett's lines."
   },
   {
     "id": "WI-110",
@@ -2121,8 +2635,13 @@
       "en": "$25 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa ENERGY STAR®."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20Appliances%20%20PDF%20-%20Reader_0.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-111",
@@ -2144,8 +2663,15 @@
       "en": "$300 rebate for integrated heat pump water heaters with UEF 2.20+.",
       "es": "Un reembolso de $300 para calentadores de agua integrados con bomba de calor y FUE 2.20+."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20Water%20Heater%20Rebate%20-%20Reader.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF 2.20 or greater",
+    "other_restrictions": "Equipment must be installed on Polk-Burnett's lines and purchased new.",
+    "stacking_details": "Rebate not to exceed cost of electric heat pump water heater."
   },
   {
     "id": "WI-112",
@@ -2169,8 +2695,14 @@
       "en": "$300/ton rebate for air source & mini-split heat pumps, SEER2 14.3+, HSPF2 7.5+.",
       "es": "Un reembolso de $300/tonelada para bombas de calor de fuente de aire y mini-splits, SEER2 14.3+, HSPF2 7.5+."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20HVAC%20-%20Reader.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3 or greater, HSPF2 7.5 or greater",
+    "other_restrictions": "Rebate cannot exceed cost of efficiency equipment. Must be installed on Polk-Burnett's lines."
   },
   {
     "id": "WI-113",
@@ -2192,8 +2724,13 @@
       "en": "$25 rebate for induction ranges.",
       "es": "Un reembolso de $25 para estufas de parrilla de inducción."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20Appliances%20%20PDF%20-%20Reader_0.pdf"
+    ],
+    "equipment_standards_restrictions": "Most glass tops are NOT inductive - Only inductive technology qualifies"
   },
   {
     "id": "WI-114",
@@ -2217,8 +2754,15 @@
       "en": "$200/kW solar PV rebate, capped at $600 per account.",
       "es": "Reembolso de $200/kW de energía solar fotovoltaica, con un tope de $600 por cuenta."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024_RenewableRebate%20-%20Reader.pdf"
+    ],
+    "equipment_standards_restrictions": "PV solar equipment must be UL listed",
+    "other_restrictions": "Equipment must be connected to Polk-Burnett's grid in 2024. System needs to be inspected by a commercial electrical inspector.",
+    "stacking_details": "Rebate capped at $600 per account."
   },
   {
     "id": "WI-115",
@@ -2241,7 +2785,13 @@
       "en": "30% of cost for air infiltration reduction measures, up to $1,000.",
       "es": "30% del costo para medidas de reducción de la infiltración de aire, hasta $1,000."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.polkburnett.com/sites/default/files/Rebates/2024%20Home%20Improvements%20-Reader.pdf"
+    ],
+    "other_restrictions": "Pre-test and post-test by certified energy rater required. Building must be at least 10 years old and on Polk Burnett's electric lines.",
+    "stacking_details": "Rebate limited to one per member within a year from the date of the first home test, unless prior agreement with the rater."
   },
   {
     "id": "WI-116",
@@ -2264,7 +2814,12 @@
       "en": "Up to $600/ton for geothermal heat pumps.",
       "es": "Hasta $600/tonelada para bombas de calor geotérmicas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20HVAC%20with%20smart%20thermostat.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost. Cannot claim for measure and its component."
   },
   {
     "id": "WI-117",
@@ -2286,7 +2841,12 @@
       "en": "$50 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $50 para secadoras de ropa ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20Appliances.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-118",
@@ -2310,7 +2870,14 @@
       "en": "Up to $1,000 rebate for water heaters, depending on capacity and efficiency. Must be load controlled.",
       "es": "Un reembolso de hasta $1,000 para calentadores de agua, en función de capacidad y eficiencia. Deben ser de carga controlada."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20Water%20Heaters.pdf"
+    ],
+    "equipment_standards_restrictions": "$150: UEF >= 0.90\n$1000: UEF >= 0.88",
+    "equipment_capacity_restrictions": "$150: 50-74 gallons\n$1000: 75+ gallons",
+    "other_restrictions": "Must be controlled by cooperative's load control program; Incentive not to exceed the equipment cost."
   },
   {
     "id": "WI-119",
@@ -2332,7 +2899,13 @@
       "en": "$300 rebate for integrated heat pump water heaters. UEF must be at least 2.2.",
       "es": "Un reembolso de $300 para calentadores de agua integrados con bomba de calor. El UEF debe ser de al menos 2,.2."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20Water%20Heaters.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF 2.2",
+    "other_restrictions": "Incentive not to exceed the equipment cost."
   },
   {
     "id": "WI-120",
@@ -2356,7 +2929,12 @@
       "en": "Up to $400/ton for air source & mini-split heat pumps with SEER2 14.3+ or SEER 15+.",
       "es": "Hasta $400/tonelada para bombas de calor de fuente de aire y mini-split con SEER2 14.3+ o SEER 15+."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20HVAC%20with%20smart%20thermostat.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost. Cannot claim for measure and its component."
   },
   {
     "id": "WI-121",
@@ -2378,7 +2956,11 @@
       "en": "$50 rebate for induction ranges.",
       "es": "Rebaja de $50 para estufas de parrilla de inducción."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20Appliances.pdf"
+    ]
   },
   {
     "id": "WI-122",
@@ -2400,8 +2982,16 @@
       "en": "$500 incentive for qualified Solar Electric (PV) System installations.",
       "es": "Incentivo de $500 para instalaciones de sistemas de energía solar eléctrica (FV) que cumplan los requisitos."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-12-31"
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20Solar%20Panels.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be installed within 90 degrees of due south, tilt 10-50 degrees, less than 10% shading",
+    "contractor_restrictions": "Must be installed by a qualified contractor",
+    "other_restrictions": "Incentive not to exceed equipment cost, must be new equipment installed on cooperative's lines",
+    "stacking_details": "Incentive may not exceed the equipment cost"
   },
   {
     "id": "WI-123",
@@ -2423,7 +3013,12 @@
       "en": "$75 incentive for WiFi enabled smart thermostats.",
       "es": "Incentivo de $75 para termostatos inteligentes con WiFi."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20HVAC%20with%20smart%20thermostat.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost. Cannot claim for measure and its component."
   },
   {
     "id": "WI-124",
@@ -2445,7 +3040,13 @@
       "en": "Up to $500 for audit-recommended energy efficiency improvements.",
       "es": "Hasta $500 para mejoras de eficiencia energética recomendadas por la auditoría."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://priceelectric.coop/sites/default/files/Rebates/2024/Fillable%20Audit%20Recommended%20Improvements.pdf"
+    ],
+    "other_restrictions": "Improvements must be from audit recommendations. One incentive every 5 years per member.",
+    "stacking_details": "If another incentive is available, only that incentive applies, not both."
   },
   {
     "id": "WI-125",
@@ -2467,7 +3068,13 @@
       "en": "$400 rebate for EV chargers with load control.",
       "es": "Un reembolso de $400 para cargadores de VEs con control de carga."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/Rebates%202024/EV%20Chargers%202024.pdf"
+    ],
+    "other_restrictions": "Must be installed on cooperative's lines and not exceed the EV charger cost.",
+    "stacking_details": "Incentive not to exceed the EV charger cost."
   },
   {
     "id": "WI-126",
@@ -2489,7 +3096,13 @@
       "en": "$800 rebate for smart EV chargers with integrated metering and load control.",
       "es": "Un reembolso de $800 para cargadores inteligentes de VEs con medidor integrado y control de carga."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/Rebates%202024/EV%20Chargers%202024.pdf"
+    ],
+    "other_restrictions": "May require additional load control device if cellular data does not transmit from installation site.",
+    "stacking_details": "Incentive not to exceed the EV charger cost."
   },
   {
     "id": "WI-127",
@@ -2512,7 +3125,12 @@
       "en": "$500/ton rebate for geothermal heat pumps.",
       "es": "Un reembolso de $500/tonelada para bombas de calor geotérmicas."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/HVAC%202024_0.pdf"
+    ],
+    "other_restrictions": "Incentive not to exceed equipment cost. Cannot claim for measure and its component."
   },
   {
     "id": "WI-128",
@@ -2534,7 +3152,12 @@
       "en": "$25 rebate for ENERGY STAR® clothes dryers.",
       "es": "Un reembolso de $25 para secadoras de ropa ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/Rebates%202024/Appliances%202024.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-129",
@@ -2558,7 +3181,14 @@
       "en": "Up to $300 rebate for residential high efficiency water heaters, depending on capacity. UEF must be at least .88.",
       "es": "Un reembolso de hasta $300 para calentadores de agua residenciales de alta eficiencia, dependiendo de la capacidad. El UEF debe ser de al menos .88."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/Rebates%202024/Water%20Heaters%202024.pdf"
+    ],
+    "equipment_standards_restrictions": "UEF >= .88",
+    "equipment_capacity_restrictions": "$150: 75-99 gallons\n$300: 100+ gallons",
+    "other_restrictions": "Incentive not to exceed the equipment cost. Must be installed on cooperative's lines."
   },
   {
     "id": "WI-130",
@@ -2580,7 +3210,13 @@
       "en": "$300 rebate for integrated heat pump water heaters, UEF at least 2.00, controlled by Cooperative's load control program.",
       "es": "Un reembolso de $300 para calentadores de agua integrados con bomba de calor, UEF de al menos 2.00, regulados por el programa de control de carga de la Cooperativa."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/Rebates%202024/Water%20Heaters%202024.pdf"
+    ],
+    "equipment_standards_restrictions": "Integrated units, UEF 2.00",
+    "other_restrictions": "Incentive not to exceed the equipment cost. Must be installed on cooperative's lines and controlled by Cooperative's load control program."
   },
   {
     "id": "WI-131",
@@ -2604,7 +3240,13 @@
       "en": "$300 rebate for air source & mini-split heat pumps. SEER2 14.3+, HSPF2 7.5+ or SEER 15+, HSPF 8.8+.",
       "es": "Un reembolso de $300 para bombas de calor de fuente de aire y mini-splits. SEER2 14.3+, HSPF2 7.5+ o SEER 15+, HSPF 8.8+."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/HVAC%202024_0.pdf"
+    ],
+    "equipment_standards_restrictions": "SEER2 14.3+, HSPF2 7.5+ or SEER 15+, HSPF 8.8+",
+    "other_restrictions": "Incentive not to exceed equipment cost. Cannot claim for measure and its component."
   },
   {
     "id": "WI-132",
@@ -2626,7 +3268,12 @@
       "en": "$25 rebate for ENERGY STAR® induction ranges.",
       "es": "Un reembolso de $25 para estufas con parrilla de inducción ENERGY STAR®."
     },
-    "end_date": "2024-12-31"
+    "program_status": "active",
+    "end_date": "2024-12-31",
+    "data_urls": [
+      "https://www.riverlandenergy.com/sites/default/files/Rebates%202024/Appliances%202024.pdf"
+    ],
+    "equipment_standards_restrictions": "Must be ENERGY STAR® appliance"
   },
   {
     "id": "WI-135",
@@ -2651,8 +3298,13 @@
       "en": "$1,300 rebate for cold climate air source heat pumps replacing natural gas or electric resistance.",
       "es": "Un reembolso de $1,300 para bombas de calor con fuente de aire para climas fríos que sustituyan a los de resistencia eléctrica o de gas natural."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-05-31"
+    "end_date": "2024-05-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/heating-and-cooling#rebate-info"
+    ],
+    "equipment_standards_restrictions": "Ducted 15.2 SEER2 | 10.0 EER2 | 8.1 HSPF2 | 1.75 COP at 5°\n\nDuctless 16.0 SEER2 | 9.0 EER2 | 9.5 HSPF2 | 1.75 COP at 5°"
   },
   {
     "id": "WI-136",
@@ -2677,8 +3329,13 @@
       "en": "$500 rebate for cold climate air source heat pumps replacing propane, oil, existing heat pump, etc.",
       "es": "Un reembolso de $500 para bombas de calor con fuente de aire de clima frío que sustituyan a las de propano, gasóleo, bomba de calor existente, etc."
     },
+    "program_status": "active",
     "start_date": "2024-01-01",
-    "end_date": "2024-05-31"
+    "end_date": "2024-05-31",
+    "data_urls": [
+      "https://focusonenergy.com/residential/heating-and-cooling#rebate-info"
+    ],
+    "equipment_standards_restrictions": "Ducted 15.2 SEER2 | 10.0 EER2 | 8.1 HSPF2 | 1.75 COP at 5°\n\nDuctless 16.0 SEER2 | 9.0 EER2 | 9.5 HSPF2 | 1.75 COP at 5°"
   },
   {
     "id": "WI-137",
@@ -2703,7 +3360,13 @@
       "en": "Rebate up to 100% of the cost of whole-home improvements, based on the modeled energy savings or measured energy savings achieved by the retrofit.",
       "es": "Un reembolso de hasta 100% del coste, basado en el ahorro de energía simulado o en el ahorro de energía medido logrado por el reacondicionamiento"
     },
+    "program_status": "active",
     "start_date": "2022-08-16",
-    "end_date": "2025-12-31"
+    "end_date": "2025-12-31",
+    "data_urls": [
+      "https://focusonenergy.com/ira-homes"
+    ],
+    "contractor_restrictions": "Must have received an assessment by an IRA Registered Contractor prior to completion of any work",
+    "other_restrictions": "For renters of single-family dwelling units, tenants must verify their income eligibility and if qualified, the landlord is responsible for initiating the work and assuming the associated costs."
   }
 ]

--- a/scripts/lib/spreadsheet-mappings.ts
+++ b/scripts/lib/spreadsheet-mappings.ts
@@ -184,7 +184,7 @@ export const FIELD_METADATA: Record<
         value_aliases: ['Active'],
         description: 'The incentive program is live',
       },
-      expired: {
+      retired: {
         value_aliases: ['Expired'],
         description: 'The incentive program has ended / expired',
       },
@@ -193,16 +193,12 @@ export const FIELD_METADATA: Record<
         description:
           'The incentive program is on pause (eg., when funding is frozen)',
       },
-      other: {
-        value_aliases: ['Other'],
-        description: 'Use when a new/different value is provided',
-      },
       unknown: {
-        value_aliases: ['Unknown'],
+        value_aliases: ['Other', 'Unknown'],
         description:
           'Use only when no information is provided about this on the rebate',
       },
-      planned: {
+      in_development: {
         value_aliases: ['Planned'],
         description:
           'The incentive program is scheduled to start at a future date',

--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -14,6 +14,7 @@ import { AMOUNT_SCHEMA } from './types/amount';
 
 import { START_END_DATE_REGEX } from '../lib/dates';
 import { Amount } from './types/amount';
+import { IncentiveStatus } from './types/incentive-status';
 import { PaymentMethod } from './types/incentive-types';
 import { ALL_ITEMS, Item } from './types/items';
 import { LocalizableString } from './types/localizable-string';
@@ -32,7 +33,7 @@ export type LowIncomeAuthority =
 // renames/aliases.
 export type CollectedIncentive = {
   id: string;
-  data_urls: string[];
+  data_urls?: string[];
   authority_type: AuthorityType;
   authority_name: string;
   geo_eligibility?: string;
@@ -41,7 +42,7 @@ export type CollectedIncentive = {
   items: Item[];
   item_if_selected_other?: string;
   short_description: LocalizableString;
-  program_status: string;
+  program_status?: string;
   start_date?: string;
   end_date?: string;
   payment_methods: PaymentMethod[];
@@ -64,7 +65,11 @@ export type CollectedIncentive = {
 
 const collectedIncentivePropertySchema = {
   id: { type: 'string' },
-  data_urls: { type: 'array', items: { type: 'string' } },
+  data_urls: {
+    type: 'array',
+    items: { type: 'string' },
+    nullable: true,
+  },
   authority_type: { type: 'string', enum: Object.values(AuthorityType) },
   authority_name: { type: 'string' },
   geo_eligibility: { type: 'string', nullable: true },
@@ -76,7 +81,11 @@ const collectedIncentivePropertySchema = {
   },
   item_if_selected_other: { type: 'string', nullable: true },
   short_description: { $ref: 'LocalizableString' },
-  program_status: { type: 'string' },
+  program_status: {
+    type: 'string',
+    enum: Object.values(IncentiveStatus),
+    nullable: true,
+  },
   start_date: {
     type: 'string',
     pattern: START_END_DATE_REGEX.source,
@@ -118,14 +127,14 @@ const collectedIncentivePropertySchema = {
 } as const;
 const requiredCollectedFields = [
   'id',
-  'data_urls',
+  //'data_urls',
   'authority_type',
   'authority_name',
   'program_title',
   'program_url',
   'items',
   'short_description',
-  'program_status',
+  //'program_status',
   'payment_methods',
   'rebate_value',
   'amount',
@@ -166,6 +175,15 @@ export const PASS_THROUGH_FIELDS = [
   'amount',
   'owner_status',
   'short_description',
+  'data_urls',
+  'program_status',
+  'equipment_standards_restrictions',
+  'equipment_capacity_restrictions',
+  'contractor_restrictions',
+  'other_restrictions',
+  'stacking_details',
+  'financing_details',
+  'editorial_notes',
 ] as const;
 type PassThroughField = (typeof PASS_THROUGH_FIELDS)[number];
 
@@ -199,11 +217,20 @@ const fieldOrder: {
   amount: undefined,
   owner_status: undefined,
   short_description: undefined,
+  program_status: undefined,
   start_date: undefined,
   end_date: undefined,
   bonus_available: undefined,
   low_income: undefined,
   more_info_url: undefined,
+  data_urls: undefined,
+  equipment_standards_restrictions: undefined,
+  equipment_capacity_restrictions: undefined,
+  contractor_restrictions: undefined,
+  other_restrictions: undefined,
+  stacking_details: undefined,
+  financing_details: undefined,
+  editorial_notes: undefined,
 } as const;
 export const FIELD_ORDER = Object.keys(fieldOrder);
 

--- a/src/data/types/incentive-status.ts
+++ b/src/data/types/incentive-status.ts
@@ -1,0 +1,8 @@
+/** The current availability of an incentive. */
+export enum IncentiveStatus {
+  Active = 'active',
+  OnHold = 'on_hold',
+  InDevelopment = 'in_development',
+  Retired = 'retired',
+  Unknown = 'unknown',
+}

--- a/test/scripts/format-converter.test.ts
+++ b/test/scripts/format-converter.test.ts
@@ -102,7 +102,7 @@ test('validation works', tap => {
     item_if_selected_other: '',
     'short_description.en':
       'Receive up to $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
-    program_status: 'Active',
+    program_status: 'active',
     program_start_raw: '1/1/2022',
     program_end_raw: '12/31/2026',
     payment_methods: 'rebate',

--- a/test/scripts/incentive-spreadsheet-to-json.test.ts
+++ b/test/scripts/incentive-spreadsheet-to-json.test.ts
@@ -77,10 +77,15 @@ test('correct row to record transformation', tap => {
           en: 'Receive a $50 rebate for an Energy Star certified electric ventless or vented clothes dryer from an approved retailer.',
           es: 'Unas palabras en español.',
         },
+        program_status: 'active',
         start_date: '2022-01-01',
         end_date: '2026-12-31',
         bonus_available: true,
         low_income: 'va-appalachian-power',
+        data_urls: ['https://takechargeva.com/programs/for-your-home'],
+        equipment_standards_restrictions: 'Must be ENERGY STAR certified.',
+        other_restrictions:
+          'Customers can only apply for one rebate of this type per calendar year.',
       },
     },
   ];


### PR DESCRIPTION
This will be the final step in spreadsheet deprecation.

The changes here are to the JSON schema and spreadsheet import
scripts, to bring in all the extra columns that are currently in
spreadsheets but nowhere else. The WI data is added here, as a
demonstration.

I don't plan to merge this to main, because there's no reason for
these extra columns to be in this codebase long-term. This is just the
most convenient way to get those columns into HERO. (The HERO change
to add these columns to the DB is already approved:
rewiringamerica/incentive_admin#79).

So the plan is:

1. Tell everyone to stop editing spreadsheets (forever) and HERO
   (temporarily).

2. Land the HERO PR to add the DB columns. Deploy to prod.

3. Run an export from HERO to here. Manually verify that there are no
   changes that exist only in HERO, then reset back to main.

3. Using the code in this PR, locally run an import from each
   spreadsheet currently in the `registry` file. That will bring the
   latest spreadsheet data, including the extra columns, into local
   JSON.

4. Get these changes reviewed, but don't merge them to main.

4. Import to prod HERO from local JSON. This is the last ever import.

5. Now people can edit HERO again.
