### PR TITLE
Check child zips for utility mappings as well

### DIFF
--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -966,6 +966,33 @@ const UTILITIES = [
       gas_utility_affects_incentives: true,
     },
   ],
+  [
+    '01450',
+    {
+      location: { state: 'MA', city: 'Groton', county_fips: '25017' },
+      utilities: {
+        'ma-fitchburg-gas-and-electric-light': {
+          name: 'Unitil',
+        },
+        // Not mapped to 01450, but to some of its non-ZCTA child zips
+        'ma-groton-electric-light-dept': {
+          name: 'Groton Electric Light Dept',
+        },
+        'ma-national-grid': {
+          name: 'National Grid',
+        },
+        'ma-town-of-littleton': {
+          name: 'Littleton Municipal Light Plant',
+        },
+      },
+      gas_utilities: {
+        'ma-national-grid-gas': {
+          name: 'National Grid',
+        },
+      },
+      gas_utility_affects_incentives: true,
+    },
+  ],
 ] as const;
 
 test('/utilities', async t => {


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/0/1208668890181682/1209236041655647)

## Description

The ENERGY STAR electric utility dataset has a bunch of mappings to
zips that aren't ZCTAs. They aren't always consistent with the "parent
ZCTA" in our dataset. For example, in the case I added as a unit test:

- 01472 is not a ZCTA. Our dataset has 01450 as its parent ZCTA.
- `ma-groton-electric-light-dept` has a mapping to 01472, but _not_ to 01450.

It is clearly the case that Groton Electric Light covers the 01450
ZCTA (it encompasses the entire town of Groton), so arguably this is a
data error. Rather than go into a rabbit hole of trying to work out
the scope of the problem and update the zip/utility mappings to fix
it, I did this quick workaround to improve our results in these cases.

This change cannot decrease the set of results `/v1/utilities` will
return for any location, which is important.

## Test Plan

New test fails without the change.
