### PR TITLE
Filter out tax credits if we compute zero tax liability

### DIFF
--- a/src/lib/tax-brackets.ts
+++ b/src/lib/tax-brackets.ts
@@ -82,7 +82,7 @@ export function estimateStateTaxAmount(
     // gets the personal exemption automatically.)
     case 'MA': {
       const exemption = MA_EXEMPTIONS[filingStatus];
-      const taxableIncome = householdIncome - exemption;
+      const taxableIncome = _.max([0, householdIncome - exemption])!;
 
       // NB: the surtax is not a higher bracket of a graduated rate; it's
       // additional to the flat base rate.

--- a/src/lib/tax-brackets.ts
+++ b/src/lib/tax-brackets.ts
@@ -122,6 +122,20 @@ export function estimateStateTaxAmount(
     }
   }
 
+  // The above calculations should always produce nonnegative results, but this
+  // is a failsafe in case they don't.
+  if (taxOwed < 0) {
+    console.error(
+      'computed negative tax',
+      taxOwed,
+      'for',
+      householdIncome,
+      filingStatus,
+      stateCode,
+    );
+    taxOwed = 0;
+  }
+
   return { taxOwed, effectiveRate };
 }
 

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -3,7 +3,7 @@ import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import { afterEach, beforeEach, test } from 'tap';
 import { AuthoritiesByType, AuthorityType } from '../../src/data/authorities';
-import { Programs } from '../../src/data/programs';
+import { ira_programs, Programs } from '../../src/data/programs';
 import { StateIncentive } from '../../src/data/state_incentives';
 import { FilingStatus } from '../../src/data/tax_brackets';
 import { AmountType } from '../../src/data/types/amount';
@@ -44,6 +44,10 @@ const LOCATION_AND_AMIS = {
   '02130': [
     { zcta: '02130', city: 'Jamaica Plain', state: 'MA', county_fips: '25025' },
     { computedAMI80: 91175, computedAMI150: 171360, evCreditEligible: false },
+  ],
+  '80212': [
+    { zcta: '80212', city: 'Denver', state: 'CO', county_fips: '08031' },
+    { computedAMI80: 102650, computedAMI150: 195600, evCreditEligible: false },
   ],
 } as const;
 
@@ -486,6 +490,44 @@ test('correctly evaluates scenario "Hoh w/ 6 kids and $500k Household income in 
   t.equal(taxCredits['used_electric_vehicle'].eligible, false);
   t.equal(taxCredits['used_electric_vehicle'].amount.number, 4000);
   t.equal(taxCredits['used_electric_vehicle'].start_date, '2023');
+});
+
+test('filters tax credits if zero tax owed', async t => {
+  const baseQuery = {
+    owner_status: OwnerStatus.Homeowner,
+    tax_filing: FilingStatus.Single,
+    household_size: 1,
+    include_beta_states: true,
+  };
+  const zeroTax = calculateIncentives(...LOCATION_AND_AMIS['02130'], {
+    ...baseQuery,
+    household_income: 0,
+  });
+  t.equal(
+    zeroTax.incentives.filter(
+      i =>
+        _.isEqual(i.payment_methods, [PaymentMethod.TaxCredit]) && i.eligible,
+    ).length,
+    0,
+  );
+
+  // This will result in zero federal tax (due to the standard deduction), but
+  // $5 state tax (MA has a flat 5% rate on income over $4,400 for single
+  // filers), so one MA tax credit will be eligible.
+  const someTax = calculateIncentives(...LOCATION_AND_AMIS['02130'], {
+    ...baseQuery,
+    household_income: 4500,
+  });
+
+  const [federalCredits, stateCredits] = _.partition(
+    someTax.incentives.filter(
+      i =>
+        _.isEqual(i.payment_methods, [PaymentMethod.TaxCredit]) && i.eligible,
+    ),
+    i => i.program in ira_programs,
+  );
+  t.equal(federalCredits.length, 0);
+  t.equal(stateCredits.length, 1);
 });
 
 test('correctly sorts incentives', async t => {

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -45,10 +45,6 @@ const LOCATION_AND_AMIS = {
     { zcta: '02130', city: 'Jamaica Plain', state: 'MA', county_fips: '25025' },
     { computedAMI80: 91175, computedAMI150: 171360, evCreditEligible: false },
   ],
-  '80212': [
-    { zcta: '80212', city: 'Denver', state: 'CO', county_fips: '08031' },
-    { computedAMI80: 102650, computedAMI150: 195600, evCreditEligible: false },
-  ],
 } as const;
 
 const IRA_HVAC_ITEMS =

--- a/test/lib/tax-brackets.test.ts
+++ b/test/lib/tax-brackets.test.ts
@@ -16,6 +16,8 @@ test('correctly determines Colorado state tax liability', async t => {
 });
 
 test('correctly calculates Massachusetts tax', async t => {
+  // No tax if less than standard exemption
+  t.equal(estimateStateTaxAmount(4399, FilingStatus.Single, 'MA')?.taxOwed, 0);
   t.equal(
     estimateStateTaxAmount(104400, FilingStatus.Single, 'MA')?.taxOwed,
     5000,


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/0/1208668890181682/1209381661213139)

## Description

Do this separately for federal and state incentives.

This also fixes a bug in the MA state tax calculation I just added,
which resulted in negative tax liability for incomes below the
personal exemption.

## Test Plan

New unit test.
