### PR TITLE
Change order of filtering in state incentive calculation

### DIFF
--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -107,16 +107,11 @@ test('test incentive relationship logic', async t => {
     AMIS,
   );
   t.ok(data);
-  t.equal(data.stateIncentives.length, 6);
   // Check that the user is only eligible for A, B, and F.
-  for (const incentive of data.stateIncentives) {
-    if (['A', 'B', 'F'].includes(incentive.id)) {
-      t.equal(incentive.eligible, true);
-    }
-    if (['C', 'D', 'E'].includes(incentive.id)) {
-      t.equal(incentive.eligible, false);
-    }
-  }
+  t.strictSame(
+    data.stateIncentives.map(i => i.id),
+    ['A', 'B', 'F'],
+  );
 });
 
 // This user is a renter. Based on this, they are eligible for incentives
@@ -146,17 +141,12 @@ test('test more complex incentive relationship logic', async t => {
     AMIS,
   );
   t.ok(data);
-  t.equal(data.stateIncentives.length, 6);
-  t.equal(data.savings.account_credit, 100);
   // Check that the user is only eligible for E.
-  for (const incentive of data.stateIncentives) {
-    if (['E'].includes(incentive.id)) {
-      t.equal(incentive.eligible, true);
-    }
-    if (['A', 'B', 'C', 'D', 'F'].includes(incentive.id)) {
-      t.equal(incentive.eligible, false);
-    }
-  }
+  t.strictSame(
+    data.stateIncentives.map(i => i.id),
+    ['E'],
+  );
+  t.equal(data.savings.account_credit, 100);
 });
 
 // This user is a renter. Based on this, they are eligible for incentives
@@ -188,17 +178,12 @@ test('test incentive relationship and combined max value logic', async t => {
     AMIS,
   );
   t.ok(data);
-  t.equal(data.stateIncentives.length, 6);
+  t.strictSame(
+    data.stateIncentives.map(i => i.id),
+    ['E', 'F', 'B'],
+  );
   // There is a combined max value of $200 for A, B, C, D, E, and F.
   t.equal(data.savings.account_credit, 200);
-  for (const incentive of data.stateIncentives) {
-    if (['B', 'E', 'F'].includes(incentive.id)) {
-      t.equal(incentive.eligible, true);
-    }
-    if (['A', 'C', 'D'].includes(incentive.id)) {
-      t.equal(incentive.eligible, false);
-    }
-  }
 });
 
 // Same as above except for income.
@@ -233,17 +218,12 @@ test('test incentive relationship and permanent ineligibility criteria', async t
   );
 
   t.ok(data);
-  t.equal(data.stateIncentives.length, 6);
+  t.strictSame(
+    data.stateIncentives.map(i => i.id),
+    ['E', 'F'],
+  );
   // There is a combined max value of $200 for A, B, C, D, E, and F.
   t.equal(data.savings.account_credit, 200);
-  for (const incentive of data.stateIncentives) {
-    if (['E', 'F'].includes(incentive.id)) {
-      t.equal(incentive.eligible, true);
-    }
-    if (['A', 'B', 'C', 'D'].includes(incentive.id)) {
-      t.equal(incentive.eligible, false);
-    }
-  }
 });
 
 // This user is a renter. Based on this, they are eligible for incentives

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -517,8 +517,6 @@ test('correctly sorts incentives', async t => {
 test('correct filtering of county incentives', async t => {
   const incentive: StateIncentive = {
     id: 'CO',
-    start_date: '2023',
-    end_date: '2024',
     payment_methods: [PaymentMethod.AccountCredit],
     items: ['ducted_heat_pump'],
     program: 'ri_hvacAndWaterHeaterIncentives',
@@ -590,8 +588,6 @@ test('correct filtering of county incentives', async t => {
 test('correct filtering of city incentives', async t => {
   const incentive: StateIncentive = {
     id: 'CO',
-    start_date: '2023',
-    end_date: '2024',
     payment_methods: [PaymentMethod.AccountCredit],
     items: ['ducted_heat_pump'],
     program: 'ri_hvacAndWaterHeaterIncentives',

--- a/test/snapshots/v0-80212-homeowner-80000-joint-4.json
+++ b/test/snapshots/v0-80212-homeowner-80000-joint-4.json
@@ -3,7 +3,7 @@
   "is_under_150_ami": true,
   "is_over_150_ami": false,
   "pos_savings": 14000,
-  "tax_savings": 5836,
+  "tax_savings": 5523,
   "performance_rebate_savings": 8000,
   "estimated_annual_savings": 1040,
   "pos_rebate_incentives": [

--- a/test/snapshots/v1-02903-state-utility-moderateincome.json
+++ b/test/snapshots/v1-02903-state-utility-moderateincome.json
@@ -21,9 +21,6 @@
     },
     "ri-commerce-corp": {
       "name": "Rhode Island Commerce Corporation"
-    },
-    "ri-dhs": {
-      "name": "Rhode Island Department of Human Services"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -5,9 +5,6 @@
   "authorities": {
     "pa-pennsylvania-department-of-environmental-protection": {
       "name": "Pennsylvania Department of Environmental Protection"
-    },
-    "pa-pennsylvania-department-of-community-and-economic-development": {
-      "name": "Pennsylvania Department of Community and Economic Development"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-80517-estes-park.json
+++ b/test/snapshots/v1-80517-estes-park.json
@@ -8,9 +8,6 @@
     },
     "co-platte-river-power-authority": {
       "name": "Platte River Power Authority"
-    },
-    "co-state-of-colorado": {
-      "name": "State of Colorado"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-80517-xcel.json
+++ b/test/snapshots/v1-80517-xcel.json
@@ -8,9 +8,6 @@
     },
     "co-colorado-energy-office": {
       "name": "Colorado Energy Office"
-    },
-    "co-state-of-colorado": {
-      "name": "State of Colorado"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-co-81657-state-utility-lowincome.json
+++ b/test/snapshots/v1-co-81657-state-utility-lowincome.json
@@ -14,9 +14,6 @@
     },
     "co-state-of-colorado": {
       "name": "State of Colorado"
-    },
-    "co-energy-outreach-colorado": {
-      "name": "Energy Outreach Colorado"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-dc-20303-state-city-lowincome.json
+++ b/test/snapshots/v1-dc-20303-state-city-lowincome.json
@@ -5,9 +5,6 @@
   "authorities": {
     "dc-dc-sustainable-energy-utility": {
       "name": "DC Sustainable Energy Utility"
-    },
-    "dc-dc-department-of-energy-and-environment": {
-      "name": "DC Department of Energy and Environment"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-ny-11557-state-utility-lowincome.json
+++ b/test/snapshots/v1-ny-11557-state-utility-lowincome.json
@@ -5,9 +5,6 @@
   "authorities": {
     "ny-nyserda": {
       "name": "New York State Energy Research and Development Authority"
-    },
-    "ny-state-of-ny": {
-      "name": "State of NY"
     }
   },
   "coverage": {

--- a/test/snapshots/v1-wi-53703-state-utility-lowincome.json
+++ b/test/snapshots/v1-wi-53703-state-utility-lowincome.json
@@ -5,9 +5,6 @@
   "authorities": {
     "wi-focus-on-energy": {
       "name": "Focus On Energy"
-    },
-    "wi-project-home": {
-      "name": "Project Home"
     }
   },
   "coverage": {


### PR DESCRIPTION
## Description

This change does two things:

- Don't return ineligible incentives from
  `calculateStateIncentivesAndSavings`. Previously, they were being
  returned, and then filtered out in the top-level route handler in
  `v1.ts`. They were never returned in the API. This makes the
  below change simpler.

- Draw a distinction between "real-life eligibility" params, and
  "API-only" params. The latter are the `authority_types` and `items`
  filters. They don't correspond to real-life incentive eligibility
  criteria; they're just there for API clients.

  The important thing here is that now the order of operations in
  eligibility calculation is slightly different:

  1. All of a state's incentives are partitioned into "eligible" and
     "ineligible" based on real-life params: location, utility, owner
     status, income/filing/hhsize, and date. (Date is not an API
     param, but it's a fact of real life that has bearing on
     eligibility.) No incentives are completely removed from
     consideration at this point.

  2. Relationships are solved. This can rule out some incentives that
     came out of step 1 as "eligible".

  3. Incentives are removed from the eligible set based on API-only
     params.

  4. Total savings are calculated. (And almost immediately thrown out,
     and never returned through the API; I plan to remove this stuff
     separately.)

  Previously, filtering by API-only params happened at the top, before
  relationship solving; this gave those params unintended semantics.
  E.g. if you passed `items=ductless_heat_pump`, rather than meaning
  "just filter out incentives for items other than ductless heat
  pumps", it would _consider you ineligible_ for such incentives. That
  had undesired implications for relationship solving.

This is in preparation for implementing the Mass Save rule properly;
that will be a followup PR.

## Test Plan

`yarn test` with updated tests.

The changes to the snapshots are all expected. Those authorities were
in there even though none of the incentives belonged to them; it's
just that some _ineligible_ incentives belonged to them. Those
ineligible incentives' authorities were put into the response before
the incentives were filtered out.
