### PR TITLE
feat: release all states

### DIFF
--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -62,15 +62,12 @@ export const TERRITORIES = [
 
 export const STATES_AND_TERRITORIES = [...STATES_PLUS_DC, ...TERRITORIES];
 
-export const BETA_STATES: string[] = [
-  'AK',
-  'CA',
-  'NC',
-  'OH',
-];
+export const BETA_STATES: string[] = [];
 
 export const LAUNCHED_STATES: string[] = [
+  'AK',
   'AZ',
+  'CA',
   'CO',
   'CT',
   'DC',
@@ -85,11 +82,13 @@ export const LAUNCHED_STATES: string[] = [
   'MI',
   'MN',
   'MO',
+  'NC',
   'NH',
   'NJ',
   'NM',
   'NV',
   'NY',
+  'OH',
   'OR',
   'PA',
   'RI',

--- a/src/data/types/states.ts
+++ b/src/data/types/states.ts
@@ -62,8 +62,6 @@ export const TERRITORIES = [
 
 export const STATES_AND_TERRITORIES = [...STATES_PLUS_DC, ...TERRITORIES];
 
-export const BETA_STATES: string[] = [];
-
 export const LAUNCHED_STATES: string[] = [
   'AK',
   'AZ',

--- a/src/lib/state-incentives-calculation.ts
+++ b/src/lib/state-incentives-calculation.ts
@@ -37,23 +37,12 @@ import {
   estimateStateTaxAmount,
 } from './tax-brackets';
 
-const RA_BAY_AREA_HEAT_PUMP_PROGRAMS = STATE_INCENTIVES_BY_STATE['CA'].filter(
-  incentive => incentive.id === 'CA-12',
-);
-
 export function getAllStateIncentives(
   stateId: string,
   request: CalculateParams,
 ) {
   // Only process incentives for launched states, or beta states if beta was requested.
   if (!isStateIncluded(stateId, request.include_beta_states ?? false)) {
-    // TODO(hannah): This hack surfaces our Bay Area heat pump program while CA
-    // is still in beta. It should be deleted once CA is launched or once the
-    // program ends in spring 2026.
-    if (stateId === 'CA') {
-      return RA_BAY_AREA_HEAT_PUMP_PROGRAMS;
-    }
-
     return [];
   }
   return STATE_INCENTIVES_BY_STATE[stateId];

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -3,7 +3,9 @@ import { LAUNCHED_STATES, STATES_AND_TERRITORIES } from '../data/types/states';
 
 export const isStateIncluded = (
   stateId: string,
-  _includeBeta: boolean, // Ignore beta flag since all states are launched
+  // Ignore beta flag since all states are launched
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _includeBeta: boolean,
 ): boolean => LAUNCHED_STATES.includes(stateId);
 
 const getStatus = (state: string) => {

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -1,22 +1,14 @@
 import { StateStatus } from '../data/types/state-status';
-import {
-  BETA_STATES,
-  LAUNCHED_STATES,
-  STATES_AND_TERRITORIES,
-} from '../data/types/states';
+import { LAUNCHED_STATES, STATES_AND_TERRITORIES } from '../data/types/states';
 
 export const isStateIncluded = (
   stateId: string,
-  includeBeta: boolean,
-): boolean =>
-  LAUNCHED_STATES.includes(stateId) ||
-  (includeBeta && BETA_STATES.includes(stateId));
+  _includeBeta: boolean, // Ignore beta flag since all states are launched
+): boolean => LAUNCHED_STATES.includes(stateId);
 
 const getStatus = (state: string) => {
   if (LAUNCHED_STATES.includes(state)) {
     return StateStatus.Launched;
-  } else if (BETA_STATES.includes(state)) {
-    return StateStatus.Beta;
   }
   return StateStatus.None;
 };

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -319,7 +319,7 @@ test('correctly evaluates scenario "Married filing jointly w/ 2 kids and $250k H
     i => i.payment_methods[0] === PaymentMethod.PerformanceRebate,
   );
 
-  t.equal(pos_rebate_incentives.length, 0);
+  t.equal(pos_rebate_incentives.length, 1);
   t.equal(tax_credit_incentives.length, 10);
   t.equal(performance_rebate_incentives.length, 0);
 

--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -8,7 +8,6 @@ import { FilingStatus } from '../../src/data/tax_brackets';
 import { AmountType } from '../../src/data/types/amount';
 import { PaymentMethod } from '../../src/data/types/incentive-types';
 import { OwnerStatus } from '../../src/data/types/owner-status';
-import { BETA_STATES, LAUNCHED_STATES } from '../../src/data/types/states';
 import { AMIAndEVCreditEligibility } from '../../src/lib/ami-evcredit-calculation';
 import calculateIncentives from '../../src/lib/incentives-calculation';
 import { GeographyType, ResolvedLocation } from '../../src/lib/location';
@@ -144,11 +143,6 @@ test('correctly evaluates scenario "Single w/ $120k Household income"', async t 
     household_size: 1,
   });
   t.ok(data);
-});
-
-test('beta states and launched states are disjoint', async t => {
-  const data = LAUNCHED_STATES.filter(s => BETA_STATES.includes(s));
-  t.equal(data.length, 0);
 });
 
 test('correctly evaluates state incentives for launched states', async t => {

--- a/test/routes/v1.test.ts
+++ b/test/routes/v1.test.ts
@@ -7,7 +7,6 @@ import { AuthorityType } from '../../src/data/authorities';
 import { ALL_ITEMS } from '../../src/data/types/items';
 import { StateStatus } from '../../src/data/types/state-status';
 import {
-  BETA_STATES,
   LAUNCHED_STATES,
   STATES_AND_TERRITORIES,
 } from '../../src/data/types/states';
@@ -1156,12 +1155,8 @@ test('/states', async t => {
     t.strictSame(statesResponse[state].status, StateStatus.Launched);
   });
 
-  BETA_STATES.forEach(state => {
-    t.strictSame(statesResponse[state].status, StateStatus.Beta);
-  });
-
   STATES_AND_TERRITORIES.filter(
-    state => !LAUNCHED_STATES.includes(state) && !BETA_STATES.includes(state),
+    state => !LAUNCHED_STATES.includes(state),
   ).forEach(state => {
     t.strictSame(statesResponse[state].status, StateStatus.None);
   });


### PR DESCRIPTION
<!-- Include a brief and informative title. -->
# Overview
<!-- A short and clear summary outlining the purpose of this contribution. -->
This PR moves all states in BETA to LAUNCHED, effectively releasing all incentive data we have out into the API. 

## Change Type
Feature

## Implementation Notes
To minimize scope creep and to not cause breaking changes to the API, I chose to not remove include_beta_states from API schema or remove StateStatus.Beta from the enum. 

## Test Plan
<!-- Include the steps taken to test the PR, a description should enable another developer to easily recreate the test steps and help reviewers identify additional cases. -->
Validate you can pull incentives for CA. 