### PR TITLE
Use static date for snapshot tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "dev": "fastify start -r ts-node/register -w --ignore-watch test -l info -P src/app.ts --options",
     "build": "./scripts/build.sh",
     "lint": "tsc --noEmit && prettier --check . --ignore-path=.prettierignore && eslint .",
-    "test": "dotenv -- tap -- --ts \"test/**/*.test.ts\"",
+    "test": "STATIC_DATE=2025-01-25 dotenv -- tap -- --ts \"test/**/*.test.ts\"",
     "testfilter": "dotenv -- tap -- --ts",
     "update-snapshots": "UPDATE_SNAPSHOTS=1 dotenv -- tap -- --ts \"test/routes/*.test.ts\"",
     "check-data-freshness": "tap --timeout=0 scripts/check-data-freshness.ts"

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -137,17 +137,7 @@ export function calculateStateIncentivesAndSavings(
 
     if (item.end_date) {
       const lastValidDay = lastDayOf(item.end_date);
-
-      // Use the current day in Eastern time, the earliest timezone of the
-      // mainland US. This is conservative: when it's 2025-01-01 at 1am in
-      // Eastern time, it will still be 2024 in Pacific time, but incentives
-      // whose validity ends on 2024-12-31 will be counted as ineligible
-      // everywhere.
-      //
-      // One possible improvement would be to infer the user's timezone from
-      // their passed-in location, but that would be a lot of effort for fairly
-      // marginal gain.
-      if (LocalDate.now(ZoneId.of('America/New_York')).isAfter(lastValidDay)) {
+      if (getCurrentDateTime().isAfter(lastValidDay)) {
         eligible = false;
       }
     }
@@ -380,4 +370,22 @@ function skipBasedOnRequestParams(
   }
 
   return false;
+}
+
+function getCurrentDateTime() {
+  // Use static date for snapshot tests
+  if (process.env.STATIC_DATE) {
+    return LocalDate.parse(process.env.STATIC_DATE);
+  }
+
+  // Use the current day in Eastern time, the earliest timezone of the
+  // mainland US. This is conservative: when it's 2025-01-01 at 1am in
+  // Eastern time, it will still be 2024 in Pacific time, but incentives
+  // whose validity ends on 2024-12-31 will be counted as ineligible
+  // everywhere.
+  //
+  // One possible improvement would be to infer the user's timezone from
+  // their passed-in location, but that would be a lot of effort for fairly
+  // marginal gain.
+  return LocalDate.now(ZoneId.of('America/New_York'));
 }


### PR DESCRIPTION
Filtering out expired incentives from `/calculator` can break some snapshot tests when using the actual current time if an incentive has expired. This change utilizes a static date during testing in order to keep the response values consistent. I set the date to 1/25/2025 since anything older would include incentives that have already been removed from the current snapshot tests.

## Test
- `yarn test`
- Unset the `STATIC_DATE` envar and `yarn test` fails because an incentive expired on 1/27 and will not be included in the response