### PR TITLE
countyFips -> county_fips

### DIFF
--- a/src/lib/ami-evcredit-calculation.ts
+++ b/src/lib/ami-evcredit-calculation.ts
@@ -57,19 +57,19 @@ export async function computeAMIAndEVCreditEligibility(
     // The entirety of these territories is non-urban and thus 30C-eligible.
     evCreditEligible = true;
   } else {
-    ami = resolvedLocation.tractGeoid
+    ami = resolvedLocation.tract_geoid
       ? await db.get<AMIRow>(
           'SELECT * FROM ami_by_tract WHERE tract_geoid = ?',
-          resolvedLocation.tractGeoid,
+          resolvedLocation.tract_geoid,
         )
       : await db.get<AMIRow>(
           'SELECT * FROM ami_by_zcta WHERE zcta = ?',
           resolvedLocation.zcta,
         );
-    const ev = resolvedLocation.tractGeoid
+    const ev = resolvedLocation.tract_geoid
       ? await db.get<{ is_eligible: string }>(
           'SELECT is_eligible FROM "30c_eligibility_by_tract" WHERE tract_geoid = ?',
-          resolvedLocation.tractGeoid,
+          resolvedLocation.tract_geoid,
         )
       : await db.get<{ is_eligible: string }>(
           'SELECT is_eligible FROM "30c_eligibility_by_zcta" WHERE zcta = ?',

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -5,8 +5,8 @@ export type ResolvedLocation = {
   state: string;
   zcta: string;
   city: string;
-  countyFips: string;
-  tractGeoid?: string;
+  county_fips: string;
+  tract_geoid?: string;
 };
 
 /**
@@ -31,7 +31,7 @@ async function zipLookup(
       COALESCE(NULLIF(parent_zcta, ''), zip) as zcta,
       state_id AS state,
       city,
-      county_fips AS countyFips
+      county_fips
     FROM zips
     WHERE zip = ?`,
     zip,
@@ -61,8 +61,8 @@ export async function resolveLocation(
         (await zipLookup(db, result.address_components.zip))?.zcta ??
         result.address_components.zip,
       city: result.address_components.city,
-      countyFips: censusInfo.county_fips,
-      tractGeoid: GEOCODIO_LOW_PRECISION.has(result.accuracy_type)
+      county_fips: censusInfo.county_fips,
+      tract_geoid: GEOCODIO_LOW_PRECISION.has(result.accuracy_type)
         ? undefined
         : censusInfo.county_fips + censusInfo.tract_code,
     };

--- a/src/lib/low-income.ts
+++ b/src/lib/low-income.ts
@@ -21,7 +21,7 @@ export function isLowIncome(
     const bySize: HHSizeThresholds =
       thresholds.type === 'hhsize'
         ? thresholds.thresholds
-        : thresholds.thresholds[location.countyFips] ??
+        : thresholds.thresholds[location.county_fips] ??
           thresholds.thresholds['other'];
     const threshold = bySize?.[household_size];
 

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -279,13 +279,13 @@ function skipBasedOnRequestParams(
   // tracks long-term work in this space.
   if (program.authority_type === AuthorityType.County) {
     // Skip if we didn't get location data.
-    if (location.countyFips === undefined) {
+    if (location.county_fips === undefined) {
       return true;
     }
 
     // We have tests to ensure county authorities are registered.
     const authorityDetails = stateAuthorities.county![program.authority!];
-    if (authorityDetails.county_fips !== location.countyFips) {
+    if (authorityDetails.county_fips !== location.county_fips) {
       return true;
     }
   }
@@ -295,7 +295,7 @@ function skipBasedOnRequestParams(
     // municipalities can have the same name within the same state.
 
     // Skip if we didn't get location data.
-    if (location.city === undefined || location.countyFips === undefined) {
+    if (location.city === undefined || location.county_fips === undefined) {
       return true;
     }
 
@@ -304,7 +304,7 @@ function skipBasedOnRequestParams(
 
     if (
       authorityDetails.city !== location.city ||
-      authorityDetails.county_fips !== location.countyFips
+      authorityDetails.county_fips !== location.county_fips
     ) {
       return true;
     }
@@ -320,10 +320,10 @@ function skipBasedOnRequestParams(
       (group.utilities &&
         (!request.utility || !group.utilities.includes(request.utility))) ||
       (group.counties &&
-        (!location.countyFips ||
+        (!location.county_fips ||
           !group.counties
             .map(id => stateAuthorities.county[id].county_fips)
-            .includes(location.countyFips))) ||
+            .includes(location.county_fips))) ||
       (group.cities &&
         (!location.city ||
           !group.cities

--- a/src/schemas/v1/location.ts
+++ b/src/schemas/v1/location.ts
@@ -23,7 +23,7 @@ territory of the location submitted in the request.`,
       description:
         'The city name as determined by looking up the ZIP code in our database.',
     },
-    countyFips: {
+    county_fips: {
       type: 'string',
       description:
         'The FIPS code of the county, as determined by looking up the ZIP code in our database.',

--- a/test/lib/ami-evcredit-calculation.test.ts
+++ b/test/lib/ami-evcredit-calculation.test.ts
@@ -23,29 +23,29 @@ const AS_LOCATION: ResolvedLocation = {
   zcta: '96799',
   state: 'AS',
   city: 'Pago Pago',
-  countyFips: '60010',
-  tractGeoid: '60010950600',
+  county_fips: '60010',
+  tract_geoid: '60010950600',
 };
 const GU_LOCATION: ResolvedLocation = {
   zcta: '96913',
   state: 'GU',
   city: 'Barrigada',
-  countyFips: '66010',
-  tractGeoid: '66010951100',
+  county_fips: '66010',
+  tract_geoid: '66010951100',
 };
 const MP_LOCATION: ResolvedLocation = {
   zcta: '96950',
   state: 'MP',
   city: 'Saipan',
-  countyFips: '69110',
-  tractGeoid: '69110001700',
+  county_fips: '69110',
+  tract_geoid: '69110001700',
 };
 const VI_LOCATION: ResolvedLocation = {
   zcta: '00840',
   state: 'VI',
   city: 'Frederiksted',
-  countyFips: '78010',
-  tractGeoid: '78010971000',
+  county_fips: '78010',
+  tract_geoid: '78010971000',
 };
 
 test('territories other than PR', async t => {
@@ -75,7 +75,7 @@ test('territories other than PR', async t => {
 const NY_TRACT = '36099950200';
 const NY_LOCATION: ResolvedLocation = {
   city: 'Seneca Falls',
-  countyFips: '36099',
+  county_fips: '36099',
   state: 'NY',
   zcta: '13148',
 };
@@ -83,7 +83,7 @@ const NY_LOCATION: ResolvedLocation = {
 const DC_TRACT = '11001010700';
 const DC_LOCATION: ResolvedLocation = {
   city: 'Washington',
-  countyFips: '11001',
+  county_fips: '11001',
   state: 'DC',
   zcta: '20036',
 };
@@ -91,7 +91,7 @@ const DC_LOCATION: ResolvedLocation = {
 const PR_TRACT = '72127002100';
 const PR_LOCATION: ResolvedLocation = {
   city: 'San Juan',
-  countyFips: '72127',
+  county_fips: '72127',
   state: 'PR',
   zcta: '00907',
 };
@@ -122,7 +122,7 @@ test('states+DC+PR with tract', async t => {
   t.strictSame(
     await computeAMIAndEVCreditEligibility(
       db,
-      { ...NY_LOCATION, tractGeoid: NY_TRACT },
+      { ...NY_LOCATION, tract_geoid: NY_TRACT },
       4,
     ),
     {
@@ -134,7 +134,7 @@ test('states+DC+PR with tract', async t => {
   t.strictSame(
     await computeAMIAndEVCreditEligibility(
       db,
-      { ...DC_LOCATION, tractGeoid: DC_TRACT },
+      { ...DC_LOCATION, tract_geoid: DC_TRACT },
       4,
     ),
     {
@@ -146,7 +146,7 @@ test('states+DC+PR with tract', async t => {
   t.strictSame(
     await computeAMIAndEVCreditEligibility(
       db,
-      { ...PR_LOCATION, tractGeoid: PR_TRACT },
+      { ...PR_LOCATION, tract_geoid: PR_TRACT },
       4,
     ),
     {
@@ -166,7 +166,7 @@ test('EV charger eligibility', async t => {
     zcta: '11211',
     state: 'NY',
     city: 'Brooklyn',
-    countyFips: '36047',
+    county_fips: '36047',
   };
   t.notOk(
     (await computeAMIAndEVCreditEligibility(db, brooklyn, 4))!.evCreditEligible,
@@ -178,7 +178,7 @@ test('EV charger eligibility', async t => {
       db,
       {
         ...brooklyn,
-        tractGeoid: '36047051700',
+        tract_geoid: '36047051700',
       },
       4,
     ))!.evCreditEligible,
@@ -189,7 +189,7 @@ test('EV charger eligibility', async t => {
       db,
       {
         ...brooklyn,
-        tractGeoid: '36047055300',
+        tract_geoid: '36047055300',
       },
       4,
     ))!.evCreditEligible,

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -19,7 +19,7 @@ const LOCATION: ResolvedLocation = {
   state: 'RI',
   zcta: '02903',
   city: 'Providence',
-  countyFips: '44007',
+  county_fips: '44007',
 };
 
 const AMIS = {

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -15,7 +15,7 @@ import { calculateStateIncentivesAndSavings } from '../../src/lib/state-incentiv
 
 const LOCATION_AND_AMIS = {
   '07083': [
-    { zcta: '07083', city: 'Union', state: 'NJ', countyFips: '34039' },
+    { zcta: '07083', city: 'Union', state: 'NJ', county_fips: '34039' },
     { computedAMI80: 97800, computedAMI150: 195450, evCreditEligible: false },
   ],
   '94117': [
@@ -23,20 +23,20 @@ const LOCATION_AND_AMIS = {
       zcta: '94117',
       city: 'San Francisco',
       state: 'CA',
-      countyFips: '06075',
+      county_fips: '06075',
     },
     { computedAMI80: 156650, computedAMI150: 293700, evCreditEligible: false },
   ],
   '39503': [
-    { zcta: '39503', city: 'Gulfport', state: 'MS', countyFips: '28047' },
+    { zcta: '39503', city: 'Gulfport', state: 'MS', county_fips: '28047' },
     { computedAMI80: 80256, computedAMI150: 150480, evCreditEligible: false },
   ],
   '02861': [
-    { zcta: '02861', city: 'Pawtucket', state: 'RI', countyFips: '44007' },
+    { zcta: '02861', city: 'Pawtucket', state: 'RI', county_fips: '44007' },
     { computedAMI80: 62930, computedAMI150: 118020, evCreditEligible: false },
   ],
   '06002': [
-    { zcta: '06002', city: 'Bloomfield', state: 'CT', countyFips: '09003' },
+    { zcta: '06002', city: 'Bloomfield', state: 'CT', county_fips: '09003' },
     { computedAMI80: 68215, computedAMI150: 127890, evCreditEligible: false },
   ],
 } as const;
@@ -557,7 +557,7 @@ test('correct filtering of county incentives', async t => {
     include_beta_states: true,
   };
   const shouldFind = calculateStateIncentivesAndSavings(
-    { state: 'CO', countyFips: '99999', city: 'Asdf', zcta: '00000' },
+    { state: 'CO', county_fips: '99999', city: 'Asdf', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -569,7 +569,7 @@ test('correct filtering of county incentives', async t => {
   t.equal(shouldFind.stateIncentives.length, 1);
 
   const shouldNotFind = calculateStateIncentivesAndSavings(
-    { state: 'CO', countyFips: '11111', city: 'Asdf', zcta: '00000' },
+    { state: 'CO', county_fips: '11111', city: 'Asdf', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -631,7 +631,7 @@ test('correct filtering of city incentives', async t => {
     include_beta_states: true,
   };
   const shouldFind = calculateStateIncentivesAndSavings(
-    { state: 'CO', city: 'New York', countyFips: '99999', zcta: '00000' },
+    { state: 'CO', city: 'New York', county_fips: '99999', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -643,7 +643,7 @@ test('correct filtering of city incentives', async t => {
   t.equal(shouldFind.stateIncentives.length, 1);
 
   const shouldNotFindWithPartialMatch = calculateStateIncentivesAndSavings(
-    { state: 'CO', city: 'New York', countyFips: '11111', zcta: '00000' },
+    { state: 'CO', city: 'New York', county_fips: '11111', zcta: '00000' },
     request,
     [incentive],
     {},
@@ -709,7 +709,7 @@ test('correctly evaluates savings when state tax liability is lower than max sav
     {
       state: 'CO',
       city: 'Colorado Springs',
-      countyFips: '11111',
+      county_fips: '11111',
       zcta: '80903',
     },
     request,

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -825,7 +825,7 @@ const UTILITIES = [
   [
     '02807',
     {
-      location: { state: 'RI', city: 'Block Island', countyFips: '44009' },
+      location: { state: 'RI', city: 'Block Island', county_fips: '44009' },
       utilities: {
         'ri-block-island-power-company': { name: 'Block Island Power Company' },
       },
@@ -834,7 +834,7 @@ const UTILITIES = [
   [
     '02814',
     {
-      location: { state: 'RI', city: 'Chepachet', countyFips: '44007' },
+      location: { state: 'RI', city: 'Chepachet', county_fips: '44007' },
       utilities: {
         'ri-rhode-island-energy': { name: 'Rhode Island Energy' },
         'ri-pascoag-utility-district': { name: 'Pascoag Utility District' },
@@ -844,14 +844,14 @@ const UTILITIES = [
   [
     '02905',
     {
-      location: { state: 'RI', city: 'Providence', countyFips: '44007' },
+      location: { state: 'RI', city: 'Providence', county_fips: '44007' },
       utilities: { 'ri-rhode-island-energy': { name: 'Rhode Island Energy' } },
     },
   ],
   [
     '06360',
     {
-      location: { state: 'CT', city: 'Norwich', countyFips: '09011' },
+      location: { state: 'CT', city: 'Norwich', county_fips: '09011' },
       utilities: {
         'ct-bozrah-light-and-power-company': {
           name: 'Bozrah Light & Power Company',
@@ -868,7 +868,7 @@ const UTILITIES = [
   [
     '84106',
     {
-      location: { state: 'UT', city: 'Salt Lake City', countyFips: '49035' },
+      location: { state: 'UT', city: 'Salt Lake City', county_fips: '49035' },
       utilities: {
         'ut-rocky-mountain-power': {
           name: 'Rocky Mountain Power',

--- a/test/snapshots/il-60304-state-utility-lowincome.json
+++ b/test/snapshots/il-60304-state-utility-lowincome.json
@@ -17,7 +17,7 @@
   "location": {
     "state": "IL",
     "city": "Oak Park",
-    "countyFips": "17031"
+    "county_fips": "17031"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -19,7 +19,7 @@
   "location": {
     "state": "RI",
     "city": "Block Island",
-    "countyFips": "44009"
+    "county_fips": "44009"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-02903-state-utility-lowincome.json
+++ b/test/snapshots/v1-02903-state-utility-lowincome.json
@@ -33,7 +33,7 @@
   "location": {
     "state": "RI",
     "city": "Providence",
-    "countyFips": "44007"
+    "county_fips": "44007"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-02903-state-utility-moderateincome.json
+++ b/test/snapshots/v1-02903-state-utility-moderateincome.json
@@ -33,7 +33,7 @@
   "location": {
     "state": "RI",
     "city": "Providence",
-    "countyFips": "44007"
+    "county_fips": "44007"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -17,7 +17,7 @@
   "location": {
     "state": "PA",
     "city": "Pittsburgh",
-    "countyFips": "42003"
+    "county_fips": "42003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-80517-estes-park.json
+++ b/test/snapshots/v1-80517-estes-park.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "CO",
     "city": "Estes Park",
-    "countyFips": "08069"
+    "county_fips": "08069"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-80517-xcel.json
+++ b/test/snapshots/v1-80517-xcel.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "CO",
     "city": "Estes Park",
-    "countyFips": "08069"
+    "county_fips": "08069"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-84106-homeowner-80000-joint-4.json
+++ b/test/snapshots/v1-84106-homeowner-80000-joint-4.json
@@ -10,7 +10,7 @@
   "location": {
     "state": "UT",
     "city": "Salt Lake City",
-    "countyFips": "49035"
+    "county_fips": "49035"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-az-85001-state-utility-moderateincome.json
+++ b/test/snapshots/v1-az-85001-state-utility-moderateincome.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "AZ",
     "city": "Phoenix",
-    "countyFips": "04013"
+    "county_fips": "04013"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-az-85701-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85701-state-utility-lowincome.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "AZ",
     "city": "Tucson",
-    "countyFips": "04019"
+    "county_fips": "04019"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-az-85702-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85702-state-utility-lowincome.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "AZ",
     "city": "Tucson",
-    "countyFips": "04019"
+    "county_fips": "04019"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-co-81657-state-utility-lowincome.json
+++ b/test/snapshots/v1-co-81657-state-utility-lowincome.json
@@ -26,7 +26,7 @@
   "location": {
     "state": "CO",
     "city": "Vail",
-    "countyFips": "08037"
+    "county_fips": "08037"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-ct-06002-state-utility-lowincome.json
+++ b/test/snapshots/v1-ct-06002-state-utility-lowincome.json
@@ -17,7 +17,7 @@
   "location": {
     "state": "CT",
     "city": "Bloomfield",
-    "countyFips": "09003"
+    "county_fips": "09003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-dc-20303-state-city-lowincome.json
+++ b/test/snapshots/v1-dc-20303-state-city-lowincome.json
@@ -17,7 +17,7 @@
   "location": {
     "state": "DC",
     "city": "Washington",
-    "countyFips": "11001"
+    "county_fips": "11001"
   },
   "data_partners": {
     "dc-electrify-dc": {

--- a/test/snapshots/v1-ga-30033-utility.json
+++ b/test/snapshots/v1-ga-30033-utility.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "GA",
     "city": "Decatur",
-    "countyFips": "13089"
+    "county_fips": "13089"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-il-60202-city-lowincome.json
+++ b/test/snapshots/v1-il-60202-city-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "IL",
     "city": "Evanston",
-    "countyFips": "17031"
+    "county_fips": "17031"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-me-04772-state-lowincome.json
+++ b/test/snapshots/v1-me-04772-state-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "ME",
     "city": "Saint Agatha",
-    "countyFips": "23003"
+    "county_fips": "23003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-me-04772-state-moderateincome.json
+++ b/test/snapshots/v1-me-04772-state-moderateincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "ME",
     "city": "Saint Agatha",
-    "countyFips": "23003"
+    "county_fips": "23003"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-mi-48103-state-utility-lowincome.json
+++ b/test/snapshots/v1-mi-48103-state-utility-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "MI",
     "city": "Ann Arbor",
-    "countyFips": "26161"
+    "county_fips": "26161"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-mi-48825-city-lowincome.json
+++ b/test/snapshots/v1-mi-48825-city-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "MI",
     "city": "East Lansing",
-    "countyFips": "26065"
+    "county_fips": "26065"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-nv-89108-state-utility-lowincome.json
+++ b/test/snapshots/v1-nv-89108-state-utility-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "NV",
     "city": "Las Vegas",
-    "countyFips": "32003"
+    "county_fips": "32003"
   },
   "data_partners": {
     "nv-nevada-clean-energy-fund": {

--- a/test/snapshots/v1-ny-11557-state-utility-lowincome.json
+++ b/test/snapshots/v1-ny-11557-state-utility-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "NY",
     "city": "Hewlett",
-    "countyFips": "36059"
+    "county_fips": "36059"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-or-97001-state-lowincome.json
+++ b/test/snapshots/v1-or-97001-state-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "OR",
     "city": "Antelope",
-    "countyFips": "41065"
+    "county_fips": "41065"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-pa-17555-state-lowincome.json
+++ b/test/snapshots/v1-pa-17555-state-lowincome.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "PA",
     "city": "Narvon",
-    "countyFips": "42071"
+    "county_fips": "42071"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-va-22030-state-utility-lowincome.json
+++ b/test/snapshots/v1-va-22030-state-utility-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "VA",
     "city": "Fairfax",
-    "countyFips": "51059"
+    "county_fips": "51059"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-vt-05401-state-utility-lowincome.json
+++ b/test/snapshots/v1-vt-05401-state-utility-lowincome.json
@@ -20,7 +20,7 @@
   "location": {
     "state": "VT",
     "city": "Burlington",
-    "countyFips": "50007"
+    "county_fips": "50007"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-vt-05845-vec-ev-low-income.json
+++ b/test/snapshots/v1-vt-05845-vec-ev-low-income.json
@@ -17,7 +17,7 @@
   "location": {
     "state": "VT",
     "city": "Irasburg",
-    "countyFips": "50019"
+    "county_fips": "50019"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-vt-addison-co-low-income.json
+++ b/test/snapshots/v1-vt-addison-co-low-income.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "VT",
     "city": "Middlebury",
-    "countyFips": "50001"
+    "county_fips": "50001"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-vt-bennington-co-not-low-income.json
+++ b/test/snapshots/v1-vt-bennington-co-not-low-income.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "VT",
     "city": "Bennington",
-    "countyFips": "50003"
+    "county_fips": "50003"
   },
   "data_partners": {
     "vt-efficiency-vermont": {

--- a/test/snapshots/v1-wi-53703-state-utility-lowincome.json
+++ b/test/snapshots/v1-wi-53703-state-utility-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "WI",
     "city": "Madison",
-    "countyFips": "55025"
+    "county_fips": "55025"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-wi-53910-lowincome.json
+++ b/test/snapshots/v1-wi-53910-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "WI",
     "city": "Adams",
-    "countyFips": "55001"
+    "county_fips": "55001"
   },
   "data_partners": {},
   "incentives": [

--- a/test/snapshots/v1-wi-53910-not-lowincome.json
+++ b/test/snapshots/v1-wi-53910-not-lowincome.json
@@ -14,7 +14,7 @@
   "location": {
     "state": "WI",
     "city": "Adams",
-    "countyFips": "55001"
+    "county_fips": "55001"
   },
   "data_partners": {},
   "incentives": [


### PR DESCRIPTION
It didn't occur to me that this should follow the API naming
convention of lowercase with underscores.
