### PR TITLE
Foundation of gas utilities in API

### DIFF
--- a/src/data/authorities.ts
+++ b/src/data/authorities.ts
@@ -23,6 +23,7 @@ export enum AuthorityType {
   County = 'county',
   State = 'state',
   Utility = 'utility',
+  GasUtility = 'gas_utility',
   Other = 'other',
 }
 
@@ -75,6 +76,7 @@ export const SCHEMA = {
       utility: authoritiesMapSchema,
       city: authoritiesMapSchema,
       county: authoritiesMapSchema,
+      gas_utility: authoritiesMapSchema,
       other: authoritiesMapSchema,
     },
     required: ['utility'],

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -261,6 +261,17 @@ function skipBasedOnRequestParams(
     return true;
   }
 
+  if (
+    program.authority_type === AuthorityType.GasUtility &&
+    program.authority !== request.gas_utility
+  ) {
+    return true;
+  }
+
+  // TODO further gas utility handling. This isn't exactly the same as electric
+  // utility handling; depending on the state, the gas utility may *prevent*
+  // some electric utility incentives from being eligible.
+
   // County and City incentives are approximate and prone to
   // false positives, since zip codes to not map 1:1 to counties
   // and cities.

--- a/src/lib/utilities-for-location.ts
+++ b/src/lib/utilities-for-location.ts
@@ -9,23 +9,51 @@ type ZipToUtility = {
   predominant: number;
 };
 
+type AuthorityMap = {
+  [id: string]: APIAuthority;
+};
+
 /**
- * Find the utilities that may serve the given location. False positives are
- * not ideal but acceptable (i.e. returning a utility as an option for a
- * location they don't actually serve), whereas false negatives are a bug (i.e.
- * failing to return a utility for a location they do actually serve).
+ * Find the electric utilities that may serve the given location. False
+ * positives are not ideal but acceptable (i.e. returning a utility as an option
+ * for a location they don't actually serve), whereas false negatives are a bug
+ * (i.e. failing to return a utility for a location they do actually serve).
  *
  * Returns a map of utility IDs to utility info, suitable for the response
  * from /api/v1/utilities.
  */
-export async function getUtilitiesForLocation(
+export async function getElectricUtilitiesForLocation(
   db: Database,
   location: ResolvedLocation,
-): Promise<{
-  [id: string]: APIAuthority;
-}> {
-  const stateUtilities = AUTHORITIES_BY_STATE[location.state]?.utility;
+): Promise<AuthorityMap> {
+  return getUtilitiesForLocation(
+    db,
+    location,
+    AUTHORITIES_BY_STATE[location.state]?.utility,
+  );
+}
 
+/**
+ * Find the gas utilities that may serve the given location.
+ */
+export async function getGasUtilitiesForLocation(
+  db: Database,
+  location: ResolvedLocation,
+): Promise<AuthorityMap | undefined> {
+  // TODO full logic to determine when gas utilities should be returned.
+  const stateMap = AUTHORITIES_BY_STATE[location.state]?.gas_utility;
+  if (stateMap && Object.keys(stateMap).length > 0) {
+    return getUtilitiesForLocation(db, location, stateMap);
+  } else {
+    return undefined;
+  }
+}
+
+async function getUtilitiesForLocation(
+  db: Database,
+  location: ResolvedLocation,
+  stateUtilities: AuthorityMap | undefined,
+): Promise<AuthorityMap> {
   if (!stateUtilities) {
     return {};
   }

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -11,7 +11,10 @@ import calculateIncentives, {
 } from '../lib/incentives-calculation';
 import { resolveLocation } from '../lib/location';
 import { statesWithStatus } from '../lib/states';
-import { getUtilitiesForLocation } from '../lib/utilities-for-location';
+import {
+  getElectricUtilitiesForLocation,
+  getGasUtilitiesForLocation,
+} from '../lib/utilities-for-location';
 import { ERROR_SCHEMA } from '../schemas/error';
 import {
   API_CALCULATOR_RESPONSE_SCHEMA,
@@ -140,7 +143,14 @@ export default async function (
           .type('application/json')
           .send({
             location: { state: location.state },
-            utilities: await getUtilitiesForLocation(fastify.sqlite, location),
+            utilities: await getElectricUtilitiesForLocation(
+              fastify.sqlite,
+              location,
+            ),
+            gas_utilities: await getGasUtilitiesForLocation(
+              fastify.sqlite,
+              location,
+            ),
           });
       } catch (error) {
         if (error instanceof InvalidInputError) {

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -37,9 +37,18 @@ If absent, incentives from all types of authorities will be considered.`,
     },
     utility: {
       type: 'string',
-      description: `The ID of your utility company, as returned from \
+      description: `The ID of your electric utility company, as returned from \
 \`/api/v1/utilities\`. Required if authority_types includes "utility". If \
-absent, no incentives offered by utilities will be returned.`,
+absent, no incentives offered by electric utilities will be returned.`,
+    },
+    gas_utility: {
+      type: 'string',
+      description: `The ID of your gas utility company, as returned from \
+\`/api/v1/utilities\`. Required if authority_types includes "gas_utility". If \
+absent, no incentives offered by gas utilities will be returned. In some \
+jurisdictions, your gas utility can affect your eligibility for incentives \
+offered by other authorities; in such cases, if this parameter is absent, \
+incentives with gas-utility-dependent eligibility will _not_ be returned.`,
     },
     items: {
       type: 'array',

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -7,7 +7,23 @@ export const API_UTILITIES_RESPONSE_SCHEMA = {
     location: API_RESPONSE_LOCATION_SCHEMA,
     utilities: {
       type: 'object',
-      description: 'A map of utility IDs to info about each utility.',
+      description: 'A map of IDs to info about each electric utility.',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: `The customer-facing brand name of the utility. This \
+may differ from the name of the utility's legal entity.`,
+          },
+        },
+      },
+    },
+    gas_utilities: {
+      type: 'object',
+      description: `A map of IDs to info about each gas utility. This may be \
+absent if the user's gas utility does not affect their eligibility for \
+incentives, or if no gas utilities serve the given location.`,
       additionalProperties: {
         type: 'object',
         properties: {
@@ -26,7 +42,7 @@ may differ from the name of the utility's legal entity.`,
 
 export const API_UTILITIES_SCHEMA = {
   summary: 'Find utilities by location',
-  description: `Returns the electric utilities that may serve the given \
+  description: `Returns electric and gas utilities that may serve the given \
 location. Because the location is imprecise, and because utility service \
 territories aren't precisely defined, there may be multiple results, including \
 utilities that don't actually serve the given location.`,


### PR DESCRIPTION
## Description

- New authority type for gas utilities

- New key in the `/v1/utilities` response for gas utilities

- New query parameter in `/v1/calculator`

Currently, there are no gas utilities (I need to do some HERO-side
work for that) and the query param to `/calculator` doesn't do
anything. This is just laying the foundation so HERO can start
exporting gas utilities without causing schema tests to fail.

One thing I'm still undecided on is whether it's necessary to
distinguish in the API between "the choice of gas utility doesn't
matter in this case" and "there are no gas utilites serving this
location". I imagined indicating the former case by not having the
`gas_utilities` key in the `/v1/utilities` response, and the latter
case by having the key present and mapped to `{}`. But I'm not sure
it's necessary to make this distinction, or maybe if it should be made
another way (e.g. a boolean flag or something).

We still have time to decide that question, since this won't be
officially a part of the API for a bit.

## Test Plan

`yarn test`.

Manually add a `gas_utility` entry to one of the authorities.json
files; make sure `yarn test` still passes.
