### PR TITLE
Add Wellesley MLP to Mass Save exception list

### DIFF
--- a/src/lib/mass-save.ts
+++ b/src/lib/mass-save.ts
@@ -9,6 +9,7 @@ export const EXCEPTION_MLPS: string[] = [
   'ma-braintree-electric-light-department',
   'ma-town-of-littleton',
   'ma-town-of-mansfield',
+  'ma-town-of-wellesley',
   'ma-west-boylston-mlp',
 ];
 


### PR DESCRIPTION
## Description

They explicitly allow double-dipping with Mass Save for dryer rebates,
and also (depending on your existing fuel) for stove, HPWH, and heat
pump rebates. We'll note the fuel restrictions in the descriptions of
their incentives.

## Test Plan

`yarn test`
