### PR TITLE
Run zcta-to-geography.py from the "import from HERO" workflow

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -33,14 +33,32 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add data/
+          git add -u
           if git diff --cached --quiet; then
             echo "no changes"
             echo "::set-output name=changes::false"
           else
             echo "changes detected"
             echo "::set-output name=changes::true"
+            if ! git diff --cached --quiet scripts/data/geographies.csv; then
+              echo "geographies.csv changed"
+              echo "::set-output name=geographychanges::true"
+            fi
           fi
+      - name: Set up Python if needed
+        if: steps.git_diff.outputs.geographychanges == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: scripts/zcta-to-geography/requirements.txt
+      - name: Generate zcta-to-geography if needed
+        if: steps.git_diff.outputs.geographychanges == 'true'
+        working-directory: scripts/zcta-to-geography
+        run: |
+          pip3 install -r requirements.txt
+          python3 zcta-to-geography.py
+          git add -u
       - name: Create Pull Request
         if: steps.git_diff.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v7

--- a/scripts/zcta-to-geography/.gitignore
+++ b/scripts/zcta-to-geography/.gitignore
@@ -1,0 +1,2 @@
+# Cached downloaded files
+shapefiles

--- a/scripts/zcta-to-geography/README.md
+++ b/scripts/zcta-to-geography/README.md
@@ -4,26 +4,16 @@ This script regenerates the mapping from ZCTAs (roughly, ZIP codes) to geography
 
 ## Running
 
-1. Download three TIGER/Line shapefiles from the Census Bureau. Start from [this page](https://www2.census.gov/geo/tiger/TIGER2024/), and then navigate into each of the following subdirectories and download the single zip file in each.
-
-   - `ZCTA520`
-   - `STATE`
-   - `COUNTY`
-
-   Don't unzip the files.
-
-   **If there is a newer vintage of data than 2024**, you can use that, but you'll need to make sure the geographies stored in HERO are up to date, and to change the Geocodio call in this codebase to request Census fields of the newer vintage.
-
-2. Set up venv and install dependencies:
+1. Set up venv and install dependencies:
 
    1. `python3 -m venv venv`
    2. `. venv/bin/activate`
    3. `python3 -m pip install -r requirements.txt`
 
-3. Run the script, passing the path to the ZCTA file, states file, and counties file from step 1, in that order. (You can run `./zcta-to-geography.py --help` to see the arguments.)
+2. Run the script: `./zcta-to-geography.py`. It will download the required Census shapefiles and cache them in a directory called `shapefiles` within this directory, so the files are only downloaded once.
 
-   The script reads from `data/geographies.json` and writes to `scripts/data/zcta-to-geography.csv`
+   The script reads from `scripts/data/geographies.csv` and writes to `scripts/data/zcta-to-geography.csv`.
 
    The script takes around two minutes to run. (And consumes multiple gigabytes of memory.)
 
-4. Run `yarn build` to load the new mapping into the SQLite database used at runtime.
+3. Run `yarn build` to load the new mapping into the SQLite database used at runtime.

--- a/scripts/zcta-to-geography/requirements.txt
+++ b/scripts/zcta-to-geography/requirements.txt
@@ -1,5 +1,8 @@
-certifi==2025.4.26
+# If you upgrade this, make sure zcta-to-geography.py can still download
+certifi==2025.1.31
+charset-normalizer==3.4.2
 geopandas==1.0.1
+idna==3.10
 numpy==2.2.4
 packaging==24.2
 pandas==2.2.3
@@ -7,6 +10,8 @@ pyogrio==0.11.0
 pyproj==3.7.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
+requests==2.32.3
 shapely==2.1.0
 six==1.17.0
 tzdata==2025.2
+urllib3==2.4.0


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/1/1200412452784804/project/1208668890181682/task/1210059285909602)

## Description

- In the import workflow, detect whether `geographies.csv` has
  changed, and run zcta-to-geography.py if so. This entails adding
  steps to set up Python and install dependencies.

- Update the script to download the required shapefiles directly from
  the Census server. This is the simplest solution and I'm content to
  just go with it until it proves to be a problem. I think the most
  likely way it will become a problem is if the download becomes
  unreliable; in that case, my first-resort fix would be to put the
  files on Cloud Storage.

  The files are cached locally, for when you're working on the script,
  but this caching has no effect on Github Actions (because it starts
  with a clean container every time). I considered using
  `actions/cache` to cache the directory of downloaded files for the
  Actions runner, and I'm still open to it, but I'm not sure we need it.

- Downgraded `certifi` in the Python requirements because the Census
  server uses a certificate that the new version of `certifi` doesn't
  have.

## Test Plan

- Ran the script locally to make sure it still works, both with the
  shapefiles in cache locally and not.

- Used https://github.com/nektos/act to run the workflow locally. It's
  not a perfect recreation of the Actions environment, so I'm ready to
  discover new issues, but it's as close as I can get, I think. (In
  particular, there's some chance that because Actions runs in a
  datacenter, the Census server will flag it as a bot and block the
  download.)
