### PR TITLE
Add gas_utilities to geo groups; change multi-type matching logic

### DIFF
--- a/data/geo_groups.json
+++ b/data/geo_groups.json
@@ -53,6 +53,13 @@
   },
   "MA": {
     "ma-mass-save": {
+      "gas_utilities": [
+        "ma-berkshire-gas-co",
+        "ma-fitchburg-gas-and-elec-lt-co",
+        "ma-liberty-utilities-ma",
+        "ma-national-grid-gas",
+        "ma-nstar-gas-company"
+      ],
       "utilities": [
         "ma-eversource",
         "ma-fitchburg-gas-and-electric-light",

--- a/src/data/geo_groups.ts
+++ b/src/data/geo_groups.ts
@@ -7,6 +7,7 @@ const GEO_GROUP_SCHEMA = {
   properties: {
     description: { type: 'string' },
     utilities: { type: 'array', items: { type: 'string' }, minItems: 1 },
+    gas_utilities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     cities: { type: 'array', items: { type: 'string' }, minItems: 1 },
     counties: { type: 'array', items: { type: 'string' }, minItems: 1 },
     incentives: { type: 'array', items: { type: 'string' }, minItems: 1 },
@@ -14,6 +15,7 @@ const GEO_GROUP_SCHEMA = {
   additionalProperties: false,
   anyOf: [
     { required: ['utilities'] },
+    { required: ['gas_utilities'] },
     { required: ['cities'] },
     { required: ['counties'] },
   ],

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -315,20 +315,33 @@ function skipBasedOnRequestParams(
     const group =
       GEO_GROUPS_BY_STATE[location.state]![incentive.eligible_geo_group];
 
-    // The request params must match ALL of the keys the geo group defines
+    // The request params must match ANY of the keys the geo group defines
+    const matchesUtility =
+      group.utilities &&
+      request.utility &&
+      group.utilities.includes(request.utility);
+    const matchesGasUtility =
+      group.gas_utilities &&
+      request.gas_utility &&
+      group.gas_utilities.includes(request.gas_utility);
+    const matchesCity =
+      group.cities &&
+      location.city &&
+      group.cities
+        .map(id => stateAuthorities.city[id].city)
+        .includes(location.city);
+    const matchesCounty =
+      group.counties &&
+      location.county_fips &&
+      group.counties
+        .map(id => stateAuthorities.county[id].county_fips)
+        .includes(location.county_fips);
+
     if (
-      (group.utilities &&
-        (!request.utility || !group.utilities.includes(request.utility))) ||
-      (group.counties &&
-        (!location.county_fips ||
-          !group.counties
-            .map(id => stateAuthorities.county[id].county_fips)
-            .includes(location.county_fips))) ||
-      (group.cities &&
-        (!location.city ||
-          !group.cities
-            .map(id => stateAuthorities.city[id].city)
-            .includes(location.city)))
+      !matchesUtility &&
+      !matchesGasUtility &&
+      !matchesCity &&
+      !matchesCounty
     ) {
       return true;
     }

--- a/test/data/geo_groups.test.ts
+++ b/test/data/geo_groups.test.ts
@@ -18,6 +18,11 @@ test('geo groups refer to valid authorities', async t => {
       group.utilities?.forEach(utility =>
         t.hasProp(authorities.utility, utility),
       );
+      group.gas_utilities?.forEach(
+        gas_utility =>
+          t.ok(authorities.gas_utility) &&
+          t.hasProp(authorities.gas_utility!, gas_utility),
+      );
       group.counties?.forEach(
         county =>
           t.ok(authorities.county) && t.hasProp(authorities.county!, county),

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -779,6 +779,13 @@ test('correctly matches geo groups', async t => {
   });
   t.equal(withGas.incentives.filter(massSaveFilter).length, 2);
 
+  const withBoth = calculateIncentives(...LOCATION_AND_AMIS['02130'], {
+    ...baseArgs,
+    utility: 'ma-national-grid',
+    gas_utility: 'ma-national-grid-gas',
+  });
+  t.equal(withBoth.incentives.filter(massSaveFilter).length, 2);
+
   const withNoMassSave = calculateIncentives(...LOCATION_AND_AMIS['02130'], {
     ...baseArgs,
     utility: 'ma-city-of-westfield',


### PR DESCRIPTION
## Description

Mass Save is the first example of this type, containing both utilities
and gas_utilities.

The code said that the request has to match on _all_ of the group's
defined categories, but I don't remember why I wrote it that way, and
it doesn't really make sense to me now.

In any case, this isn't an observable behavior change because there
were no multi-type groups before.

## Test Plan

`yarn test`
