### PR TITLE
Calculate taxes for MA and NM

### DIFF
--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -232,6 +232,7 @@ export function calculateStateIncentivesAndSavings(
   // Get state tax owed to determine max potential tax savings
   const stateTaxOwed = estimateStateTaxAmount(
     request.household_income,
+    request.tax_filing,
     stateId,
   );
 

--- a/src/lib/tax-brackets.ts
+++ b/src/lib/tax-brackets.ts
@@ -25,44 +25,34 @@ const MA_SURTAX_THRESHOLD = 1_083_150;
 // https://www.tax.newmexico.gov/individuals/wp-content/uploads/sites/5/2021/12/PIT-rates_2005_2021.pdf
 const NM_BRACKETS: {
   [S in FilingStatus]: { maxIncome: number; rate: number }[];
-} = {
-  [FilingStatus.Single]: [
-    { maxIncome: 5500, rate: 0.017 },
-    { maxIncome: 11000, rate: 0.032 },
-    { maxIncome: 16000, rate: 0.047 },
-    { maxIncome: 210000, rate: 0.049 },
-    { maxIncome: Infinity, rate: 0.059 },
-  ],
-  [FilingStatus.MarriedFilingSeparately]: [
-    { maxIncome: 4000, rate: 0.017 },
-    { maxIncome: 8000, rate: 0.032 },
-    { maxIncome: 12000, rate: 0.047 },
-    { maxIncome: 157500, rate: 0.049 },
-    { maxIncome: Infinity, rate: 0.059 },
-  ],
-  // Below three all the same
-  [FilingStatus.Joint]: [
+} = (() => {
+  const joint = [
     { maxIncome: 8000, rate: 0.017 },
     { maxIncome: 16000, rate: 0.032 },
     { maxIncome: 24000, rate: 0.047 },
     { maxIncome: 315000, rate: 0.049 },
     { maxIncome: Infinity, rate: 0.059 },
-  ],
-  [FilingStatus.HoH]: [
-    { maxIncome: 8000, rate: 0.017 },
-    { maxIncome: 16000, rate: 0.032 },
-    { maxIncome: 24000, rate: 0.047 },
-    { maxIncome: 315000, rate: 0.049 },
-    { maxIncome: Infinity, rate: 0.059 },
-  ],
-  [FilingStatus.QualifyingWidower]: [
-    { maxIncome: 8000, rate: 0.017 },
-    { maxIncome: 16000, rate: 0.032 },
-    { maxIncome: 24000, rate: 0.047 },
-    { maxIncome: 315000, rate: 0.049 },
-    { maxIncome: Infinity, rate: 0.059 },
-  ],
-};
+  ];
+  return {
+    [FilingStatus.Single]: [
+      { maxIncome: 5500, rate: 0.017 },
+      { maxIncome: 11000, rate: 0.032 },
+      { maxIncome: 16000, rate: 0.047 },
+      { maxIncome: 210000, rate: 0.049 },
+      { maxIncome: Infinity, rate: 0.059 },
+    ],
+    [FilingStatus.MarriedFilingSeparately]: [
+      { maxIncome: 4000, rate: 0.017 },
+      { maxIncome: 8000, rate: 0.032 },
+      { maxIncome: 12000, rate: 0.047 },
+      { maxIncome: 157500, rate: 0.049 },
+      { maxIncome: Infinity, rate: 0.059 },
+    ],
+    [FilingStatus.Joint]: joint,
+    [FilingStatus.HoH]: joint,
+    [FilingStatus.QualifyingWidower]: joint,
+  };
+})();
 
 /**
  * Formula to calculate tax owed to states

--- a/src/lib/tax-brackets.ts
+++ b/src/lib/tax-brackets.ts
@@ -4,11 +4,72 @@ import { TERRITORIES } from '../data/types/states';
 import { TaxEstimate } from '../data/types/tax';
 import { roundCents } from './rounding';
 
+// This basically works like deductions in federal taxes. Everyone is allowed to
+// claim a "personal exemption", which deducts this amount from taxable income.
+// https://www.mass.gov/info-details/massachusetts-personal-income-tax-exemptions
+const MA_EXEMPTIONS: { [S in FilingStatus]: number } = {
+  [FilingStatus.Single]: 4400,
+  [FilingStatus.MarriedFilingSeparately]: 4400,
+  [FilingStatus.HoH]: 6800,
+  [FilingStatus.Joint]: 8800,
+  [FilingStatus.QualifyingWidower]: 8800,
+};
+
+// Income over this amount is subject to the 4% surtax (a.k.a. "millionaire's
+// tax"). The threshold goes up every year, which is why it's not an even $1M.
+// This is for the 2025 tax year.
+// https://www.mass.gov/info-details/4-surtax-on-taxable-income-over-1000000
+const MA_SURTAX_THRESHOLD = 1_083_150;
+
+// Source: last page of
+// https://www.tax.newmexico.gov/individuals/wp-content/uploads/sites/5/2021/12/PIT-rates_2005_2021.pdf
+const NM_BRACKETS: {
+  [S in FilingStatus]: { maxIncome: number; rate: number }[];
+} = {
+  [FilingStatus.Single]: [
+    { maxIncome: 5500, rate: 0.017 },
+    { maxIncome: 11000, rate: 0.032 },
+    { maxIncome: 16000, rate: 0.047 },
+    { maxIncome: 210000, rate: 0.049 },
+    { maxIncome: Infinity, rate: 0.059 },
+  ],
+  [FilingStatus.MarriedFilingSeparately]: [
+    { maxIncome: 4000, rate: 0.017 },
+    { maxIncome: 8000, rate: 0.032 },
+    { maxIncome: 12000, rate: 0.047 },
+    { maxIncome: 157500, rate: 0.049 },
+    { maxIncome: Infinity, rate: 0.059 },
+  ],
+  // Below three all the same
+  [FilingStatus.Joint]: [
+    { maxIncome: 8000, rate: 0.017 },
+    { maxIncome: 16000, rate: 0.032 },
+    { maxIncome: 24000, rate: 0.047 },
+    { maxIncome: 315000, rate: 0.049 },
+    { maxIncome: Infinity, rate: 0.059 },
+  ],
+  [FilingStatus.HoH]: [
+    { maxIncome: 8000, rate: 0.017 },
+    { maxIncome: 16000, rate: 0.032 },
+    { maxIncome: 24000, rate: 0.047 },
+    { maxIncome: 315000, rate: 0.049 },
+    { maxIncome: Infinity, rate: 0.059 },
+  ],
+  [FilingStatus.QualifyingWidower]: [
+    { maxIncome: 8000, rate: 0.017 },
+    { maxIncome: 16000, rate: 0.032 },
+    { maxIncome: 24000, rate: 0.047 },
+    { maxIncome: 315000, rate: 0.049 },
+    { maxIncome: Infinity, rate: 0.059 },
+  ],
+};
+
 /**
  * Formula to calculate tax owed to states
  */
 export function estimateStateTaxAmount(
   householdIncome: number,
+  filingStatus: FilingStatus,
   stateCode: string,
 ): TaxEstimate | null {
   let taxOwed = null;
@@ -24,6 +85,48 @@ export function estimateStateTaxAmount(
       taxOwed = Math.ceil(householdIncome * (effectiveRate / 100));
       break;
     }
+
+    // MA has a flat rate of 5% on all income, plus 4% on all income over $1MM.
+    // This is after applying a "personal exemption"; i.e. basically a standard
+    // deduction. (You can get more exemptions for various things, but everyone
+    // gets the personal exemption automatically.)
+    case 'MA': {
+      const exemption = MA_EXEMPTIONS[filingStatus];
+      const taxableIncome = householdIncome - exemption;
+
+      // NB: the surtax is not a higher bracket of a graduated rate; it's
+      // additional to the flat base rate.
+      const baseTax = taxableIncome * 0.05;
+      const surtax =
+        taxableIncome > MA_SURTAX_THRESHOLD
+          ? (taxableIncome - MA_SURTAX_THRESHOLD) * 0.04
+          : 0;
+
+      taxOwed = Math.ceil(baseTax + surtax);
+      effectiveRate = (taxOwed / householdIncome) * 100;
+      break;
+    }
+
+    // NM has graduated brackets and no standard deduction.
+    case 'NM': {
+      const brackets = NM_BRACKETS[filingStatus];
+      let prevBracketMax = 0;
+      taxOwed = 0;
+
+      for (const { maxIncome, rate } of brackets) {
+        taxOwed +=
+          (_.min([householdIncome, maxIncome])! - prevBracketMax) * rate;
+        if (householdIncome < maxIncome) {
+          break;
+        }
+        prevBracketMax = maxIncome;
+      }
+
+      taxOwed = Math.ceil(taxOwed);
+      effectiveRate = (taxOwed / householdIncome) * 100;
+      break;
+    }
+
     default: {
       return null;
     }

--- a/test/lib/tax-brackets.test.ts
+++ b/test/lib/tax-brackets.test.ts
@@ -10,13 +10,48 @@ import {
  * test `estimateStateTaxAmount`, which calculates tax owed to states
  */
 test('correctly determines Colorado state tax liability', async t => {
-  const data = estimateStateTaxAmount(100000, 'CO');
+  const data = estimateStateTaxAmount(100000, FilingStatus.Single, 'CO');
   t.equal(data?.taxOwed, 4400);
   t.equal(data?.effectiveRate, 4.4);
 });
 
+test('correctly calculates Massachusetts tax', async t => {
+  t.equal(
+    estimateStateTaxAmount(104400, FilingStatus.Single, 'MA')?.taxOwed,
+    5000,
+  );
+  t.equal(
+    estimateStateTaxAmount(108800, FilingStatus.Joint, 'MA')?.taxOwed,
+    5000, // Higher personal exemption
+  );
+  t.equal(
+    estimateStateTaxAmount(1187550, FilingStatus.Single, 'MA')?.taxOwed,
+    63158, // Surtax
+  );
+});
+
+test('correctly calculates New Mexico tax', async t => {
+  t.equal(
+    estimateStateTaxAmount(16000, FilingStatus.Single, 'NM')?.taxOwed,
+    505,
+  );
+  t.equal(
+    estimateStateTaxAmount(210000, FilingStatus.Single, 'NM')?.taxOwed,
+    10011,
+  );
+  t.equal(
+    estimateStateTaxAmount(157500, FilingStatus.MarriedFilingSeparately, 'NM')
+      ?.taxOwed,
+    7514,
+  );
+  t.equal(
+    estimateStateTaxAmount(315000, FilingStatus.Joint, 'NM')?.taxOwed,
+    15027,
+  );
+});
+
 test('defaults to a null state tax obligation for unsupported states', async t => {
-  const data = estimateStateTaxAmount(100000, 'DC');
+  const data = estimateStateTaxAmount(100000, FilingStatus.Single, 'DC');
   t.equal(data, null);
 });
 


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/0/1208668890181682/1209428558323182)

## Description

We have state tax credits for these, so we ought to calculate their taxes.

I learned through doing this that a lot of MA tax calculators on the
internet (or at least the ones that have good SEO) are wrong; they
either don't account for the millionaire's tax or use the wrong
threshold for it.

I also learned that Wikipedia has the best SEO for "new mexico state
tax" but the table on the page is wrong; it doesn't include the top
marginal rate of 5.9%, which is new in 2021.

I'm left with a general feeling of irritation that I'm not quite sure
what to do with.

## Test Plan

New unit tests. The NM expected values are the ones given in the
source document. The MA values were calculated by me actually going
through MA tax forms and following the instructions.
