### PR TITLE
Use Github App for HERO import

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.IMPORTER_APP_ID }}
+          private-key: ${{ secrets.IMPORTER_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Use Node.js 18.x
@@ -31,8 +37,6 @@ jobs:
       - name: Check for changes
         id: git_diff
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add -u
           if git diff --cached --quiet; then
             echo "no changes"
@@ -63,8 +67,10 @@ jobs:
         if: steps.git_diff.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Incentive Admin Update
           branch: incentive-admin-update
           title: Incentive Admin Update
           body: This PR updates the API data files, using data maintained by the [Incentive Admin](https://github.com/rewiringamerica/incentive_admin).
           base: main
+          team-reviewers: '@rewiringamerica/incentives'

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 scripts/income_limits/data/raw/
 scripts/income_limits/config.json
 secrets/
+.secrets
 venv/
 __pycache__/
 .idea/


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-568)

## Description

This has two upsides over the previous approach of simply using the
provided `GITHUB_TOKEN`:

- CI will run without requiring a manual step
- It can add the incentives team as a reviewer

The app is all set up already, including configuring the two secrets
on this repo. The secrets are actually set at the organization level
so the same app can easily be used in other repos for similar
processes (i.e. anything that requires authenticating to Github but
where `GITHUB_TOKEN` isn't sufficient for whatever reason).

## Test Plan

Ran locally using https://github.com/nektos/act . It's not a perfect
simulation of Github itself, but it did work; the result is
rewiringamerica/api.rewiringamerica.org#754 .
