### PR TITLE
Fix brittle Santa Clara RA heat pump test

### DIFF
--- a/test/lib/incentives-calculation.test.ts
+++ b/test/lib/incentives-calculation.test.ts
@@ -683,16 +683,19 @@ test('includes RA heat pump program for Santa Clara county', async t => {
     household_size: 1,
     authority_types: [AuthorityType.Other],
   };
+  const raHeatPumpFilter = (i: StateIncentive) =>
+    i.program ===
+    'ca_rewiringAmerica_santaClaraAndSanMateoCountyHeatPumpAccessProgram';
 
   const santaClaraResults = calculateIncentives(
     ...LOCATION_AND_AMIS['94086'],
     args,
   );
-  t.equal(santaClaraResults.incentives.length, 1);
+  t.equal(santaClaraResults.incentives.filter(raHeatPumpFilter).length, 1);
 
   const sanFranciscoResults = calculateIncentives(
     ...LOCATION_AND_AMIS['94117'],
     args,
   );
-  t.equal(sanFranciscoResults.incentives.length, 0);
+  t.equal(sanFranciscoResults.incentives.filter(raHeatPumpFilter).length, 0);
 });


### PR DESCRIPTION
## Summary
- The `yarn test` job on #917 fails because the incoming data adds a new, legitimately **statewide** CA `"other"`-authority incentive (`QuitCarbon-CA`, `data/CA/authorities.json` / `programs.json` / `incentives.json`), which now also shows up for the San Francisco zip used in this test — not just Santa Clara.
- `test/lib/incentives-calculation.test.ts`'s `includes RA heat pump program for Santa Clara county` test asserted a raw `incentives.length` for `authority_type: "other"`, assuming the only such incentive in the area was the Rewiring America "Santa Clara and San Mateo County Heat Pump Access Program". That assumption no longer holds.
- This filters on the specific RA program id (`ca_rewiringAmerica_santaClaraAndSanMateoCountyHeatPumpAccessProgram`) instead of the raw count, matching the pattern used by neighboring tests in the same file (e.g. the MA energy-audit test). Verified the fix passes both against current `main` data and against #917's incoming CA data.

## Test plan
- [x] `yarn testfilter "test/lib/incentives-calculation.test.ts"` passes against current `main` data
- [x] Same test passes with #917's `data/CA/{authorities,incentives,programs}.json` swapped in
- [x] `yarn test` — full suite passes (30681 pass, 1 skip, 0 fail)
- [x] Pre-existing `yarn lint` failures (unrelated `FromSchemaOptions` TS errors) confirmed present on `main` baseline too, not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)