### PR TITLE
Add unit test for existence of city authorities in zips table

### DIFF
--- a/test/data/cities.test.ts
+++ b/test/data/cities.test.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import { open } from 'sqlite';
+import sqlite3 from 'sqlite3';
+import { test } from 'tap';
+import { AUTHORITIES_BY_STATE } from '../../src/data/authorities';
+
+test('all city authorities exist in zips table', async t => {
+  const database = await open({
+    filename: path.join(__dirname, '../../incentives-api.db'),
+    driver: sqlite3.Database,
+  });
+
+  for (const auths of Object.values(AUTHORITIES_BY_STATE)) {
+    for (const [authorityKey, data] of Object.entries(auths.city || {})) {
+      // If there are no zip codes with this postal city name and county FIPS,
+      // no user location can resolve to this authority.
+      const result = await database.get<{ count: number }>(
+        'SELECT count(1) AS count FROM zips WHERE city = ? AND county_fips = ?',
+        data.city!,
+        data.county_fips!,
+      );
+
+      t.not(
+        result!.count,
+        0,
+        `${authorityKey} does not correspond to a postal city`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Description

Ticket: https://app.asana.com/0/1208668890181682/1209141933112058

In `resolveLocation`, we pull a postal city and county FIPS out of the
`zips` table in SQLite. Then those are matched against `city`-type
authorities. This test makes sure that each `city` authority would
match at least one zip, because if it doesn't, that city authority is
effectively dead.

## Test Plan

`yarn test`
