### PR TITLE
Make filing status optional in v1

### DIFF
--- a/src/lib/low-income.ts
+++ b/src/lib/low-income.ts
@@ -32,6 +32,11 @@ export function isLowIncome(
     // conservative and return false (i.e. "not low income").
     return typeof threshold === 'number' && household_income <= threshold;
   } else if (thresholds.type === 'filing-status') {
+    if (!tax_filing) {
+      // If the thresholds are filing-status-dependent but the request didn't
+      // include filing status, be conservative and say we don't meet them.
+      return false;
+    }
     const [min, max] = thresholds.thresholds[tax_filing];
     return household_income >= min && household_income <= max;
   } else if (thresholds.type === 'ami-percentage') {

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -90,12 +90,16 @@ export function calculateStateIncentivesAndSavings(
   const eligibleIncentives = new Map<string, StateIncentive>();
   const ineligibleIncentives = new Map<string, StateIncentive>();
 
-  // Get state tax owed to determine max potential tax savings
-  const stateTaxOwed = estimateStateTaxAmount(
-    request.household_income,
-    request.tax_filing,
-    stateId,
-  );
+  // Get state tax owed to determine max potential tax savings and filter out
+  // tax credits if no tax liability. Don't compute tax if we don't have
+  // filing status.
+  const stateTaxOwed = request.tax_filing
+    ? estimateStateTaxAmount(
+        request.household_income,
+        request.tax_filing,
+        stateId,
+      )
+    : null;
 
   // Separate the state's incentive set into eligible and ineligible ones, based
   // on criteria that reflect real-life eligibility rules.

--- a/src/schemas/v1/calculator-endpoint.ts
+++ b/src/schemas/v1/calculator-endpoint.ts
@@ -94,7 +94,9 @@ spouse's income.`,
     tax_filing: {
       type: 'string',
       description:
-        'The status under which the consumer files their federal taxes.',
+        'The status under which the consumer files their taxes. If this \
+parameter is absent, incentives whose eligibility depends on tax filing status \
+will not be included in the results.',
       enum: Object.values(FilingStatus),
     },
     household_size: {
@@ -132,7 +134,6 @@ taxes, and their spouse if they file taxes jointly.`,
   required: [
     'owner_status',
     'household_income',
-    'tax_filing',
     'household_size',
   ],
 } as const;

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -730,12 +730,6 @@ const BAD_QUERIES = [
     zip: '80212',
     owner_status: 'homeowner',
     household_income: 80000,
-    household_size: 4,
-  },
-  {
-    zip: '80212',
-    owner_status: 'homeowner',
-    household_income: 80000,
     tax_filing: '',
     household_size: 4,
   },


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/0/1208668890181682/1208959599500050)

## Description

If it's not passed, don't filter out tax credits (as we do if tax owed
is zero), and assume we don't meet filing-status-dependent low-income
thresholds.

Also don't cap the tax credit savings total at tax owed. This is a
non-issue in practice: the number is only shown in API v0, which
still requires filing status to be passed.

## Test Plan

Unit tests
