### PR TITLE
Fix how resolved location is returned in API

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -382,10 +382,7 @@ export default function calculateIncentives(
     authorities,
     coverage,
     data_partners,
-    location: {
-      state: state_id,
-      city: location.city,
-    },
+    location,
     savings,
     incentives: sortedIncentives,
   };

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -142,7 +142,7 @@ export default async function (
           .status(200)
           .type('application/json')
           .send({
-            location: { state: location.state },
+            location,
             utilities: await getElectricUtilitiesForLocation(
               fastify.sqlite,
               location,

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -23,10 +23,10 @@ territory of the location submitted in the request.`,
       description:
         'The city name as determined by looking up the ZIP code in our database.',
     },
-    county: {
+    countyFips: {
       type: 'string',
       description:
-        'The county name as determined by looking up the ZIP code in our database.',
+        'The FIPS code of the county, as determined by looking up the ZIP code in our database.',
     },
   },
   required: ['state'],

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -825,7 +825,7 @@ const UTILITIES = [
   [
     '02807',
     {
-      location: { state: 'RI' },
+      location: { state: 'RI', city: 'Block Island', countyFips: '44009' },
       utilities: {
         'ri-block-island-power-company': { name: 'Block Island Power Company' },
       },
@@ -834,7 +834,7 @@ const UTILITIES = [
   [
     '02814',
     {
-      location: { state: 'RI' },
+      location: { state: 'RI', city: 'Chepachet', countyFips: '44007' },
       utilities: {
         'ri-rhode-island-energy': { name: 'Rhode Island Energy' },
         'ri-pascoag-utility-district': { name: 'Pascoag Utility District' },
@@ -844,14 +844,14 @@ const UTILITIES = [
   [
     '02905',
     {
-      location: { state: 'RI' },
+      location: { state: 'RI', city: 'Providence', countyFips: '44007' },
       utilities: { 'ri-rhode-island-energy': { name: 'Rhode Island Energy' } },
     },
   ],
   [
     '06360',
     {
-      location: { state: 'CT' },
+      location: { state: 'CT', city: 'Norwich', countyFips: '09011' },
       utilities: {
         'ct-bozrah-light-and-power-company': {
           name: 'Bozrah Light & Power Company',
@@ -868,7 +868,7 @@ const UTILITIES = [
   [
     '84106',
     {
-      location: { state: 'UT' },
+      location: { state: 'UT', city: 'Salt Lake City', countyFips: '49035' },
       utilities: {
         'ut-rocky-mountain-power': {
           name: 'Rocky Mountain Power',

--- a/test/snapshots/il-60304-state-utility-lowincome.json
+++ b/test/snapshots/il-60304-state-utility-lowincome.json
@@ -16,7 +16,8 @@
   },
   "location": {
     "state": "IL",
-    "city": "Oak Park"
+    "city": "Oak Park",
+    "countyFips": "17031"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -18,7 +18,8 @@
   },
   "location": {
     "state": "RI",
-    "city": "Block Island"
+    "city": "Block Island",
+    "countyFips": "44009"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-02903-state-utility-lowincome.json
+++ b/test/snapshots/v1-02903-state-utility-lowincome.json
@@ -32,7 +32,8 @@
   },
   "location": {
     "state": "RI",
-    "city": "Providence"
+    "city": "Providence",
+    "countyFips": "44007"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-02903-state-utility-moderateincome.json
+++ b/test/snapshots/v1-02903-state-utility-moderateincome.json
@@ -32,7 +32,8 @@
   },
   "location": {
     "state": "RI",
-    "city": "Providence"
+    "city": "Providence",
+    "countyFips": "44007"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -16,7 +16,8 @@
   },
   "location": {
     "state": "PA",
-    "city": "Pittsburgh"
+    "city": "Pittsburgh",
+    "countyFips": "42003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-80517-estes-park.json
+++ b/test/snapshots/v1-80517-estes-park.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "CO",
-    "city": "Estes Park"
+    "city": "Estes Park",
+    "countyFips": "08069"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-80517-xcel.json
+++ b/test/snapshots/v1-80517-xcel.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "CO",
-    "city": "Estes Park"
+    "city": "Estes Park",
+    "countyFips": "08069"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-84106-homeowner-80000-joint-4.json
+++ b/test/snapshots/v1-84106-homeowner-80000-joint-4.json
@@ -9,7 +9,8 @@
   },
   "location": {
     "state": "UT",
-    "city": "Salt Lake City"
+    "city": "Salt Lake City",
+    "countyFips": "49035"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-az-85001-state-utility-moderateincome.json
+++ b/test/snapshots/v1-az-85001-state-utility-moderateincome.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "AZ",
-    "city": "Phoenix"
+    "city": "Phoenix",
+    "countyFips": "04013"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-az-85701-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85701-state-utility-lowincome.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "AZ",
-    "city": "Tucson"
+    "city": "Tucson",
+    "countyFips": "04019"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-az-85702-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85702-state-utility-lowincome.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "AZ",
-    "city": "Tucson"
+    "city": "Tucson",
+    "countyFips": "04019"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-co-81657-state-utility-lowincome.json
+++ b/test/snapshots/v1-co-81657-state-utility-lowincome.json
@@ -25,7 +25,8 @@
   },
   "location": {
     "state": "CO",
-    "city": "Vail"
+    "city": "Vail",
+    "countyFips": "08037"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-ct-06002-state-utility-lowincome.json
+++ b/test/snapshots/v1-ct-06002-state-utility-lowincome.json
@@ -16,7 +16,8 @@
   },
   "location": {
     "state": "CT",
-    "city": "Bloomfield"
+    "city": "Bloomfield",
+    "countyFips": "09003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-dc-20303-state-city-lowincome.json
+++ b/test/snapshots/v1-dc-20303-state-city-lowincome.json
@@ -16,7 +16,8 @@
   },
   "location": {
     "state": "DC",
-    "city": "Washington"
+    "city": "Washington",
+    "countyFips": "11001"
   },
   "data_partners": {
     "dc-electrify-dc": {

--- a/test/snapshots/v1-ga-30033-utility.json
+++ b/test/snapshots/v1-ga-30033-utility.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "GA",
-    "city": "Decatur"
+    "city": "Decatur",
+    "countyFips": "13089"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-il-60202-city-lowincome.json
+++ b/test/snapshots/v1-il-60202-city-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "IL",
-    "city": "Evanston"
+    "city": "Evanston",
+    "countyFips": "17031"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-me-04772-state-lowincome.json
+++ b/test/snapshots/v1-me-04772-state-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "ME",
-    "city": "Saint Agatha"
+    "city": "Saint Agatha",
+    "countyFips": "23003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-me-04772-state-moderateincome.json
+++ b/test/snapshots/v1-me-04772-state-moderateincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "ME",
-    "city": "Saint Agatha"
+    "city": "Saint Agatha",
+    "countyFips": "23003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-mi-48103-state-utility-lowincome.json
+++ b/test/snapshots/v1-mi-48103-state-utility-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "MI",
-    "city": "Ann Arbor"
+    "city": "Ann Arbor",
+    "countyFips": "26161"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-mi-48825-city-lowincome.json
+++ b/test/snapshots/v1-mi-48825-city-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "MI",
-    "city": "East Lansing"
+    "city": "East Lansing",
+    "countyFips": "26065"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-nv-89108-state-utility-lowincome.json
+++ b/test/snapshots/v1-nv-89108-state-utility-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "NV",
-    "city": "Las Vegas"
+    "city": "Las Vegas",
+    "countyFips": "32003"
   },
   "data_partners": {
     "nv-nevada-clean-energy-fund": {

--- a/test/snapshots/v1-ny-11557-state-utility-lowincome.json
+++ b/test/snapshots/v1-ny-11557-state-utility-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "NY",
-    "city": "Hewlett"
+    "city": "Hewlett",
+    "countyFips": "36059"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-or-97001-state-lowincome.json
+++ b/test/snapshots/v1-or-97001-state-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "OR",
-    "city": "Antelope"
+    "city": "Antelope",
+    "countyFips": "41065"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-pa-17555-state-lowincome.json
+++ b/test/snapshots/v1-pa-17555-state-lowincome.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "PA",
-    "city": "Narvon"
+    "city": "Narvon",
+    "countyFips": "42071"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-va-22030-state-utility-lowincome.json
+++ b/test/snapshots/v1-va-22030-state-utility-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "VA",
-    "city": "Fairfax"
+    "city": "Fairfax",
+    "countyFips": "51059"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-vt-05401-state-utility-lowincome.json
+++ b/test/snapshots/v1-vt-05401-state-utility-lowincome.json
@@ -19,7 +19,8 @@
   },
   "location": {
     "state": "VT",
-    "city": "Burlington"
+    "city": "Burlington",
+    "countyFips": "50007"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-vt-05845-vec-ev-low-income.json
+++ b/test/snapshots/v1-vt-05845-vec-ev-low-income.json
@@ -16,7 +16,8 @@
   },
   "location": {
     "state": "VT",
-    "city": "Irasburg"
+    "city": "Irasburg",
+    "countyFips": "50019"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-vt-addison-co-low-income.json
+++ b/test/snapshots/v1-vt-addison-co-low-income.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "VT",
-    "city": "Middlebury"
+    "city": "Middlebury",
+    "countyFips": "50001"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-vt-bennington-co-not-low-income.json
+++ b/test/snapshots/v1-vt-bennington-co-not-low-income.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "VT",
-    "city": "Bennington"
+    "city": "Bennington",
+    "countyFips": "50003"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-wi-53703-state-utility-lowincome.json
+++ b/test/snapshots/v1-wi-53703-state-utility-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "WI",
-    "city": "Madison"
+    "city": "Madison",
+    "countyFips": "55025"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-wi-53910-lowincome.json
+++ b/test/snapshots/v1-wi-53910-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "WI",
-    "city": "Adams"
+    "city": "Adams",
+    "countyFips": "55001"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-wi-53910-not-lowincome.json
+++ b/test/snapshots/v1-wi-53910-not-lowincome.json
@@ -13,7 +13,8 @@
   },
   "location": {
     "state": "WI",
-    "city": "Adams"
+    "city": "Adams",
+    "countyFips": "55001"
   },
   "data_partners": {},
   "incentives": [


### PR DESCRIPTION
## Description

- The v1 APIs weren't returning the entire resolved location; the
  utilities endpoint was just returning state, and neither was
  returning county FIPS code.

- The API spec still included a `county` key, which we weren't
  returning under any circumstances. Change it to `countyFips`.

Note that mapping a zip code to a single city and a single county is
unsound -- ZCTAs cross city and county (and even state) boundaries all
the time. This PR isn't intended to rectify that, but just to make the
behavior match the currently-intended behavior.

## Test Plan

`yarn test` with updated tests.