### PR TITLE
Filter out incentives with end dates in the past

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@fastify/cors": "^9.0.1",
     "@fastify/sensible": "^5.6.0",
     "@fastify/swagger": "^8.12.0",
+    "@js-joda/core": "^5.6.1",
+    "@js-joda/timezone": "^2.21.1",
     "@types/cheerio": "^0.22.35",
     "axios": "^1.7.7",
     "axios-retry": "^4.0.0",
@@ -30,7 +32,6 @@
   },
   "devDependencies": {
     "@fastify/type-provider-json-schema-to-ts": "^2.2.2",
-    "@js-joda/core": "^5.6.1",
     "@js-joda/locale_en-us": "^4.14.0",
     "@types/glob": "^8.1.0",
     "@types/lodash": "^4.17.13",

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,3 +1,5 @@
+import { LocalDate, YearMonth } from '@js-joda/core';
+
 /**
  * This allows representing the start or end date of an incentive at the
  * granularity of:
@@ -14,3 +16,42 @@
  */
 export const START_END_DATE_REGEX =
   /^\d{4}(H[12]|Q[1-4]|-(0[1-9]|1[0-2])(-(0[1-9]|1[0-9]|2[0-9]|3[01]))?)?$/;
+
+/**
+ * Returns a LocalDate representing the last possible day of the period denoted
+ * by the given start/end date string. Assumes that the given string matches the
+ * regex above.
+ */
+export function lastDayOf(incentiveDate: string): LocalDate {
+  const quarterHalfMatch = incentiveDate.match(/(\d{4})(Q[1-4]|H[1-2])/);
+  if (quarterHalfMatch) {
+    const year = parseInt(quarterHalfMatch[1]);
+    switch (quarterHalfMatch[2]) {
+      case 'Q1':
+        return LocalDate.of(year, 3, 31);
+      case 'Q2':
+      case 'H1':
+        return LocalDate.of(year, 6, 30);
+      case 'Q3':
+        return LocalDate.of(year, 9, 30);
+      case 'Q4':
+      case 'H2':
+        return LocalDate.of(year, 12, 31);
+    }
+  }
+
+  // Now it must be a normal, partial ISO 8601 date
+  const components = incentiveDate.split('-').map(n => parseInt(n));
+
+  switch (components.length) {
+    case 1:
+      return LocalDate.of(components[0], 12, 31);
+    case 2:
+      return YearMonth.of(components[0], components[1]).atEndOfMonth();
+    case 3:
+      return LocalDate.of(components[0], components[1], components[2]);
+  }
+
+  // Should not get here if START_END_DATE_REGEX precondition holds
+  throw new Error(`Invalid end date ${incentiveDate}`);
+}

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -140,8 +140,13 @@ export function calculateStateIncentivesAndSavings(
 
       // Use the current day in Eastern time, the earliest timezone of the
       // mainland US. This is conservative: when it's 2025-01-01 at 1am in
-      // Eastern time, it will still be 2024 in Pacific time but incentives
-      // whose validity ends on 2024-12-31 will be considered invalid.
+      // Eastern time, it will still be 2024 in Pacific time, but incentives
+      // whose validity ends on 2024-12-31 will be counted as ineligible
+      // everywhere.
+      //
+      // One possible improvement would be to infer the user's timezone from
+      // their passed-in location, but that would be a lot of effort for fairly
+      // marginal gain.
       if (LocalDate.now(ZoneId.of('America/New_York')).isAfter(lastValidDay)) {
         eligible = false;
       }

--- a/test/lib/dates.test.ts
+++ b/test/lib/dates.test.ts
@@ -1,5 +1,6 @@
+import { LocalDate } from '@js-joda/core';
 import { test } from 'tap';
-import { START_END_DATE_REGEX } from '../../src/lib/dates';
+import { lastDayOf, START_END_DATE_REGEX } from '../../src/lib/dates';
 
 const VALID_DATES = [
   '2024',
@@ -35,4 +36,17 @@ test('invalid dates do not match the regex', async t => {
   INVALID_DATES.forEach(date => {
     t.notOk(START_END_DATE_REGEX.test(date), `${date} should be invalid`);
   });
+});
+
+test('lastDayOf is correct', async t => {
+  t.same(lastDayOf('2024'), LocalDate.of(2024, 12, 31));
+  t.same(lastDayOf('2024-11'), LocalDate.of(2024, 11, 30));
+  t.same(lastDayOf('2024-06-07'), LocalDate.of(2024, 6, 7));
+
+  // Leap days
+  t.same(lastDayOf('2024-02'), LocalDate.of(2024, 2, 29));
+  t.same(lastDayOf('2025-02'), LocalDate.of(2025, 2, 28));
+
+  t.same(lastDayOf('2024Q1'), LocalDate.of(2024, 3, 31));
+  t.same(lastDayOf('2025H2'), LocalDate.of(2025, 12, 31));
 });

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -3,11 +3,11 @@
   "is_under_150_ami": true,
   "is_over_150_ami": false,
   "authorities": {
-    "pa-pennsylvania-department-of-environmental-protection": {
-      "name": "Pennsylvania Department of Environmental Protection"
-    },
     "pa-pennsylvania-department-of-community-and-economic-development": {
       "name": "Pennsylvania Department of Community and Economic Development"
+    },
+    "pa-pennsylvania-department-of-environmental-protection": {
+      "name": "Pennsylvania Department of Environmental Protection"
     }
   },
   "coverage": {
@@ -21,56 +21,6 @@
   },
   "data_partners": {},
   "incentives": [
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "pa-pennsylvania-department-of-environmental-protection",
-      "program": "Alternative Fuel Vehicle Rebates",
-      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "items": [
-        "new_electric_vehicle",
-        "new_plugin_hybrid_vehicle"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 2000,
-        "maximum": 2000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-07-01",
-      "end_date": "2024-06-30",
-      "short_description": "Income-qualified rebate for purchase or lease of new electric vehicles. $2,000 for battery EVs; $1,500 for plug-in hybrid EVs."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "pa-pennsylvania-department-of-environmental-protection",
-      "program": "Alternative Fuel Vehicle Rebates",
-      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "items": [
-        "used_electric_vehicle",
-        "used_plugin_hybrid_vehicle"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 2000,
-        "maximum": 2000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-07-01",
-      "end_date": "2024-06-30",
-      "short_description": "Income-qualified rebate for purchase of eligible used electric vehicles. $2,000 rebate for battery EVs; $1,500 rebate for plug-in hybrid EVs."
-    },
     {
       "payment_methods": [
         "tax_credit"

--- a/test/snapshots/v1-az-85701-state-utility-lowincome.json
+++ b/test/snapshots/v1-az-85701-state-utility-lowincome.json
@@ -332,28 +332,6 @@
       ],
       "authority_type": "utility",
       "authority": "az-tucson-electric-power",
-      "program": "Efficient Home Water Heating",
-      "program_url": "https://www.tep.com/efficient-home-water-heating/",
-      "items": [
-        "heat_pump_water_heater"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 400
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2023-01-01",
-      "end_date": "2023-12-31",
-      "short_description": "$400 rebate for TEP residential customers who purchase and install an Energy Star HPWH equipped with a wireless, programmable controller."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "az-tucson-electric-power",
       "program": "Smart Thermostat Rebate",
       "program_url": "https://www.tep.com/smart-thermostat-rebate/",
       "items": [

--- a/test/snapshots/v1-dc-20303-state-city-lowincome.json
+++ b/test/snapshots/v1-dc-20303-state-city-lowincome.json
@@ -56,148 +56,6 @@
   "incentives": [
     {
       "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Affordable Home Electrification Program",
-      "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "items": [
-        "heat_pump_water_heater"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "short_description": "100% of costs covered for switching to heat pump water heaters. Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Affordable Home Electrification Program",
-      "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "items": [
-        "electric_panel"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-04",
-      "end_date": "2024-10-03",
-      "short_description": "100% of costs covered for upgrading electrical panels. Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "state",
-      "authority": "dc-dc-department-of-energy-and-environment",
-      "program": "Weatherization Assistance Program",
-      "program_url": "https://doee.dc.gov/service/wap",
-      "items": [
-        "air_sealing",
-        "attic_or_roof_insulation",
-        "wall_insulation",
-        "other_insulation",
-        "crawlspace_insulation"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "short_description": "100% of costs covered for home weatherization (insulation and air sealing). Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Solar for All Single-Family Program",
-      "program_url": "https://www.dcseu.com/solar-for-all",
-      "items": [
-        "rooftop_solar_installation"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-02-23",
-      "end_date": "2024-09-30",
-      "short_description": "100% of costs covered for income-qualified homeowners to have solar photovoltaic (PV) systems installed by local contractors."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Affordable Home Electrification Program",
-      "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "items": [
-        "electric_stove"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "short_description": "100% of costs covered for switching to induction cooktops or electric resistance stoves. Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
-        "assistance_program"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "Affordable Home Electrification Program",
-      "program_url": "https://www.dcseu.com/affordable-home-electrification",
-      "items": [
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "percent",
-        "number": 1
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "short_description": "100% of costs covered for switching to qualified ducted or ductless heating systems. Income-qualified residents only."
-    },
-    {
-      "payment_methods": [
         "rebate"
       ],
       "authority_type": "city",
@@ -218,6 +76,28 @@
       ],
       "start_date": "2024-10-28",
       "short_description": "$4000-$5000 rebate for qualified ducted or ductless heat pump systems when fuel switching."
+    },
+    {
+      "payment_methods": [
+        "rebate"
+      ],
+      "authority_type": "city",
+      "authority": "dc-dc-sustainable-energy-utility",
+      "program": "DC Residential Rebates",
+      "program_url": "https://www.dcseu.com/homes/appliance-rebates",
+      "items": [
+        "ductless_heat_pump"
+      ],
+      "amount": {
+        "type": "dollar_amount",
+        "number": 1500,
+        "maximum": 1500
+      },
+      "owner_status": [
+        "homeowner"
+      ],
+      "start_date": "2023-12-31",
+      "short_description": "$1000-$1500 rebate for qualified ducted or ductless heat pump systems."
     },
     {
       "payment_methods": [
@@ -316,29 +196,6 @@
       "program": "DC Residential Rebates",
       "program_url": "https://www.dcseu.com/homes/appliance-rebates",
       "items": [
-        "heat_pump_clothes_dryer"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 200,
-        "maximum": 200
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "short_description": "$75-$200 rebate for ENERGY STAR® or ENERGY STAR® Most Efficient qualified clothes dryers."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "DC Residential Rebates",
-      "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "items": [
         "electric_outdoor_equipment"
       ],
       "amount": {
@@ -351,29 +208,6 @@
       ],
       "start_date": "2023-10-01",
       "short_description": "$75 rebate for electric push lawn mowers."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "city",
-      "authority": "dc-dc-sustainable-energy-utility",
-      "program": "DC Residential Rebates",
-      "program_url": "https://www.dcseu.com/homes/appliance-rebates",
-      "items": [
-        "smart_thermostat"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 50
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-10-01",
-      "end_date": "2024-09-30",
-      "short_description": "$50 rebate for ENERGY STAR® qualified smart thermostats."
     }
   ]
 }

--- a/test/snapshots/v1-mi-48103-state-utility-lowincome.json
+++ b/test/snapshots/v1-mi-48103-state-utility-lowincome.json
@@ -130,50 +130,6 @@
       ],
       "authority_type": "utility",
       "authority": "mi-dte",
-      "program": "Insulation & Windows",
-      "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "items": [
-        "attic_or_roof_insulation"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 400
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2024-08-01",
-      "end_date": "2024-12-01",
-      "short_description": "$400 for roof & attic insulation. Must insulate a minimum of 500 square feet of attic area."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "mi-dte",
-      "program": "Insulation & Windows",
-      "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/Insulation.html",
-      "items": [
-        "wall_insulation"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 400
-      },
-      "owner_status": [
-        "homeowner"
-      ],
-      "start_date": "2024-08-01",
-      "end_date": "2024-12-01",
-      "short_description": "$400 for above-grade wall insulation. Must insulate a minimum of 250 square feet of attic area."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "utility",
-      "authority": "mi-dte",
       "program": "Washers & Dryers",
       "program_url": "https://www.dteenergy.com/us/en/residential/save-money-energy/rebates-and-offers/washers-dryers.html#tabs-f1a15f985f-item-83a9b1fa23",
       "items": [

--- a/test/snapshots/v1-pa-17555-state-lowincome.json
+++ b/test/snapshots/v1-pa-17555-state-lowincome.json
@@ -115,56 +115,6 @@
       "payment_methods": [
         "rebate"
       ],
-      "authority_type": "state",
-      "authority": "pa-pennsylvania-department-of-environmental-protection",
-      "program": "Alternative Fuel Vehicle Rebates",
-      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "items": [
-        "new_electric_vehicle",
-        "new_plugin_hybrid_vehicle"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 3000,
-        "maximum": 3000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-07-01",
-      "end_date": "2024-06-30",
-      "short_description": "Income-qualified rebate for purchase or lease of new electric vehicles. $3,000 for battery EVs; $2,500 for plug-in hybrid EVs."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "state",
-      "authority": "pa-pennsylvania-department-of-environmental-protection",
-      "program": "Alternative Fuel Vehicle Rebates",
-      "program_url": "https://www.dep.pa.gov/Citizens/GrantsLoansRebates/Alternative-Fuels-Incentive-Grant/pages/alternative-fuel-vehicles.aspx",
-      "items": [
-        "used_electric_vehicle",
-        "used_plugin_hybrid_vehicle"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 3000,
-        "maximum": 3000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2023-07-01",
-      "end_date": "2024-06-30",
-      "short_description": "Income-qualified rebate for purchase of eligible used electric vehicles. $3,000 rebate for battery EVs; $2,500 rebate for plug-in hybrid EVs."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
       "authority_type": "other",
       "authority": "pa-first-energy",
       "program": "Residential Products Rebate Program",

--- a/test/snapshots/v1-wi-53703-state-utility-lowincome.json
+++ b/test/snapshots/v1-wi-53703-state-utility-lowincome.json
@@ -24,52 +24,6 @@
       ],
       "authority_type": "other",
       "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "air_sealing"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1125
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $1,125 rebate for ENERGY STAR® Qualified Air Sealing, assessment required. For income-qualified customers."
-    },
-    {
-      "payment_methods": [
-        "pos_rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "attic_or_roof_insulation"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 675
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $675 rebate for attic insulation. For income-qualified customers."
-    },
-    {
-      "payment_methods": [
-        "pos_rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
       "program": "Solar for Homes",
       "program_url": "https://focusonenergy.com/residential/solar-for-homes",
       "items": [
@@ -111,29 +65,6 @@
     },
     {
       "payment_methods": [
-        "pos_rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "other_insulation"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 225
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $225 rebate for foundation insulation. For income-qualified customers."
-    },
-    {
-      "payment_methods": [
         "rebate"
       ],
       "authority_type": "other",
@@ -162,149 +93,6 @@
       ],
       "authority_type": "other",
       "authority": "wi-focus-on-energy",
-      "program": "Heating & Cooling Rebates",
-      "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1300
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "$1,300 rebate for cold climate air source heat pumps replacing natural gas or electric resistance."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Heating & Cooling Rebates",
-      "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "$1,000 rebate for air source heat pumps replacing natural gas or electric resistance."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Heating & Cooling Rebates",
-      "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "items": [
-        "geothermal_heating_installation"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1000,
-        "maximum": 1000
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "$750 rebate for certified geothermal heat pumps without natural gas service or $1000 with natural gas service."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Heating & Cooling Rebates",
-      "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 500
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "$500 rebate for cold climate air source heat pumps replacing propane, oil, existing heat pump, etc."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "wall_insulation"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 450
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $450 rebate for wall insulation."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Heating & Cooling Rebates",
-      "program_url": "https://focusonenergy.com/residential/heating-and-cooling",
-      "items": [
-        "ducted_heat_pump",
-        "ductless_heat_pump"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 400
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "$400 rebate for air source heat pumps replacing propane, oil, existing heat pump, etc."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
       "program": "DIY Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/diy",
       "items": [
@@ -322,29 +110,6 @@
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
       "short_description": "$200 rebate for DIY attic insulation and air sealing, must meet R42 insulation level."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "duct_sealing"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 75
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $75 rebate for duct sealing & insulation."
     },
     {
       "payment_methods": [

--- a/test/snapshots/v1-wi-53910-lowincome.json
+++ b/test/snapshots/v1-wi-53910-lowincome.json
@@ -20,29 +20,6 @@
   "incentives": [
     {
       "payment_methods": [
-        "pos_rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "air_sealing"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 1125
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $1,125 rebate for ENERGY STAR® Qualified Air Sealing, assessment required. For income-qualified customers."
-    },
-    {
-      "payment_methods": [
         "rebate"
       ],
       "authority_type": "other",

--- a/test/snapshots/v1-wi-53910-not-lowincome.json
+++ b/test/snapshots/v1-wi-53910-not-lowincome.json
@@ -24,29 +24,6 @@
       ],
       "authority_type": "other",
       "authority": "wi-focus-on-energy",
-      "program": "Insulation & Air Sealing Rebates",
-      "program_url": "https://focusonenergy.com/residential/insulation-and-air-sealing",
-      "items": [
-        "air_sealing"
-      ],
-      "amount": {
-        "type": "dollar_amount",
-        "number": 675
-      },
-      "owner_status": [
-        "homeowner",
-        "renter"
-      ],
-      "start_date": "2024-01-01",
-      "end_date": "2024-05-31",
-      "short_description": "Up to $675 rebate for ENERGY STAR® Qualified Air Sealing, assessment required."
-    },
-    {
-      "payment_methods": [
-        "rebate"
-      ],
-      "authority_type": "other",
-      "authority": "wi-focus-on-energy",
       "program": "DIY Insulation & Air Sealing Rebates",
       "program_url": "https://focusonenergy.com/residential/diy",
       "items": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,6 +279,11 @@
   resolved "https://registry.yarnpkg.com/@js-joda/locale_en-us/-/locale_en-us-4.14.0.tgz#8710946aadaac5e6f5051078ecdfaa1e00df2220"
   integrity sha512-iPbGT32FDwomeXOI2VXLY9jzYRRip7GaU5Ahyj9bymuRCo2sv1tRa5iXW/0ofRcEDlEtf7KWHHgkmEMUftasGw==
 
+"@js-joda/timezone@^2.21.1":
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/@js-joda/timezone/-/timezone-2.21.1.tgz#c552dbbf5b58a4e861dfb7b43caa2cc3bae852b0"
+  integrity sha512-QOWH24q+6Z0bvYjuiQ5rNlJMWTbogsQkgL1EV35n0jy9msh2I9bgxwryGAFE/N6w8FWQJR+8p4/mIT7+nAb43g==
+
 "@lukeed/ms@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@lukeed/ms/-/ms-2.0.2.tgz#07f09e59a74c52f4d88c6db5c1054e819538e2a8"
@@ -4428,16 +4433,7 @@ string-length@^6.0.0:
   dependencies:
     strip-ansi "^7.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4462,14 +4458,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4916,16 +4905,7 @@ widest-line@^4.0.1:
   dependencies:
     string-width "^5.0.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

Because of the more-than-just-a-day date formats we support, this is a
little bit subtle.

Note that this does not filter on incentive status, which we are not
exporting from HERO yet.

Note also that this uses js-joda, a competent date/time library;
Javascript's native Date is a nightmare.

## Test Plan

Unit test of the new date logic. Snapshot tests reveal a bunch of
expired incentives that don't get returned anymore!

Related, though: this makes the results of snapshot test runs
**time-dependent**, which is really not ideal. This will cause
test failures on completely unrelated PRs. The proper solution is to
inject the "current time" as a parameter to the filtering logic, instead
of calling `LocalDate.now()`, but that may have to wait; we want to
get this change out before the end of year break.
