### PR TITLE
Fix bug in coverage reporting

### DIFF
--- a/src/lib/incentives-calculation.ts
+++ b/src/lib/incentives-calculation.ts
@@ -10,6 +10,7 @@ import { IRA_INCENTIVES } from '../data/ira_incentives';
 import { PROGRAMS } from '../data/programs';
 import { StateIncentive } from '../data/state_incentives';
 import { FilingStatus } from '../data/tax_brackets';
+import { APICoverage } from '../data/types/coverage';
 import { PaymentMethod } from '../data/types/incentive-types';
 import { OwnerStatus } from '../data/types/owner-status';
 import {
@@ -146,7 +147,7 @@ export default function calculateIncentives(
 
   const allStateIncentives = getAllStateIncentives(state_id, request);
   const stateIncentiveRelationships = getStateIncentiveRelationships(state_id);
-  const state = calculateStateIncentives(
+  const incentives = calculateStateIncentives(
     location,
     request,
     [...IRA_INCENTIVES, ...allStateIncentives],
@@ -155,7 +156,11 @@ export default function calculateIncentives(
     PROGRAMS,
     amiAndEvCreditEligibility,
   );
-  const incentives = state.stateIncentives;
+
+  const coverage: APICoverage =
+    allStateIncentives.length > 0
+      ? { state: state_id, utility: request.utility || null }
+      : { state: null, utility: null };
 
   // Sort incentives https://app.asana.com/0/0/1204275945510481/f
   // Sort by payment method first, treating "performance_rebate" the same as
@@ -196,7 +201,7 @@ export default function calculateIncentives(
     is_under_150_ami: isUnder150Ami,
     is_over_150_ami: isOver150Ami,
     authorities,
-    coverage: state.coverage,
+    coverage,
     data_partners,
     location,
     incentives: sortedIncentives,

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -14,7 +14,6 @@ import {
   STATE_INCENTIVES_BY_STATE,
   StateIncentive,
 } from '../data/state_incentives';
-import { APICoverage } from '../data/types/coverage';
 import { PaymentMethod } from '../data/types/incentive-types';
 import { OwnerStatus } from '../data/types/owner-status';
 import { Program } from '../data/types/program';
@@ -72,17 +71,7 @@ export function calculateStateIncentives(
   stateAuthorities: AuthoritiesByType,
   allPrograms: Programs,
   amiAndEvCreditEligibility: AMIAndEVCreditEligibility,
-): {
-  stateIncentives: StateIncentive[];
-  coverage: APICoverage;
-} {
-  if (incentives.length === 0) {
-    return {
-      stateIncentives: [],
-      coverage: { state: null, utility: null },
-    };
-  }
-
+): StateIncentive[] {
   const stateId = location.state;
   const eligibleIncentives = new Map<string, StateIncentive>();
   const ineligibleIncentives = new Map<string, StateIncentive>();
@@ -245,13 +234,7 @@ export function calculateStateIncentives(
     }
   }
 
-  return {
-    stateIncentives,
-    coverage: {
-      state: stateId,
-      utility: request.utility ?? null,
-    },
-  };
+  return stateIncentives;
 }
 
 function ineligibleByLocationOrUtility(

--- a/test/lib/incentive-relationships.test.ts
+++ b/test/lib/incentive-relationships.test.ts
@@ -53,7 +53,7 @@ test('basic test for supplying test incentive data to calculation logic', async 
   );
   t.ok(data);
   // This user is eligible for all of the incentives.
-  t.equal(data.stateIncentives.length, 6);
+  t.equal(data.length, 6);
 });
 
 test('test calculation with no incentives', async t => {
@@ -75,7 +75,7 @@ test('test calculation with no incentives', async t => {
     AMIS,
   );
   t.ok(data);
-  t.equal(data.stateIncentives.length, 0);
+  t.equal(data.length, 0);
 });
 
 // This user is a renter. Based on this, they are eligible for incentives
@@ -108,7 +108,7 @@ test('test incentive relationship logic', async t => {
   t.ok(data);
   // Check that the user is only eligible for A, B, and F.
   t.strictSame(
-    data.stateIncentives.map(i => i.id),
+    data.map(i => i.id),
     ['A', 'B', 'F'],
   );
 });
@@ -142,7 +142,7 @@ test('test more complex incentive relationship logic', async t => {
   t.ok(data);
   // Check that the user is only eligible for E.
   t.strictSame(
-    data.stateIncentives.map(i => i.id),
+    data.map(i => i.id),
     ['E'],
   );
 });
@@ -177,7 +177,7 @@ test('test incentive relationship and combined max value logic', async t => {
   );
   t.ok(data);
   t.strictSame(
-    data.stateIncentives.map(i => i.id),
+    data.map(i => i.id),
     ['E', 'F', 'B'],
   );
 });
@@ -215,7 +215,7 @@ test('test incentive relationship and permanent ineligibility criteria', async t
 
   t.ok(data);
   t.strictSame(
-    data.stateIncentives.map(i => i.id),
+    data.map(i => i.id),
     ['E', 'F'],
   );
 });
@@ -248,7 +248,7 @@ test('test nested incentive relationship logic', async t => {
     AMIS,
   );
   t.ok(data);
-  const eligibleIds = data.stateIncentives.map(i => i.id).sort();
+  const eligibleIds = data.map(i => i.id).sort();
   t.strictSame(eligibleIds, ['A', 'C', 'E', 'F']);
 });
 
@@ -275,7 +275,7 @@ test('test combined maximum savings logic', async t => {
   );
   t.ok(data);
   // Check that the user is eligible for B, E, and F.
-  const eligibleIds = data.stateIncentives.map(i => i.id).sort();
+  const eligibleIds = data.map(i => i.id).sort();
   t.strictSame(eligibleIds, ['B', 'E', 'F']);
 });
 

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -546,7 +546,7 @@ test('correct filtering of incentives with geography', async t => {
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldFind);
-  t.equal(shouldFind.stateIncentives.length, 1);
+  t.equal(shouldFind.length, 1);
 
   const shouldNotFind = calculateStateIncentives(
     {
@@ -571,7 +571,7 @@ test('correct filtering of incentives with geography', async t => {
     { computedAMI80: 80000, computedAMI150: 150000, evCreditEligible: false },
   );
   t.ok(shouldNotFind);
-  t.equal(shouldNotFind.stateIncentives.length, 0);
+  t.equal(shouldNotFind.length, 0);
 });
 
 test('correctly matches geo groups', async t => {

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -738,6 +738,21 @@ test('WI low income threshold', async t => {
   );
 });
 
+test('null coverage for state with no incentive data', async t => {
+  await validateResponse(
+    t,
+    {
+      zip: '57104',
+      owner_status: 'homeowner',
+      household_size: 1,
+      household_income: 20000,
+      tax_filing: 'joint',
+      utility: 'sd-black-hills-power',
+    },
+    './test/snapshots/v1-sd-no-coverage.json',
+  );
+});
+
 const BAD_QUERIES = [
   // bad location:
   {

--- a/test/snapshots/v1-sd-no-coverage.json
+++ b/test/snapshots/v1-sd-no-coverage.json
@@ -1,0 +1,15 @@
+{
+  "is_under_80_ami": true,
+  "is_under_150_ami": true,
+  "is_over_150_ami": false,
+  "authorities": {},
+  "coverage": {
+    "state": null,
+    "utility": null
+  },
+  "location": {
+    "state": "SD"
+  },
+  "data_partners": {},
+  "incentives": []
+}


### PR DESCRIPTION
## Description

This was caused by the big post-v0 overhaul I just did.
`calculateStateIncentive` was computing the `coverage` part of the API
response by whether the list of incentives passed to it was empty. In
the overhaul, I made it so that it's _never_ empty (it always includes
IRA incentives), so the returned `coverage` was always non-null.

This changes it to compute `coverage` one level up, which allows for
some code simplification.

## Test Plan

New snapshot test that failed before the change. Existing tests pass.
