### PR TITLE
Slightly rework gas utilities API

### DIFF
--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -12,6 +12,7 @@ import calculateIncentives, {
 import { resolveLocation } from '../lib/location';
 import { statesWithStatus } from '../lib/states';
 import {
+  canGasUtilityAffectEligibility,
   getElectricUtilitiesForLocation,
   getGasUtilitiesForLocation,
 } from '../lib/utilities-for-location';
@@ -137,6 +138,14 @@ export default async function (
         );
       }
 
+      const gas_utilities = await getGasUtilitiesForLocation(
+        fastify.sqlite,
+        location,
+      );
+      const gas_utility_affects_incentives = gas_utilities
+        ? canGasUtilityAffectEligibility(location)
+        : undefined;
+
       try {
         reply
           .status(200)
@@ -147,10 +156,8 @@ export default async function (
               fastify.sqlite,
               location,
             ),
-            gas_utilities: await getGasUtilitiesForLocation(
-              fastify.sqlite,
-              location,
-            ),
+            gas_utilities,
+            gas_utility_affects_incentives,
           });
       } catch (error) {
         if (error instanceof InvalidInputError) {

--- a/src/schemas/v1/utilities-endpoint.ts
+++ b/src/schemas/v1/utilities-endpoint.ts
@@ -21,9 +21,9 @@ may differ from the name of the utility's legal entity.`,
     },
     gas_utilities: {
       type: 'object',
-      description: `A map of IDs to info about each gas utility. This may be \
-absent if the user's gas utility does not affect their eligibility for \
-incentives, or if no gas utilities serve the given location.`,
+      description: `A map of IDs to info about each gas utility. If absent, \
+that means we have no information on the gas utilities in the given location. \
+Even if present, may be empty if no gas utilities serve the given location.`,
       additionalProperties: {
         type: 'object',
         properties: {
@@ -34,6 +34,13 @@ may differ from the name of the utility's legal entity.`,
           },
         },
       },
+    },
+    gas_utility_affects_incentives: {
+      type: 'boolean',
+      description: `Whether the user's gas utility may affect the set of \
+incentives they are eligible for. This can be because there are gas utilities \
+that offer incentives we track, or because more complex eligibility rules \
+apply in the user's location.`,
     },
   },
   required: ['location', 'utilities'],

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -904,6 +904,26 @@ const UTILITIES = [
       },
     },
   ],
+  [
+    '02116',
+    {
+      location: { state: 'MA', city: 'Boston', county_fips: '25025' },
+      utilities: {
+        'ma-eversource': {
+          name: 'Eversource',
+        },
+      },
+      gas_utilities: {
+        'ma-national-grid-gas': {
+          name: 'National Grid',
+        },
+        'ma-nstar-gas-company': {
+          name: 'Eversource',
+        },
+      },
+      gas_utility_affects_incentives: true,
+    },
+  ],
 ] as const;
 
 test('/utilities', async t => {


### PR DESCRIPTION
## Description

This will make the API more suitable for general use, while still
supporting the calculator's intended behavior of only showing the gas
utility selector when necessary.

In addition to the recently added `gas_utilities` key in the
`/v1/utilities` response, I added `gas_utility_affects_incentives`.
If we don't have gas utility data for a state at all, both keys are
absent. If we have gas utility data, `gas_utilities` is always
populated and `gas_utility_affects_incentives` is present.

This way, clients who are just interested in which utilities serve the
area get whatever data we have. But the calculator can look at the
boolean flag to see whether it should show the selector.

## Test Plan

Testing is incomplete because we only have gas utility incentives in
MA, which is special-cased in the code anyway. But the new and
existing `/utilities` tests are decent coverage.
