### PR TITLE
Use geocodio type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fastify-cli": "^6.1.1",
     "fastify-plugin": "^4.5.1",
     "fastify-sqlite": "^1.1.0",
-    "geocodio-library-node": "^1.6.1",
+    "geocodio-library-node": "^1.7.0",
     "lodash": "^4.17.21",
     "qs": "^6.11.2",
     "sqlite": "^5.1.1"

--- a/src/@types/geocodio-library-node.d.ts
+++ b/src/@types/geocodio-library-node.d.ts
@@ -1,2 +1,0 @@
-// Trivial module declaration to satisfy tsc
-declare module 'geocodio-library-node';

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -1,3 +1,4 @@
+import { GeocodeAccuracyType } from 'geocodio-library-node';
 import { Database } from 'sqlite';
 import { geocoder } from './geocoder';
 
@@ -15,7 +16,7 @@ export type ResolvedLocation = {
  * types are imprecise enough, in practice, that we can't trust the geocoded
  * census tract.
  */
-const GEOCODIO_LOW_PRECISION = new Set([
+const GEOCODIO_LOW_PRECISION = new Set<GeocodeAccuracyType>([
   'street_center',
   'place',
   'county',
@@ -47,13 +48,13 @@ export async function resolveLocation(
   } else {
     const { address } = zipOrAddress;
     const response = await geocoder.geocode(address, ['census2020']);
-    const result = response?.results?.at(0);
+    const result = response.results.at(0);
 
     if (!result || result.address_components.country !== 'US') {
       return null;
     }
 
-    const censusInfo = result.fields.census['2020'];
+    const censusInfo = result.fields?.census?.['2020'];
 
     return {
       state: result.address_components.state,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,10 +2357,10 @@ generify@^4.0.0:
     split2 "^3.0.0"
     walker "^1.0.6"
 
-geocodio-library-node@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/geocodio-library-node/-/geocodio-library-node-1.6.1.tgz#3762f6e3e9fc799652de67b310fb66596521398c"
-  integrity sha512-/VbjgjsNz04jbuPC3HVHCQNOneVzD7npyKpOFZJ7ErgxF21W2cdVsA5sbeIwqB1oQD5IrQ73eoe/PSe4PlBLOQ==
+geocodio-library-node@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/geocodio-library-node/-/geocodio-library-node-1.7.0.tgz#cc8d9ac429ba897b17699865fd7a687ba093e5c4"
+  integrity sha512-geGIyJN+FWSdgyfCzzdHpmzZY1ZQyEnIbdVcyd+pvPn6bu7NOv309IUDfSRBNuIW05K9z73CWuvVgnAdCo9BYw==
   dependencies:
     axios "^1.6.7"
     form-data "^4.0.0"


### PR DESCRIPTION
I've updated the geocodio node sdk to `1.7.0` which adds type definitions [here](https://github.com/Geocodio/geocodio-library-node/pull/39).

To pass type-checking, our code will either need runtime validation or non-null assertions (for example, with the census check)