### PR TITLE
Remove "yearly reset" from IRA credit copy

### DIFF
--- a/data/ira_incentives.json
+++ b/data/ira_incentives.json
@@ -95,8 +95,8 @@
     "start_date": "2023",
     "end_date": "2025-12-31",
     "short_description": {
-      "en": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset.",
-      "es": "Crédito fiscal del 30% (hasta $600) por actualización del tablero en junto con otra mejora cubierto por 25C o 25D. Reinicio anual."
+      "en": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade.",
+      "es": "Crédito fiscal del 30% (hasta $600) por actualización del tablero en junto con otra mejora cubierto por 25C o 25D."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits",
@@ -685,8 +685,8 @@
     "start_date": "2023",
     "end_date": "2025-12-31",
     "short_description": {
-      "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
-      "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor. Reinicio anual."
+      "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters.",
+      "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits",
@@ -721,8 +721,8 @@
     "start_date": "2023",
     "end_date": "2025-12-31",
     "short_description": {
-      "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
-      "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor. Reinicio anual."
+      "en": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters.",
+      "es": "Crédito fiscal del 30% (hasta $2,000) por las bombas de calor y los calentadores de agua con bomba de calor."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits",
@@ -1050,8 +1050,8 @@
     "start_date": "2023",
     "end_date": "2025-12-31",
     "short_description": {
-      "en": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset.",
-      "es": "Crédito fiscal del 30% (hasta $1,200) por los proyectos de impermeabilización. Reinicio anual."
+      "en": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows.",
+      "es": "Crédito fiscal del 30% (hasta $1,200) por los proyectos de impermeabilización."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",
@@ -1086,8 +1086,8 @@
     "start_date": "2023",
     "end_date": "2025-12-31",
     "short_description": {
-      "en": "Tax credit of up to $150 for an energy audit. Yearly reset.",
-      "es": "Crédito fiscal de hasta $150) por . Reinicio anual."
+      "en": "Tax credit of up to $150 for an energy audit.",
+      "es": "Crédito fiscal de hasta $150) por una auditoría energética."
     },
     "more_info_url": {
       "en": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits",

--- a/test/snapshots/v0-80212-homeowner-80000-joint-4.json
+++ b/test/snapshots/v0-80212-homeowner-80000-joint-4.json
@@ -336,7 +336,7 @@
       "ami_qualification": null,
       "agi_max_limit": 0,
       "eligible": true,
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters.",
       "more_info_url_internal": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-tax-credits"
     },
     {
@@ -360,7 +360,7 @@
       "ami_qualification": null,
       "agi_max_limit": 0,
       "eligible": true,
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset.",
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters.",
       "more_info_url_internal": "https://homes.rewiringamerica.org/federal-incentives/25c-heat-pump-water-heater-tax-credits"
     },
     {
@@ -384,7 +384,7 @@
       "ami_qualification": null,
       "agi_max_limit": 0,
       "eligible": true,
-      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset.",
+      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows.",
       "more_info_url_internal": "https://homes.rewiringamerica.org/federal-incentives/25c-weatherization-tax-credits"
     },
     {
@@ -432,7 +432,7 @@
       "ami_qualification": null,
       "agi_max_limit": 0,
       "eligible": true,
-      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset.",
+      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade.",
       "more_info_url_internal": "https://homes.rewiringamerica.org/federal-incentives/25c-electrical-panel-tax-credits"
     }
   ]

--- a/test/snapshots/v1-02807-state-items.json
+++ b/test/snapshots/v1-02807-state-items.json
@@ -111,7 +111,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters."
     }
   ]
 }

--- a/test/snapshots/v1-15289-homeowner-85000-joint-4.json
+++ b/test/snapshots/v1-15289-homeowner-85000-joint-4.json
@@ -226,7 +226,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters."
     },
     {
       "payment_methods": [
@@ -249,7 +249,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters."
     },
     {
       "payment_methods": [
@@ -275,7 +275,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset."
+      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows."
     },
     {
       "payment_methods": [
@@ -298,7 +298,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
+      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade."
     },
     {
       "payment_methods": [
@@ -321,7 +321,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "Tax credit of up to $150 for an energy audit. Yearly reset."
+      "short_description": "Tax credit of up to $150 for an energy audit."
     }
   ]
 }

--- a/test/snapshots/v1-84106-homeowner-80000-joint-4.json
+++ b/test/snapshots/v1-84106-homeowner-80000-joint-4.json
@@ -181,7 +181,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters."
     },
     {
       "payment_methods": [
@@ -204,7 +204,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters. Yearly reset."
+      "short_description": "30% tax credit (up to $2,000) for heat pumps and heat pump water heaters."
     },
     {
       "payment_methods": [
@@ -230,7 +230,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows. Yearly reset."
+      "short_description": "30% tax credit (up to $1,200) for weatherization projects: insulation, air sealing, doors, windows."
     },
     {
       "payment_methods": [
@@ -253,7 +253,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade. Yearly reset."
+      "short_description": "30% tax credit (up to $600) for electrical panel upgrade when done with another 25C or 25D upgrade."
     },
     {
       "payment_methods": [
@@ -276,7 +276,7 @@
       ],
       "start_date": "2023",
       "end_date": "2025-12-31",
-      "short_description": "Tax credit of up to $150 for an energy audit. Yearly reset."
+      "short_description": "Tax credit of up to $150 for an energy audit."
     }
   ]
 }


### PR DESCRIPTION
## Description

They aren't going to reset yearly anymore :(

Also fixed some missing Spanish copy for the energy audit credit.

## Test Plan

`yarn test`. `git-grep -i 'yearly reset'` has no results.
