### PR TITLE
Upgrade to Node 22

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-          node-version: 18.x
+          node-version: 22.x
           cache: 'yarn'
       - run: yarn --frozen-lockfile
       - run: yarn build

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -19,11 +19,11 @@ jobs:
           private-key: ${{ secrets.IMPORTER_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-          node-version: 18.x
+          node-version: 22.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-          node-version: 18.x
+          node-version: 22.x
           cache: 'yarn'
       - run: yarn --frozen-lockfile
       - run: yarn build

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+v22.18

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "@fastify/autoload": "^5.8.2",
@@ -40,7 +40,7 @@
     "@types/lodash": "^4.17.20",
     "@types/make-fetch-happen": "^10.0.4",
     "@types/minimist": "^1.2.5",
-    "@types/node": "18.19.127",
+    "@types/node": "22.18.6",
     "@types/qs": "^6.9.8",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",


### PR DESCRIPTION
## Description

No particular forcing function for this, but it's long past time: v18
has been end-of-life since March.

## Test Plan

`yarn test`.

`yarn dev` and hit a few endpoints.

Github CI.
