### PR TITLE
Build the SQLite database before updating snapshots

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           npx ts-node scripts/incentive-admin-import.ts
           npx ts-node scripts/incentive-admin-capital-import.ts
+          yarn build
           yarn update-snapshots
       - name: Check for changes
         id: git_diff


### PR DESCRIPTION
## Description

Forgot about this.

## Test Plan

This time I tested locally with `act`.

I had to add the extra steps of `apt update; apt install sqlite3` to
make it work, because the image `act` uses doesn't have sqlite3
installed. The Github image does, though, as demonstrated by (a) the
fact that the `yarn build` command in the test.yml workflow Just
Works, and (b) Github's [own docs](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#databases).
