### PR TITLE
Remove deprecated items from the enum

### DIFF
--- a/src/data/types/items.ts
+++ b/src/data/types/items.ts
@@ -45,9 +45,6 @@ export const ITEMS_SCHEMA = {
   wall_insulation: { type: 'string' },
   whole_house_fan: { type: 'string' },
   window_replacement: { type: 'string' },
-  // TODO remove the two below once frontends are not using them anymore
-  heat_pump_air_conditioner_heater: { type: 'string' },
-  weatherization: { type: 'string' },
 } as const;
 
 export type Item = keyof typeof ITEMS_SCHEMA;

--- a/test/fixtures/test-incentives.json
+++ b/test/fixtures/test-incentives.json
@@ -4,7 +4,7 @@
     "payment_methods": [
       "account_credit"
     ],
-    "item": "heat_pump_air_conditioner_heater",
+    "item": "heat_pump_water_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -23,7 +23,7 @@
     "payment_methods": [
       "account_credit"
     ],
-    "item": "heat_pump_air_conditioner_heater",
+    "item": "heat_pump_water_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -43,7 +43,7 @@
     "payment_methods": [
       "account_credit"
     ],
-    "item": "heat_pump_air_conditioner_heater",
+    "item": "heat_pump_water_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -62,7 +62,7 @@
     "payment_methods": [
       "account_credit"
     ],
-    "item": "heat_pump_air_conditioner_heater",
+    "item": "heat_pump_water_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -80,7 +80,7 @@
     "payment_methods": [
       "account_credit"
     ],
-    "item": "heat_pump_air_conditioner_heater",
+    "item": "heat_pump_water_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",
@@ -99,7 +99,7 @@
     "payment_methods": [
       "account_credit"
     ],
-    "item": "heat_pump_air_conditioner_heater",
+    "item": "heat_pump_water_heater",
     "program": "ri_hvacAndWaterHeaterIncentives",
     "amount": {
       "type": "dollar_amount",


### PR DESCRIPTION
## Description

I should have done this a while ago (adding them back in #486 was
supposed to be temporary) and this would have caught the problem that
caused rewiringamerica/incentive_admin#110.

## Test Plan

`yarn test`. Search for both strings and find only the references in
the v0 code and data.
