### PR TITLE
Update tax data to 2025 tax year

### DIFF
--- a/data/tax_brackets.json
+++ b/data/tax_brackets.json
@@ -2,197 +2,197 @@
   {
     "filing_status": "single",
     "income_min": 0,
-    "income_max": 11000,
+    "income_max": 11925,
     "tax_rate": 0.1,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "single",
-    "income_min": 11001,
-    "income_max": 44725,
+    "income_min": 11926,
+    "income_max": 48475,
     "tax_rate": 0.12,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "single",
-    "income_min": 44726,
-    "income_max": 95375,
+    "income_min": 48476,
+    "income_max": 103350,
     "tax_rate": 0.22,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "single",
-    "income_min": 95376,
-    "income_max": 182100,
+    "income_min": 103351,
+    "income_max": 197300,
     "tax_rate": 0.24,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "single",
-    "income_min": 182101,
-    "income_max": 231250,
+    "income_min": 197301,
+    "income_max": 250525,
     "tax_rate": 0.32,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "single",
-    "income_min": 231251,
-    "income_max": 578125,
+    "income_min": 250526,
+    "income_max": 626350,
     "tax_rate": 0.35,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "single",
-    "income_min": 578126,
+    "income_min": 626351,
     "income_max": 10000000000,
     "tax_rate": 0.37,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
     "income_min": 0,
-    "income_max": 11000,
+    "income_max": 11925,
     "tax_rate": 0.1,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
-    "income_min": 11001,
-    "income_max": 44725,
+    "income_min": 11926,
+    "income_max": 48475,
     "tax_rate": 0.12,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
-    "income_min": 44726,
-    "income_max": 95375,
+    "income_min": 48476,
+    "income_max": 103350,
     "tax_rate": 0.22,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
-    "income_min": 95376,
-    "income_max": 182100,
+    "income_min": 103351,
+    "income_max": 197300,
     "tax_rate": 0.24,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
-    "income_min": 182101,
-    "income_max": 231250,
+    "income_min": 197301,
+    "income_max": 250525,
     "tax_rate": 0.32,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
-    "income_min": 231251,
-    "income_max": 346875,
+    "income_min": 250526,
+    "income_max": 375800,
     "tax_rate": 0.35,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "married_filing_separately",
-    "income_min": 346876,
+    "income_min": 375801,
     "income_max": 10000000000,
     "tax_rate": 0.37,
-    "standard_deduction": 13850
+    "standard_deduction": 15000
   },
   {
     "filing_status": "joint",
     "income_min": 0,
-    "income_max": 22000,
+    "income_max": 23850,
     "tax_rate": 0.1,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "joint",
-    "income_min": 22001,
-    "income_max": 89450,
+    "income_min": 23851,
+    "income_max": 96950,
     "tax_rate": 0.12,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "joint",
-    "income_min": 89451,
-    "income_max": 190750,
+    "income_min": 96951,
+    "income_max": 206700,
     "tax_rate": 0.22,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "joint",
-    "income_min": 190751,
-    "income_max": 364200,
+    "income_min": 206701,
+    "income_max": 394600,
     "tax_rate": 0.24,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "joint",
-    "income_min": 364201,
-    "income_max": 462500,
+    "income_min": 394601,
+    "income_max": 501050,
     "tax_rate": 0.32,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "joint",
-    "income_min": 462501,
-    "income_max": 693750,
+    "income_min": 501051,
+    "income_max": 751600,
     "tax_rate": 0.35,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "joint",
-    "income_min": 693751,
+    "income_min": 751601,
     "income_max": 10000000000,
     "tax_rate": 0.37,
-    "standard_deduction": 27700
+    "standard_deduction": 30000
   },
   {
     "filing_status": "hoh",
     "income_min": 0,
-    "income_max": 15700,
+    "income_max": 17000,
     "tax_rate": 0.1,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   },
   {
     "filing_status": "hoh",
-    "income_min": 15701,
-    "income_max": 59850,
+    "income_min": 17001,
+    "income_max": 64850,
     "tax_rate": 0.12,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   },
   {
     "filing_status": "hoh",
-    "income_min": 59851,
-    "income_max": 95350,
+    "income_min": 64851,
+    "income_max": 103350,
     "tax_rate": 0.22,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   },
   {
     "filing_status": "hoh",
-    "income_min": 95351,
-    "income_max": 182100,
+    "income_min": 103351,
+    "income_max": 197300,
     "tax_rate": 0.24,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   },
   {
     "filing_status": "hoh",
-    "income_min": 182101,
-    "income_max": 231250,
+    "income_min": 197301,
+    "income_max": 250500,
     "tax_rate": 0.32,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   },
   {
     "filing_status": "hoh",
-    "income_min": 231251,
-    "income_max": 578100,
+    "income_min": 250501,
+    "income_max": 626350,
     "tax_rate": 0.35,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   },
   {
     "filing_status": "hoh",
-    "income_min": 578101,
+    "income_min": 626351,
     "income_max": 10000000000,
     "tax_rate": 0.37,
-    "standard_deduction": 20800
+    "standard_deduction": 22500
   }
 ]

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -167,7 +167,7 @@ test('correctly evaluates scenario "Single w/ $120k Household income in NJ"', as
   t.equal(data.is_over_150_ami, false);
 
   t.equal(data.savings.pos_rebate, 14000);
-  t.equal(data.savings.tax_credit, 18876);
+  t.equal(data.savings.tax_credit, 18047);
   t.equal(data.savings.performance_rebate, 4000);
 
   const pos_rebate_incentives = data.incentives.filter(
@@ -749,7 +749,7 @@ test('correctly excludes IRA rebates', async t => {
   );
   t.equal(data.savings.pos_rebate, 0);
   t.equal(data.savings.performance_rebate, 0);
-  t.equal(data.savings.tax_credit, 18876);
+  t.equal(data.savings.tax_credit, 18047);
 });
 
 test('correctly matches geo groups', async t => {

--- a/test/lib/tax-brackets.test.ts
+++ b/test/lib/tax-brackets.test.ts
@@ -35,32 +35,32 @@ test('defaults to a null state tax obligation for unsupported states', async t =
 
 test('correctly evaluates scenerio: $112,500 hoh', async t => {
   const data = estimateFederalTaxAmount('CA', FilingStatus.HoH, 112500);
-  t.equal(data.taxOwed, 13875);
+  t.equal(data.taxOwed, 12975);
 });
 
 test('correctly evaluates scenerio: $53,100 single', async t => {
   const data = estimateFederalTaxAmount('CA', FilingStatus.Single, 53100);
-  t.equal(data.taxOwed, 4490);
+  t.equal(data.taxOwed, 4334);
 });
 
 test('correctly evaluates scenerio: $300,000 hoh', async t => {
   const data = estimateFederalTaxAmount('CA', FilingStatus.HoH, 300000);
-  t.equal(data.taxOwed, 68009);
+  t.equal(data.taxOwed, 64934);
 });
 
 test('correctly evaluates scenerio: $300,000 single', async t => {
   const data = estimateFederalTaxAmount('CA', FilingStatus.Single, 300000);
-  t.equal(data.taxOwed, 72047);
+  t.equal(data.taxOwed, 69297);
 });
 
 test('correctly evaluates scenerio: $94,000 joint', async t => {
   const data = estimateFederalTaxAmount('CA', FilingStatus.Joint, 94000);
-  t.equal(data.taxOwed, 7516);
+  t.equal(data.taxOwed, 7203);
 });
 
 test('correctly evaluates scenerio: $1,000,000 joint', async t => {
   const data = estimateFederalTaxAmount('CA', FilingStatus.Joint, 1000000);
-  t.equal(data.taxOwed, 289665);
+  t.equal(data.taxOwed, 282963);
 });
 
 test('correctly evaluates scenerio: $8,000 single', async t => {
@@ -89,7 +89,7 @@ test('correctly evaluates scenario: $500,000 married-separate', async t => {
     FilingStatus.MarriedFilingSeparately,
     500000,
   );
-  t.equal(data.taxOwed, 144833);
+  t.equal(data.taxOwed, 141481);
 });
 
 test('correctly evaluates scenario: $53,100 married-separate', async t => {
@@ -98,7 +98,7 @@ test('correctly evaluates scenario: $53,100 married-separate', async t => {
     FilingStatus.MarriedFilingSeparately,
     53100,
   );
-  t.equal(data.taxOwed, 4490);
+  t.equal(data.taxOwed, 4334);
 });
 
 test('bracket bounds are well-formed', async t => {

--- a/test/routes/v0.test.ts
+++ b/test/routes/v0.test.ts
@@ -52,7 +52,7 @@ test('response is valid and correct', async t => {
   t.equal(calculatorResponse.is_over_150_ami, false);
 
   t.equal(calculatorResponse.pos_savings, 14000);
-  t.equal(calculatorResponse.tax_savings, 5836);
+  t.equal(calculatorResponse.tax_savings, 5523);
   t.equal(calculatorResponse.performance_rebate_savings, 8000);
   t.equal(calculatorResponse.estimated_annual_savings, 1040);
 


### PR DESCRIPTION
## Description

Taken from here: https://www.irs.gov/pub/irs-drop/rp-24-40.pdf

These are the brackets that will apply to stuff you do this year, for
the tax return that you'll file in calendar year 2026.

We did skip the entire 2024 tax year, but fortunately, the bracket
numbers have no effect on the v1 API output. (Which raises the
question: is there any point in keeping this stuff once we delete v0?)

## Test Plan

Updated tests. I did a couple of the calculations manually to confirm;
trusting the rest are correct since I didn't touch the calculation
logic.
