### PR TITLE
Fix import

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,12 +1,12 @@
 set -e
 
 CHANGED=$(git diff "$1" "$2" --stat -- ./yarn.lock | wc -l)
-if (( CHANGED > 0 )); then
+if [ $CHANGED -gt 0 ]; then
     echo "📦 yarn.lock changed. Run yarn install to bring your dependencies up to date."
 fi
 
 CHANGED=$(git diff "$1" "$2" --stat -- ./scripts/import-csvs.sql ./scripts/data/*.csv ./scripts/income_limits/data/processed | wc -l)
-if (( CHANGED > 0 )); then
+if [ $CHANGED -gt 0 ]; then
     echo "Building SQLite database..."
     yarn build
 fi


### PR DESCRIPTION
## Description

The weekly HERO import didn't work, and it looks to be because of this
Husky post-checkout script. It turns out the newest version of Husky
runs hooks in `sh`, which does not support the double-paren-to-do-math
syntax that this hook was using (that's a Bash thing). Change it to be
sh-friendly.

## Test Plan

Will look at the CI logs on this PR to make sure there's no error
messages from this hook.
