### PR TITLE
Exclude federal energy audit for MA residents

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -92,6 +92,16 @@ function calculateFederalIncentivesAndSavings(
       continue;
     }
 
+    // MA residents are already eligible for free energy audits, so do not include
+    // that federal incentive
+    if (
+      location.state === 'MA' &&
+      incentive.items.length === 1 &&
+      incentive.items[0] === 'energy_audit'
+    ) {
+      continue;
+    }
+
     //
     // 1) Verify that the selected homeowner status qualifies
     //

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -850,3 +850,22 @@ test('correctly matches geo groups', async t => {
   });
   t.equal(withNoMassSave.incentives.filter(massSaveFilter).length, 0);
 });
+
+test('exclude federal energy audit incentive for MA', async t => {
+  const args = {
+    owner_status: OwnerStatus.Homeowner,
+    household_income: 40000,
+    tax_filing: FilingStatus.Single,
+    household_size: 1,
+  };
+  const filter = (i: CalculatedIncentive) =>
+    i.payment_methods[0] === 'tax_credit' &&
+    i.items.length === 1 &&
+    i.items[0] === 'energy_audit';
+
+  const maResults = calculateIncentives(...LOCATION_AND_AMIS['02130'], args);
+  t.equal(maResults.incentives.filter(filter).length, 0);
+
+  const riResults = calculateIncentives(...LOCATION_AND_AMIS['02861'], args);
+  t.ok(riResults.incentives.filter(filter).length > 0);
+});


### PR DESCRIPTION
MA residents are already eligible for free energy audits, so that incentive will be filtered from the caclulator results for that location. 

https://app.asana.com/0/1208668890181682/1209811787832381/f

## Test
- New unit test
- Validated calculator results do not include the incentive using Bruno