### PR TITLE
Launch CT and OR; put IN and NM in beta

### DIFF
--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -65,16 +65,17 @@ export const STATES_AND_TERRITORIES = [...STATES_PLUS_DC, ...TERRITORIES];
 export const BETA_STATES: string[] = [
   'AK',
   'CA',
-  'CT',
   'DE',
+  'IN',
   'MA',
-  'OR',
+  'NM',
   'TX',
 ];
 
 export const LAUNCHED_STATES: string[] = [
   'AZ',
   'CO',
+  'CT',
   'DC',
   'GA',
   'IL',
@@ -82,6 +83,7 @@ export const LAUNCHED_STATES: string[] = [
   'MI',
   'NV',
   'NY',
+  'OR',
   'PA',
   'RI',
   'VA',

--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -338,7 +338,9 @@ export default function calculateIncentives(
     authority_types.includes(AuthorityType.State) ||
     authority_types.includes(AuthorityType.Utility) ||
     authority_types.includes(AuthorityType.County) ||
-    authority_types.includes(AuthorityType.City)
+    authority_types.includes(AuthorityType.City) ||
+    authority_types.includes(AuthorityType.GasUtility) ||
+    authority_types.includes(AuthorityType.Other)
   ) {
     const allStateIncentives = getAllStateIncentives(state_id, request);
     const stateIncentiveRelationships =

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -95,14 +95,14 @@ test('correctly evaluates state incentives for launched states', async t => {
 });
 
 test('correctly excludes state incentives for beta states', async t => {
-  // CT is not launched so will not get state incentives.
-  const data = calculateIncentives(...LOCATION_AND_AMIS['06002'], {
+  // MA is not launched so will not get state incentives.
+  const data = calculateIncentives(...LOCATION_AND_AMIS['02130'], {
     owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
     tax_filing: FilingStatus.Single,
     household_size: 1,
-    authority_types: [AuthorityType.State, AuthorityType.Utility],
-    utility: 'ct-norwich-public-utilities',
+    authority_types: [AuthorityType.Other],
+    utility: 'ma-eversource',
     include_beta_states: false,
   });
   t.ok(data);
@@ -110,14 +110,14 @@ test('correctly excludes state incentives for beta states', async t => {
 });
 
 test('correctly evaluates state incentives for beta states', async t => {
-  // CT is in beta so we should get incentives for it when beta is requested.
-  const data = calculateIncentives(...LOCATION_AND_AMIS['06002'], {
+  // MA is in beta so we should get incentives for it when beta is requested.
+  const data = calculateIncentives(...LOCATION_AND_AMIS['02130'], {
     owner_status: OwnerStatus.Homeowner,
     household_income: 120000,
     tax_filing: FilingStatus.Single,
     household_size: 1,
-    authority_types: [AuthorityType.State, AuthorityType.Utility],
-    utility: 'ct-norwich-public-utilities',
+    authority_types: [AuthorityType.Other],
+    utility: 'ma-eversource',
     include_beta_states: true,
   });
   t.ok(data);


### PR DESCRIPTION
## Description

Had to update some tests that assumed CT was in beta; in doing so I
found a bug that had been around for a while. We would have been
underestimating eligibility for clients that passed
`authority_types=other`; offhand I would guess that this is zero
clients. (It was not affecting the calculator, because the calculator
doesn't pass the `authority_types` param.)

## Test Plan

`yarn test`
