### PR TITLE
Update end dates of IRA tax credits

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -21,7 +21,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average.",
       "es": "Crédito fiscal del 30% (sin límite) por los sistemas de almacenamiento de batería, con un valor promedio de $4,800."
@@ -57,7 +57,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2022",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit (uncapped) for geothermal install. Worth $12,000 on average.",
       "es": "Crédito fiscal del 30% (sin límite) por la instalación geotérmica, con un valor promedio de $12,000."
@@ -93,7 +93,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $600) por actualización del tablero en junto con otra mejora cubierto por 25C o 25D. Reinicio anual."
@@ -341,7 +341,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2026-06-30",
     "short_description": {
       "en": "Tax credit (up to $1,000) for EV chargers. Available in rural or low-income communities.",
       "es": "Crédito fiscal hasta $1,000 por los cargadores de vehículos eléctricos. Disponible en zonas rurales o comunidades de bajos ingresos."
@@ -379,7 +379,7 @@
     "agi_max_limit": 150000,
     "filing_status": "single",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
@@ -417,7 +417,7 @@
     "agi_max_limit": 150000,
     "filing_status": "married_filing_separately",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
@@ -455,7 +455,7 @@
     "agi_max_limit": 225000,
     "filing_status": "hoh",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
@@ -493,7 +493,7 @@
     "agi_max_limit": 300000,
     "filing_status": "joint",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000.",
       "es": "Crédito fiscal proporcionado como un reembolso inicial para los nuevos vehículos eléctricos con un MSRP máximo de $55,000 y furgonetas, camionetas y SUVs con un MSRP máximo de $80,000."
@@ -531,7 +531,7 @@
     "agi_max_limit": 75000,
     "filing_status": "single",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -569,7 +569,7 @@
     "agi_max_limit": 75000,
     "filing_status": "married_filing_separately",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -607,7 +607,7 @@
     "agi_max_limit": 150000,
     "filing_status": "joint",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -645,7 +645,7 @@
     "agi_max_limit": 112500,
     "filing_status": "hoh",
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-09-30",
     "short_description": {
       "en": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000.",
       "es": "Crédito fiscal del 30% (hasta $4,000) por los vehículos eléctricos usados con el precio sugerido hasta $25,000 y el peso hasta 14,000 libras."
@@ -683,7 +683,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor. Reinicio anual."
@@ -719,7 +719,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor. Reinicio anual."
@@ -972,7 +972,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2022",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas.",
       "es": "Crédito fiscal del 30% (sin límite) por la instalación del tejado solar y en conjunto, un crédito fiscal por la actualización del tablero."
@@ -1048,7 +1048,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset.",
       "es": "Crédito fiscal del 30% (hasta $1,200) por los proyectos de impermeabilización. Reinicio anual."
@@ -1084,7 +1084,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2023",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "Tax credit of up to $150 for an energy audit. Yearly reset.",
       "es": "Crédito fiscal de hasta $150) por . Reinicio anual."
@@ -1226,7 +1226,7 @@
     ],
     "ami_qualification": null,
     "start_date": "2022",
-    "end_date": "2032",
+    "end_date": "2025-12-31",
     "short_description": {
       "en": "30% tax credit for solar water heater (uncapped).",
       "es": "Crédito fiscal del 30% (sin límite) por la instalación del un calentador de agua solar."

--- a/test/snapshots/v0-80212-homeowner-80000-joint-4.json
+++ b/test/snapshots/v0-80212-homeowner-80000-joint-4.json
@@ -211,7 +211,7 @@
         "homeowner"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 4800,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -234,7 +234,7 @@
         "homeowner"
       ],
       "start_date": 2022,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 7200,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -258,7 +258,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 300000,
@@ -282,7 +282,7 @@
         "homeowner"
       ],
       "start_date": 2022,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -306,7 +306,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 150000,
@@ -331,7 +331,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -355,7 +355,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -379,7 +379,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -403,7 +403,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2026,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 0,
@@ -427,7 +427,7 @@
         "renter"
       ],
       "start_date": 2023,
-      "end_date": 2032,
+      "end_date": 2025,
       "representative_amount": 0,
       "ami_qualification": null,
       "agi_max_limit": 0,

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -85,7 +85,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -110,7 +110,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     }
   ]

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -86,7 +86,7 @@
         "homeowner"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
     },
     {
@@ -109,7 +109,7 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $12,000 on average."
     },
     {
@@ -132,7 +132,7 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
     },
     {
@@ -154,7 +154,7 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit for solar water heater (uncapped)."
     },
     {
@@ -177,7 +177,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -200,7 +200,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     },
     {
@@ -225,7 +225,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -248,7 +248,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -274,7 +274,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset."
     },
     {
@@ -297,7 +297,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
     },
     {
@@ -320,7 +320,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "Tax credit of up to $150 for an energy audit. Yearly reset."
     }
   ]

--- a/test/snapshots/v1-84106-homeowner-80000-joint-4.json
+++ b/test/snapshots/v1-84106-homeowner-80000-joint-4.json
@@ -41,7 +41,7 @@
         "homeowner"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (uncapped) for battery storage systems, worth $4,800 on average."
     },
     {
@@ -64,7 +64,7 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (uncapped) for geothermal install. Worth $12,000 on average."
     },
     {
@@ -87,7 +87,7 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit for rooftop solar (uncapped, $4,600 avg.); panel upgrade too. Community/leased solar may get 10-20% bonuses for low-income areas."
     },
     {
@@ -109,7 +109,7 @@
         "homeowner"
       ],
       "start_date": "2022",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit for solar water heater (uncapped)."
     },
     {
@@ -132,7 +132,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -155,7 +155,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     },
     {
@@ -180,7 +180,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -203,7 +203,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
     },
     {
@@ -229,7 +229,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset."
     },
     {
@@ -252,7 +252,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
     },
     {
@@ -275,7 +275,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-12-31",
       "short_description": "Tax credit of up to $150 for an energy audit. Yearly reset."
     }
   ]

--- a/test/snapshots/v1-vt-05845-vec-ev-low-income.json
+++ b/test/snapshots/v1-vt-05845-vec-ev-low-income.json
@@ -164,7 +164,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "Tax credit provided as an upfront rebate for new EVs with a maximum MSRP of $55,000 and vans, pickup trucks, and SUVs with a maximum MSRP of $80,000."
     },
     {
@@ -187,7 +187,7 @@
         "renter"
       ],
       "start_date": "2023",
-      "end_date": "2032",
+      "end_date": "2025-09-30",
       "short_description": "30% tax credit (up to $4,000) for a used EV of up to 14,000 lbs, with an MSRP of up to $25,000."
     }
   ]


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-686)

## Description

- 25C (energy efficient home improvement) and 25D (residential clean
  energy) are available for installations that happen before the end
  of 2025.

- 30D (new EV) and 25E (used EV) are available for vehicles purchased
  before the end of September.

- 30C is available for installations before the end of June 2026.

Note that in the v0 API, the end date is just a number signifying the
year, so these are returned in v0 as just `2025` (or `2026` in one
case). v0 is about to be deleted, so I'm not worried about that.

As written, this means that we'll completely stop showing them after
the end date. However, people who want to claim them will still need
to remember to do so, come tax time next year; I'm not sure if we'll
want to keep showing these cards in 2026 for that reason?

## Test Plan

`yarn test`
