### PR TITLE
Stop manually loading in each state's incentives

### DIFF
--- a/src/data/state_incentives.ts
+++ b/src/data/state_incentives.ts
@@ -9,6 +9,7 @@ import { PaymentMethod } from './types/incentive-types';
 import { ALL_ITEMS, Item } from './types/items';
 import { LocalizableString } from './types/localizable-string';
 import { OwnerStatus } from './types/owner-status';
+import { STATES_AND_TERRITORIES } from './types/states';
 
 export type StateIncentive = {
   id: string;
@@ -77,323 +78,29 @@ const requiredProperties = [
   'short_description',
 ] as const;
 
-export const STATE_SCHEMA: JSONSchemaType<StateIncentive> = {
-  type: 'object',
-  properties: {
-    ...incentivePropertySchema,
+export const STATE_SCHEMA: JSONSchemaType<StateIncentive[]> = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      ...incentivePropertySchema,
+    },
+    required: requiredProperties,
+    additionalProperties: false,
   },
-  required: requiredProperties,
-  additionalProperties: false,
 } as const;
 
 /******************************************************************************/
 /* State-specific types/schemas                                               */
 /******************************************************************************/
 
-export const AZ_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const AZ_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/AZ/incentives.json', 'utf-8'),
-);
-
-export const CO_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const CO_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/CO/incentives.json', 'utf-8'),
-);
-
-export const CT_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const CT_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/CT/incentives.json', 'utf-8'),
-);
-
-export const DC_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-  },
-} as const;
-
-export const DC_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/DC/incentives.json', 'utf-8'),
-);
-
-export const GA_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const GA_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/GA/incentives.json', 'utf-8'),
-);
-
-export const IL_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const IL_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/IL/incentives.json', 'utf-8'),
-);
-
-export const MA_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const MA_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/MA/incentives.json', 'utf-8'),
-);
-
-export const ME_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const ME_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/ME/incentives.json', 'utf-8'),
-);
-
-export const MI_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const MI_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/MI/incentives.json', 'utf-8'),
-);
-
-export const NV_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const NV_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/NV/incentives.json', 'utf-8'),
-);
-
-export const NY_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const NY_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/NY/incentives.json', 'utf-8'),
-);
-
-export const PA_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const PA_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/PA/incentives.json', 'utf-8'),
-);
-
-export const RI_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const RI_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/RI/incentives.json', 'utf-8'),
-);
-
-export const OR_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const OR_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/OR/incentives.json', 'utf-8'),
-);
-
-export const TX_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const TX_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/TX/incentives.json', 'utf-8'),
-);
-
-export const VA_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const VA_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/VA/incentives.json', 'utf-8'),
-);
-
-export const VT_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const VT_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/VT/incentives.json', 'utf-8'),
-);
-
-export const WI_INCENTIVES_SCHEMA: JSONSchemaType<StateIncentive[]> = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      ...incentivePropertySchema,
-    },
-    required: requiredProperties,
-    additionalProperties: false,
-  },
-} as const;
-
-export const WI_INCENTIVES: StateIncentive[] = JSON.parse(
-  fs.readFileSync('./data/WI/incentives.json', 'utf-8'),
-);
-
-export const STATE_INCENTIVES_BY_STATE: StateIncentivesMap = {
-  AZ: AZ_INCENTIVES,
-  CO: CO_INCENTIVES,
-  CT: CT_INCENTIVES,
-  DC: DC_INCENTIVES,
-  GA: GA_INCENTIVES,
-  IL: IL_INCENTIVES,
-  MA: MA_INCENTIVES,
-  ME: ME_INCENTIVES,
-  MI: MI_INCENTIVES,
-  NV: NV_INCENTIVES,
-  NY: NY_INCENTIVES,
-  OR: OR_INCENTIVES,
-  PA: PA_INCENTIVES,
-  RI: RI_INCENTIVES,
-  TX: TX_INCENTIVES,
-  VA: VA_INCENTIVES,
-  VT: VT_INCENTIVES,
-  WI: WI_INCENTIVES,
-};
+export const STATE_INCENTIVES_BY_STATE: StateIncentivesMap = (() => {
+  const result: StateIncentivesMap = {};
+  for (const state of STATES_AND_TERRITORIES) {
+    const incentivesPath = `./data/${state}/incentives.json`;
+    if (fs.existsSync(incentivesPath)) {
+      result[state] = JSON.parse(fs.readFileSync(incentivesPath, 'utf-8'));
+    }
+  }
+  return result;
+})();

--- a/test/data/schemas.test.ts
+++ b/test/data/schemas.test.ts
@@ -23,48 +23,13 @@ import {
   INCENTIVE_RELATIONSHIPS_SCHEMA,
 } from '../../src/data/state_incentive_relationships';
 import {
-  AZ_INCENTIVES,
-  AZ_INCENTIVES_SCHEMA,
-  CO_INCENTIVES,
-  CO_INCENTIVES_SCHEMA,
-  CT_INCENTIVES,
-  CT_INCENTIVES_SCHEMA,
-  DC_INCENTIVES,
-  DC_INCENTIVES_SCHEMA,
-  GA_INCENTIVES,
-  GA_INCENTIVES_SCHEMA,
-  IL_INCENTIVES,
-  IL_INCENTIVES_SCHEMA,
-  MA_INCENTIVES,
-  MA_INCENTIVES_SCHEMA,
-  ME_INCENTIVES,
-  ME_INCENTIVES_SCHEMA,
-  MI_INCENTIVES,
-  MI_INCENTIVES_SCHEMA,
-  NV_INCENTIVES,
-  NV_INCENTIVES_SCHEMA,
-  NY_INCENTIVES,
-  NY_INCENTIVES_SCHEMA,
-  OR_INCENTIVES,
-  OR_INCENTIVES_SCHEMA,
-  PA_INCENTIVES,
-  PA_INCENTIVES_SCHEMA,
-  RI_INCENTIVES,
-  RI_INCENTIVES_SCHEMA,
+  STATE_INCENTIVES_BY_STATE,
+  STATE_SCHEMA,
   StateIncentive,
-  TX_INCENTIVES,
-  TX_INCENTIVES_SCHEMA,
-  VA_INCENTIVES,
-  VA_INCENTIVES_SCHEMA,
-  VT_INCENTIVES,
-  VT_INCENTIVES_SCHEMA,
-  WI_INCENTIVES,
-  WI_INCENTIVES_SCHEMA,
 } from '../../src/data/state_incentives';
 import { TAX_BRACKETS, SCHEMA as TB_SCHEMA } from '../../src/data/tax_brackets';
 
 import Ajv from 'ajv/dist/2020';
-import { JSONSchemaType } from 'ajv/dist/types/json-schema';
 import {
   GEO_GROUPS_BY_STATE,
   GEO_GROUPS_SCHEMA,
@@ -110,31 +75,6 @@ test('static JSON files match schema', async tap => {
   });
 });
 
-const STATE_INCENTIVE_TESTS: [
-  string,
-  JSONSchemaType<StateIncentive[]>,
-  StateIncentive[],
-][] = [
-  ['AZ', AZ_INCENTIVES_SCHEMA, AZ_INCENTIVES],
-  ['CO', CO_INCENTIVES_SCHEMA, CO_INCENTIVES],
-  ['CT', CT_INCENTIVES_SCHEMA, CT_INCENTIVES],
-  ['DC', DC_INCENTIVES_SCHEMA, DC_INCENTIVES],
-  ['GA', GA_INCENTIVES_SCHEMA, GA_INCENTIVES],
-  ['IL', IL_INCENTIVES_SCHEMA, IL_INCENTIVES],
-  ['MA', MA_INCENTIVES_SCHEMA, MA_INCENTIVES],
-  ['ME', ME_INCENTIVES_SCHEMA, ME_INCENTIVES],
-  ['MI', MI_INCENTIVES_SCHEMA, MI_INCENTIVES],
-  ['NV', NV_INCENTIVES_SCHEMA, NV_INCENTIVES],
-  ['NY', NY_INCENTIVES_SCHEMA, NY_INCENTIVES],
-  ['OR', OR_INCENTIVES_SCHEMA, OR_INCENTIVES],
-  ['PA', PA_INCENTIVES_SCHEMA, PA_INCENTIVES],
-  ['RI', RI_INCENTIVES_SCHEMA, RI_INCENTIVES],
-  ['TX', TX_INCENTIVES_SCHEMA, TX_INCENTIVES],
-  ['VA', VA_INCENTIVES_SCHEMA, VA_INCENTIVES],
-  ['VT', VT_INCENTIVES_SCHEMA, VT_INCENTIVES],
-  ['WI', WI_INCENTIVES_SCHEMA, WI_INCENTIVES],
-];
-
 /**
  * Checks some invariants of incentives that aren't expressible in schemas.
  */
@@ -163,8 +103,10 @@ function isValidMaximum(amount: StateIncentive['amount']): boolean {
 test('state incentives JSON files match schemas', async tap => {
   const ajv = new Ajv({ schemas: [LOCALIZABLE_STRING_SCHEMA] });
 
-  STATE_INCENTIVE_TESTS.forEach(([stateId, schema, data]) => {
-    if (!tap.ok(ajv.validate(schema, data), `${stateId} incentives invalid`)) {
+  Object.entries(STATE_INCENTIVES_BY_STATE).forEach(([stateId, data]) => {
+    if (
+      !tap.ok(ajv.validate(STATE_SCHEMA, data), `${stateId} incentives invalid`)
+    ) {
       console.error(ajv.errors);
     }
 
@@ -199,7 +141,7 @@ test('state incentives JSON files match schemas', async tap => {
 });
 
 test("launched states do not have any values that we don't support for broader consumption in the API", async tap => {
-  STATE_INCENTIVE_TESTS.forEach(([state, , data]) => {
+  Object.entries(STATE_INCENTIVES_BY_STATE).forEach(([state, data]) => {
     if (LAUNCHED_STATES.includes(state)) {
       for (const incentive of data) {
         tap.notOk(
@@ -325,7 +267,7 @@ test('state incentive relationships contain no circular dependencies', async tap
 test('state incentive relationships only reference real IDs', async tap => {
   // Collect all the incentive IDs we know about.
   const incentiveIds = new Map<string, Set<string>>();
-  STATE_INCENTIVE_TESTS.forEach(([stateId, , data]) => {
+  Object.entries(STATE_INCENTIVES_BY_STATE).forEach(([stateId, data]) => {
     // Check some constraints that aren't expressed in JSON schema
     const ids = new Set<string>();
     data.forEach(incentive => {


### PR DESCRIPTION
## Links

- https://app.asana.com/0/1208668890181682/1208930378081802

## Description

This hasn't made sense since we stopped having programs defined in
Typescript. Just iterate over the states like we do for other types of
state-specific data file.

This will avoid an easily-forgotten piece of busywork that happens
with every new state we add.

## Test Plan

`yarn test`. Manually make a non-conformant change to a state
incentives JSON file and make sure the test fails.
