### PR TITLE
Remove periods in schema $id

### DIFF
--- a/src/data/types/capital-types.ts
+++ b/src/data/types/capital-types.ts
@@ -10,7 +10,7 @@ import { API_IMAGE_SCHEMA } from '../../schemas/v1/image';
  * Schema for EligibleProjectType.
  */
 export const ELIGIBLE_PROJECT_TYPE_SCHEMA = {
-  $id: 'EligibleProjectType.schema.json',
+  $id: 'EligibleProjectType',
   type: 'object',
   properties: {
     type: {
@@ -26,7 +26,7 @@ export const ELIGIBLE_PROJECT_TYPE_SCHEMA = {
  * Schema for FinancialAuthority.
  */
 export const FINANCIAL_AUTHORITY_SCHEMA = {
-  $id: 'FinancialAuthority.schema.json',
+  $id: 'FinancialAuthority',
   type: 'object',
   properties: {
     id: { type: 'number' },
@@ -56,7 +56,7 @@ export const FINANCIAL_AUTHORITY_SCHEMA = {
  * Schema for LoanProgramTerms.
  */
 export const LOAN_PROGRAM_TERMS_SCHEMA = {
-  $id: 'LoanProgramTerms.schema.json',
+  $id: 'LoanProgramTerms',
   type: 'object',
   properties: {
     id: { type: 'number' },
@@ -78,7 +78,7 @@ export const LOAN_PROGRAM_TERMS_SCHEMA = {
  * Schema for a single LoanProgram.
  */
 export const LOAN_PROGRAM_SCHEMA = {
-  $id: 'LoanProgram.schema.json',
+  $id: 'LoanProgram',
   type: 'object',
   properties: {
     id: { type: 'number' },
@@ -96,12 +96,12 @@ export const LOAN_PROGRAM_SCHEMA = {
     status: { type: 'string', enum: Object.values(LoanProgramStatus) },
     website_url: { type: 'string', format: 'uri' },
     financial_authority_id: { type: 'number' },
-    financial_authority: { $ref: 'FinancialAuthority.schema.json' },
+    financial_authority: { $ref: 'FinancialAuthority' },
     loan_program_terms_id: { type: 'number' },
-    loan_program_terms: { $ref: 'LoanProgramTerms.schema.json' },
+    loan_program_terms: { $ref: 'LoanProgramTerms' },
     eligible_project_types: {
       type: 'array',
-      items: { $ref: 'EligibleProjectType.schema.json' },
+      items: { $ref: 'EligibleProjectType' },
     },
     state: { type: 'string' },
     is_national: { type: 'boolean' },
@@ -132,7 +132,7 @@ export const LOAN_PROGRAMS_SCHEMA = {
   title: 'LoanPrograms',
   type: 'object',
   patternProperties: {
-    '^.*$': { $ref: 'LoanProgram.schema.json' },
+    '^.*$': { $ref: 'LoanProgram' },
   },
   additionalProperties: false,
 } as const;

--- a/src/data/types/program.ts
+++ b/src/data/types/program.ts
@@ -4,7 +4,7 @@ import { ALL_ITEMS } from './items';
 import { LOCALIZABLE_STRING_SCHEMA } from './localizable-string';
 
 export const PROGRAM_SCHEMA = {
-  $id: 'Program.schema.json',
+  $id: 'Program',
   type: 'object',
   properties: {
     name: {
@@ -33,7 +33,7 @@ export const PROGRAMS_SCHEMA = {
   title: 'Programs',
   type: 'object',
   patternProperties: {
-    '^.*$': { $ref: 'Program.schema.json' },
+    '^.*$': { $ref: 'Program' },
   },
   additionalProperties: false,
 } as const;


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-366)

## Description

The new merge script that @SkittyWitty wrote (rewiringamerica/api-zuplo#140) trips up on schema names that have periods in them (because it uses lodash to follow period-delimited paths through a JSON object). Rather than try to deal with that in the script, I just fixed the schema names; there's no reason to have the `.schema.json` part.

## Test Plan

`yarn test`. Fetch /spec.json locally and diff it with the spec generated from main to make sure removing the string `.schema.json` is the only difference.
