### PR TITLE
Update language for federal EV tax credit

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -340,8 +340,8 @@
     "start_date": "2023",
     "end_date": "2032",
     "short_description": {
-      "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
-      "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
+      "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
+      "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
@@ -374,8 +374,8 @@
     "start_date": "2023",
     "end_date": "2032",
     "short_description": {
-      "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
-      "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
+      "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
+      "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
@@ -408,8 +408,8 @@
     "start_date": "2023",
     "end_date": "2032",
     "short_description": {
-      "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
-      "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
+      "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
+      "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",
@@ -442,8 +442,8 @@
     "start_date": "2023",
     "end_date": "2032",
     "short_description": {
-      "en": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
-      "es": "Crédito fiscal hasta $7,500 por los vehículos eléctricos nuevos con el precio sugerido hasta $55,000 y los monovolúmenes, camionetas, y SUVs hasta $80,000."
+      "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
+      "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive",

--- a/test/snapshots/v0-80212-homeowner-80000-joint-4.json
+++ b/test/snapshots/v0-80212-homeowner-80000-joint-4.json
@@ -264,7 +264,7 @@
       "agi_max_limit": 300000,
       "filing_status": "joint",
       "eligible": true,
-      "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
+      "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "more_info_url_internal": "https://homes.rewiringamerica.org/federal-incentives/30d-new-ev-tax-incentive"
     },
     {

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -88,7 +88,7 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
+      "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
       "payment_methods": [

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -158,7 +158,7 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
+      "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
       "payment_methods": [

--- a/test/snapshots/v1-84106-homeowner-80000-joint-4.json
+++ b/test/snapshots/v1-84106-homeowner-80000-joint-4.json
@@ -104,7 +104,7 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
+      "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
       "payment_methods": [

--- a/test/snapshots/v1-vt-05845-vec-ev-low-income.json
+++ b/test/snapshots/v1-vt-05845-vec-ev-low-income.json
@@ -166,7 +166,7 @@
       ],
       "start_date": "2023",
       "end_date": "2032",
-      "short_description": "Tax credit (up to $7,500) for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
+      "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
       "payment_methods": [


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/0/1208668890181682/1209198275861173)

## Description

To reflect that the credit is now deliverable as an upfront discount
at the point of sale (by being transferred to the dealership, I
think?). I removed the `(up to $7,500)` parenthetical from the
language in the ticket, to stay under the char limit, and because the
amount is in the `amount` field (which will be prominently shown in
the calculator).

Re: the ask to link to the DOE's `fueleconomy.gov` site instead: I
decided not to, because the [IRS page we currently link
to](https://www.irs.gov/credits-deductions/credits-for-new-clean-vehicles-purchased-in-2023-or-after)
is not bad, and it links to fueleconomy.gov itself. (In contrast,
fueleconomy.gov does not link to any IRS page as far as I can see.)

## Test Plan

Snapshot tests updated.
